### PR TITLE
Add admin invites, resets, and password change

### DIFF
--- a/marketlink-backend/src/lib/mailer.ts
+++ b/marketlink-backend/src/lib/mailer.ts
@@ -67,3 +67,75 @@ export async function sendMagicLinkEmail(to: string, verifyUrl: string): Promise
     return { ok: false, error: 'network' };
   }
 }
+
+export async function sendInviteEmail(to: string, tempPassword: string, loginUrl: string, role: 'provider' | 'admin'): Promise<SendResult> {
+  if (!RESEND_API_KEY || !MAIL_FROM) {
+    console.log('[mailer] Missing RESEND_API_KEY or MAIL_FROM; logging invite instead:', {
+      to,
+      tempPassword,
+      loginUrl,
+      role,
+    });
+    return { ok: false, error: 'missing-config' };
+  }
+
+  const subject = `${APP_NAME} - Your account access`;
+  const text = [
+    `Hi,`,
+    ``,
+    `An admin created a ${role} account for you.`,
+    `Email: ${to}`,
+    `Temporary password: ${tempPassword}`,
+    ``,
+    `Sign in here: ${loginUrl}`,
+    ``,
+    `You will be asked to change your password after login.`,
+    ``,
+    `- ${APP_NAME}`,
+  ].join('\n');
+
+  const html = `
+    <div style="font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial;">
+      <p>Hi,</p>
+      <p>An admin created a <strong>${role}</strong> account for you.</p>
+      <p><strong>Email:</strong> ${to}</p>
+      <p><strong>Temporary password:</strong> ${tempPassword}</p>
+      <p>
+        <a href="${loginUrl}"
+           style="display:inline-block;padding:10px 16px;border-radius:8px;border:1px solid #e5e7eb;text-decoration:none;">
+          Sign in to ${APP_NAME}
+        </a>
+      </p>
+      <p>You will be asked to change your password after login.</p>
+      <p>- ${APP_NAME}</p>
+    </div>
+  `.trim();
+
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: MAIL_FROM,
+        to,
+        subject,
+        text,
+        html,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      console.error('[mailer] Resend error', res.status, body);
+      return { ok: false, error: `resend-${res.status}` };
+    }
+
+    return { ok: true };
+  } catch (err: any) {
+    console.error('[mailer] Network/unknown error', err?.message || err);
+    return { ok: false, error: 'network' };
+  }
+}

--- a/marketlink-backend/src/routes/admin.ts
+++ b/marketlink-backend/src/routes/admin.ts
@@ -1,7 +1,10 @@
 import type { FastifyPluginAsync } from 'fastify';
 import type { Prisma } from '@prisma/client';
+import crypto from 'node:crypto';
+import bcrypt from 'bcryptjs';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
+import { sendInviteEmail } from '../lib/mailer';
 import { ProviderStatus, InquiryStatus } from '@prisma/client';
 
 const requireAdmin = async (fastify: any, req: any) => {
@@ -38,6 +41,21 @@ const normalizeSlug = (raw: string) =>
     .replace(/^-|-$/g, '');
 
 const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+const TEMP_PASSWORD_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$';
+const generateTempPassword = (length = 12) => {
+  const bytes = crypto.randomBytes(length);
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += TEMP_PASSWORD_ALPHABET[bytes[i] % TEMP_PASSWORD_ALPHABET.length];
+  }
+  return out;
+};
+
+const getLoginUrl = () => {
+  const base = process.env.WEB_URL || 'http://localhost:3000';
+  return `${base.replace(/\/$/, '')}/login`;
+};
 
 const normalizeServices = (services: unknown): string[] | undefined => {
   if (typeof services === 'undefined') return undefined;
@@ -189,6 +207,108 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
     if (!provider) return reply.code(404).send({ error: 'Provider not found' });
 
     return reply.send({ ok: true, provider });
+  });
+
+  /**
+   * POST /admin/users/invite
+   * Body: { email, role? }
+   * - Creates a user with a temp password and sends email invite.
+   */
+  fastify.post('/admin/users/invite', async (req, reply) => {
+    const gate = await requireAdmin(fastify, req);
+    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+
+    const body = (req.body || {}) as { email?: string; role?: 'provider' | 'admin' };
+    const email = String(body.email || '')
+      .trim()
+      .toLowerCase();
+    const role = body.role === 'admin' ? 'admin' : 'provider';
+
+    if (!isValidEmail(email)) return reply.code(400).send({ error: 'Invalid email.' });
+
+    const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+    if (existing) return reply.code(409).send({ error: 'User already exists.' });
+
+    const tempPassword = generateTempPassword();
+    const passwordHash = await bcrypt.hash(tempPassword, 10);
+
+    const user = await prisma.user.create({
+      data: {
+        email,
+        role,
+        passwordHash,
+        mustChangePassword: true,
+        isDisabled: false,
+      },
+      select: { id: true, email: true, role: true },
+    });
+
+    const emailRes = await sendInviteEmail(email, tempPassword, getLoginUrl(), role);
+
+    return reply.send({
+      ok: true,
+      user,
+      tempPassword,
+      emailSent: emailRes.ok,
+    });
+  });
+
+  /**
+   * POST /admin/providers/:id/reset-password
+   * - Ensures provider has a user, sets temp password, sends email.
+   */
+  fastify.post('/admin/providers/:id/reset-password', async (req, reply) => {
+    const gate = await requireAdmin(fastify, req);
+    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+
+    const { id } = req.params as { id: string };
+    const provider = await prisma.provider.findUnique({
+      where: { id },
+      select: { id: true, email: true, userId: true },
+    });
+    if (!provider) return reply.code(404).send({ error: 'Provider not found' });
+
+    const email = String(provider.email || '')
+      .trim()
+      .toLowerCase();
+    if (!isValidEmail(email)) return reply.code(400).send({ error: 'Invalid provider email.' });
+
+    let userId = provider.userId || null;
+    if (!userId) {
+      const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+      if (existing) {
+        userId = existing.id;
+      } else {
+        const created = await prisma.user.create({
+          data: { email, role: 'provider', mustChangePassword: true, isDisabled: false },
+          select: { id: true },
+        });
+        userId = created.id;
+      }
+
+      await prisma.provider.update({
+        where: { id: provider.id },
+        data: { userId },
+      });
+    }
+
+    const tempPassword = generateTempPassword();
+    const passwordHash = await bcrypt.hash(tempPassword, 10);
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { passwordHash, mustChangePassword: true, isDisabled: false },
+    });
+
+    const emailRes = await sendInviteEmail(email, tempPassword, getLoginUrl(), 'provider');
+
+    return reply.send({
+      ok: true,
+      providerId: provider.id,
+      userId,
+      tempPassword,
+      emailSent: emailRes.ok,
+    });
   });
 
   /**

--- a/marketlink-backend/src/routes/auth.ts
+++ b/marketlink-backend/src/routes/auth.ts
@@ -91,6 +91,56 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
     await deleteCurrentSession(fastify, req, reply);
     return reply.send({ ok: true });
   });
+
+  /**
+   * POST /auth/change-password
+   * Body: { currentPassword, newPassword }
+   * - Requires auth, verifies current password, sets new hash, clears mustChangePassword.
+   */
+  fastify.post('/auth/change-password', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ ok: false, message: 'Not authenticated.' });
+
+    const { currentPassword, newPassword } = (req.body || {}) as {
+      currentPassword?: string;
+      newPassword?: string;
+    };
+
+    const current = String(currentPassword || '');
+    const next = String(newPassword || '');
+
+    if (!current || !next) {
+      return reply.code(400).send({ ok: false, message: 'Current and new password are required.' });
+    }
+    if (next.length < 8) {
+      return reply.code(400).send({ ok: false, message: 'New password must be at least 8 characters.' });
+    }
+
+    const full = await prisma.user.findUnique({
+      where: { id: user.id },
+      select: { id: true, passwordHash: true, isDisabled: true },
+    });
+
+    if (!full || full.isDisabled) {
+      return reply.code(403).send({ ok: false, message: 'Account disabled.' });
+    }
+    if (!full.passwordHash) {
+      return reply.code(400).send({ ok: false, message: 'Password not set for this account.' });
+    }
+
+    const ok = await bcrypt.compare(current, full.passwordHash);
+    if (!ok) {
+      return reply.code(401).send({ ok: false, message: 'Current password is incorrect.' });
+    }
+
+    const passwordHash = await bcrypt.hash(next, 10);
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash, mustChangePassword: false },
+    });
+
+    return reply.send({ ok: true });
+  });
 };
 
 export default authRoutes;

--- a/marketlink-frontend/src/app/dashboard/admin/invite/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/invite/page.tsx
@@ -1,0 +1,53 @@
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import InviteUserForm from '@/components/admin/InviteUserForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminInvitePage() {
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+  const cookie = headers().get('cookie') || '';
+
+  const statsRes = await fetch(`${apiBase}/admin/stats`, {
+    cache: 'no-store',
+    headers: { 'content-type': 'application/json', cookie },
+  });
+
+  if (statsRes.status === 401 || statsRes.status === 403) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <h1 className="text-2xl font-semibold mb-2">Admin Invite</h1>
+        <p className="text-red-600">You are not authorized to view this page.</p>
+      </main>
+    );
+  }
+
+  if (!statsRes.ok) {
+    const txt = await statsRes.text();
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <h1 className="text-2xl font-semibold mb-2">Admin Invite</h1>
+        <p className="text-red-600">Failed to load admin guard.</p>
+        <pre className="mt-3 rounded border bg-gray-50 p-3 text-xs overflow-auto">{txt}</pre>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-10 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Invite User</h1>
+          <p className="text-sm text-gray-500">Create a user and send a temp password.</p>
+        </div>
+        <Link href="/dashboard/admin" className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50">
+          Back to admin
+        </Link>
+      </div>
+
+      <div className="rounded-2xl border bg-white p-5 shadow-sm">
+        <InviteUserForm />
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/admin/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/page.tsx
@@ -237,6 +237,9 @@ export default async function AdminOverviewPage({ searchParams }: { searchParams
           <h1 className="text-xl font-semibold">Admin Overview</h1>
           <p className="text-sm text-gray-500">Moderate providers and manage listings.</p>
         </div>
+        <Link href="/dashboard/admin/invite" className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50">
+          Invite user
+        </Link>
       </div>
 
       {/* Clickable Stats / Quick Filters */}

--- a/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { revalidatePath } from 'next/cache';
+import ResetPasswordPanel from '@/components/admin/ResetPasswordPanel';
 
 export const dynamic = 'force-dynamic';
 
@@ -300,6 +301,11 @@ export default async function AdminProviderEditPage({ params }: { params: { id: 
                 <option value="false">false</option>
               </select>
             </Field>
+          </div>
+
+          <div className="rounded-2xl border bg-white p-5 shadow-sm space-y-4">
+            <SectionTitle title="Access" subtitle="Reset the provider's password." />
+            <ResetPasswordPanel providerId={p.id} providerEmail={p.email} />
           </div>
 
           <div className="rounded-2xl border bg-white p-5 shadow-sm space-y-4">

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -41,6 +41,12 @@ export default function ProfileEditorPage() {
   const [dirty, setDirty] = useState(false);
 
   const [data, setData] = useState<Provider | null>(null);
+  const [pwCurrent, setPwCurrent] = useState('');
+  const [pwNext, setPwNext] = useState('');
+  const [pwConfirm, setPwConfirm] = useState('');
+  const [pwSaving, setPwSaving] = useState(false);
+  const [pwMessage, setPwMessage] = useState<string | null>(null);
+  const [pwOpen, setPwOpen] = useState(false);
 
   // Load current user's provider from /me/summary (works for active/pending/disabled)
   useEffect(() => {
@@ -155,6 +161,55 @@ export default function ProfileEditorPage() {
     }
   }
 
+  function resetPwForm() {
+    setPwCurrent('');
+    setPwNext('');
+    setPwConfirm('');
+    setPwMessage(null);
+  }
+
+  async function handleChangePassword(e: React.FormEvent) {
+    e.preventDefault();
+    setPwMessage(null);
+
+    if (!pwCurrent || !pwNext) {
+      setPwMessage('Enter your current password and a new password.');
+      return;
+    }
+    if (pwNext.length < 8) {
+      setPwMessage('New password must be at least 8 characters.');
+      return;
+    }
+    if (pwNext !== pwConfirm) {
+      setPwMessage('New password and confirmation do not match.');
+      return;
+    }
+
+    setPwSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/auth/change-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ currentPassword: pwCurrent, newPassword: pwNext }),
+      });
+
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(body?.message || 'Failed to change password.');
+      }
+
+      setPwCurrent('');
+      setPwNext('');
+      setPwConfirm('');
+      setPwMessage('Password updated.');
+    } catch (e: any) {
+      setPwMessage(e?.message || 'Failed to change password.');
+    } finally {
+      setPwSaving(false);
+    }
+  }
+
   // ----- keep hooks before early returns -----
   const known = useMemo(() => new Set(SERVICE_OPTIONS.map((s) => s.value)), []);
   const extraServices = useMemo(() => (data?.services || []).filter((s) => !known.has(s)), [data?.services, known]);
@@ -182,8 +237,20 @@ export default function ProfileEditorPage() {
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-10">
-      <h1 className="text-2xl font-semibold">Edit profile</h1>
-      <p className="mt-2 text-gray-600">Update your provider details.</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Edit profile</h1>
+          <p className="mt-2 text-gray-600">Update your provider details.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={() => setPwOpen(true)} className="rounded-xl border px-4 py-2.5 text-sm font-medium hover:bg-gray-50">
+            Change password
+          </button>
+          <button type="button" onClick={() => router.replace('/dashboard')} className="rounded-xl border px-4 py-2.5 text-sm font-medium hover:bg-gray-50">
+            Back to dashboard
+          </button>
+        </div>
+      </div>
 
       {/* Admin-only moderation controls */}
       {role === 'admin' ? (
@@ -282,22 +349,66 @@ export default function ProfileEditorPage() {
 
         <div className="flex flex-wrap gap-3">
           <button type="submit" disabled={disableSave} className={`rounded-xl border px-4 py-3 font-medium ${disableSave ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-50'}`}>
-            {saving ? 'Saving…' : 'Save changes'}
+            {saving ? 'Saving...' : 'Save changes'}
           </button>
-
-          <button type="button" onClick={() => router.replace('/dashboard')} className="rounded-xl border px-4 py-3 font-medium hover:bg-gray-50">
-            Back to dashboard
-          </button>
-
-          {data.status === 'active' ? (
-            <button type="button" onClick={() => router.replace(`/providers/${data.slug}`)} className="rounded-xl border px-4 py-3 font-medium hover:bg-gray-50">
-              View public page
-            </button>
-          ) : null}
         </div>
 
         <p className="text-xs text-gray-500">* required</p>
       </form>
+
+
+      {pwOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="w-full max-w-md rounded-2xl bg-white p-5 shadow-lg">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Change password</h2>
+              <button
+                type="button"
+                onClick={() => {
+                  setPwOpen(false);
+                  resetPwForm();
+                }}
+                className="rounded border px-2 py-1 text-xs hover:bg-gray-50"
+              >
+                Close
+              </button>
+            </div>
+
+            <form onSubmit={handleChangePassword} className="mt-4 grid gap-4">
+              <div>
+                <label className="mb-1 block text-sm">Current password</label>
+                <input type="password" autoComplete="current-password" className="w-full rounded-xl border px-4 py-3" value={pwCurrent} onChange={(e) => setPwCurrent(e.target.value)} />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm">New password</label>
+                <input type="password" autoComplete="new-password" className="w-full rounded-xl border px-4 py-3" value={pwNext} onChange={(e) => setPwNext(e.target.value)} />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm">Confirm new password</label>
+                <input type="password" autoComplete="new-password" className="w-full rounded-xl border px-4 py-3" value={pwConfirm} onChange={(e) => setPwConfirm(e.target.value)} />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <button type="submit" disabled={pwSaving} className={`rounded-xl border px-4 py-2.5 text-sm font-medium ${pwSaving ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-50'}`}>
+                  {pwSaving ? 'Updating...' : 'Update password'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setPwOpen(false);
+                    resetPwForm();
+                  }}
+                  className="rounded-xl border px-4 py-2.5 text-sm font-medium hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
+
+              {pwMessage ? <p className="text-sm text-gray-600">{pwMessage}</p> : null}
+            </form>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/marketlink-frontend/src/components/admin/InviteUserForm.tsx
+++ b/marketlink-frontend/src/components/admin/InviteUserForm.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+
+type InviteResult = {
+  ok: boolean;
+  tempPassword?: string;
+  emailSent?: boolean;
+  error?: string;
+};
+
+export default function InviteUserForm() {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<'provider' | 'admin'>('provider');
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<InviteResult | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResult(null);
+    setBusy(true);
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/admin/users/invite`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, role }),
+      });
+
+      const data = (await res.json().catch(() => ({}))) as any;
+
+      if (!res.ok) {
+        setResult({ ok: false, error: data?.error || 'Invite failed.' });
+      } else {
+        setResult({ ok: true, tempPassword: data?.tempPassword, emailSent: data?.emailSent });
+      }
+    } catch (err: any) {
+      setResult({ ok: false, error: err?.message || 'Invite failed.' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <label className="block text-sm font-medium">
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="mt-1 w-full rounded border px-3 py-2 text-sm"
+          placeholder="owner@agency.com"
+          required
+        />
+      </label>
+
+      <label className="block text-sm font-medium">
+        Role
+        <select value={role} onChange={(e) => setRole(e.target.value as 'provider' | 'admin')} className="mt-1 w-full rounded border px-3 py-2 text-sm">
+          <option value="provider">provider</option>
+          <option value="admin">admin</option>
+        </select>
+      </label>
+
+      <button type="submit" disabled={busy} className="rounded bg-black px-4 py-2 text-sm font-medium text-white disabled:opacity-60">
+        {busy ? 'Sending...' : 'Send invite'}
+      </button>
+
+      {result ? (
+        <div className={`rounded border px-3 py-2 text-sm ${result.ok ? 'bg-green-50 text-green-800 border-green-200' : 'bg-red-50 text-red-800 border-red-200'}`}>
+          {result.ok ? (
+            <div className="space-y-1">
+              <div>Invite created.</div>
+              <div>Email sent: {result.emailSent ? 'yes' : 'no'}</div>
+              {result.tempPassword ? <div>Temp password: <span className="font-mono">{result.tempPassword}</span></div> : null}
+            </div>
+          ) : (
+            <div>{result.error}</div>
+          )}
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/marketlink-frontend/src/components/admin/ResetPasswordPanel.tsx
+++ b/marketlink-frontend/src/components/admin/ResetPasswordPanel.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+
+type ResetResult = {
+  ok: boolean;
+  tempPassword?: string;
+  emailSent?: boolean;
+  error?: string;
+};
+
+export default function ResetPasswordPanel({ providerId, providerEmail }: { providerId: string; providerEmail: string }) {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<ResetResult | null>(null);
+
+  const reset = async () => {
+    setResult(null);
+    setBusy(true);
+
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000'}/admin/providers/${providerId}/reset-password`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      const data = (await res.json().catch(() => ({}))) as any;
+      if (!res.ok) {
+        setResult({ ok: false, error: data?.error || 'Reset failed.' });
+      } else {
+        setResult({ ok: true, tempPassword: data?.tempPassword, emailSent: data?.emailSent });
+      }
+    } catch (err: any) {
+      setResult({ ok: false, error: err?.message || 'Reset failed.' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs text-gray-500">Send a new temp password to {providerEmail}.</div>
+      <button type="button" onClick={reset} disabled={busy} className="rounded border px-3 py-1.5 text-xs hover:bg-gray-50 disabled:opacity-60">
+        {busy ? 'Resetting...' : 'Reset password'}
+      </button>
+
+      {result ? (
+        <div className={`rounded border px-2 py-1.5 text-xs ${result.ok ? 'bg-green-50 text-green-800 border-green-200' : 'bg-red-50 text-red-800 border-red-200'}`}>
+          {result.ok ? (
+            <div className="space-y-1">
+              <div>Email sent: {result.emailSent ? 'yes' : 'no'}</div>
+              {result.tempPassword ? <div>Temp password: <span className="font-mono">{result.tempPassword}</span></div> : null}
+            </div>
+          ) : (
+            <div>{result.error}</div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/marketlink-frontend/tests/admin.spec.ts
+++ b/marketlink-frontend/tests/admin.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = 'http://localhost:3000';
+const ADMIN_EMAIL = process.env.ML_ADMIN_EMAIL || '';
+const ADMIN_PASSWORD = process.env.ML_ADMIN_PASSWORD || '';
+
+async function loginAsAdmin(page: any) {
+  if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+    throw new Error('Missing ML_ADMIN_EMAIL or ML_ADMIN_PASSWORD env vars.');
+  }
+
+  await page.goto(`${BASE_URL}/login`);
+  await page.getByLabel('Email').fill(ADMIN_EMAIL);
+  await page.getByLabel('Password').fill(ADMIN_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/\/dashboard\/admin/);
+}
+
+test('admin can open dashboard', async ({ page }) => {
+  await loginAsAdmin(page);
+  await expect(page.getByRole('heading', { name: 'Admin Overview' })).toBeVisible();
+});
+
+test('admin can invite a user', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.getByRole('link', { name: 'Invite user' }).click();
+
+  await expect(page).toHaveURL(/\/dashboard\/admin\/invite/);
+
+  const email = `playwright+${Date.now()}@example.com`;
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Role').selectOption('provider');
+  await page.getByRole('button', { name: 'Send invite' }).click();
+
+  await expect(page.getByText('Invite created.')).toBeVisible();
+  await expect(page.getByText('Temp password:')).toBeVisible();
+});
+
+test('admin can reset a provider password', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const editLink = page.getByRole('link', { name: 'Edit' }).first();
+  await editLink.click();
+
+  await expect(page).toHaveURL(/\/dashboard\/admin\/providers\//);
+  await page.getByRole('button', { name: 'Reset password' }).click();
+
+  await expect(page.getByText('Temp password:')).toBeVisible();
+});


### PR DESCRIPTION
Phase 5 admin invites, password resets, and provider password change

Summary:

Add admin user invite flow with temp password email
Add admin provider password reset action
Add provider change‑password endpoint and UI
Add admin Playwright tests
Changes:

New backend endpoints: /admin/users/invite, /admin/providers/:id/reset-password, /auth/change-password
New mail helper sendInviteEmail
Admin UI: invite page + reset password panel
Provider profile: change‑password modal
Playwright admin tests using env creds
Testing:

admin.spec.ts
Manual: /dashboard/admin/invite and /dashboard/admin/providers/:id reset password