### PR TITLE
MM-9: update shared navigation labels and role-aware dashboard link

### DIFF
--- a/marketlink-frontend/src/app/dashboard/admin/invite/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/invite/page.tsx
@@ -6,7 +6,8 @@ export const dynamic = 'force-dynamic';
 
 export default async function AdminInvitePage() {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-  const cookie = headers().get('cookie') || '';
+  const requestHeaders = await headers();
+  const cookie = requestHeaders.get('cookie') || '';
 
   const statsRes = await fetch(`${apiBase}/admin/stats`, {
     cache: 'no-store',

--- a/marketlink-frontend/src/app/dashboard/admin/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/page.tsx
@@ -84,7 +84,8 @@ function StatCardLink({ label, value, href, hint }: { label: string; value: numb
 async function adminPATCH(path: string, body: unknown) {
   'use server';
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-  const cookie = headers().get('cookie') || '';
+  const requestHeaders = await headers();
+  const cookie = requestHeaders.get('cookie') || '';
 
   const res = await fetch(`${apiBase}${path}`, {
     method: 'PATCH',
@@ -105,7 +106,8 @@ type AdminOverviewPageProps = {
 
 export default async function AdminOverviewPage({ searchParams }: AdminOverviewPageProps) {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-  const cookie = headers().get('cookie') || '';
+  const requestHeaders = await headers();
+  const cookie = requestHeaders.get('cookie') || '';
   const resolvedSearchParams = await searchParams;
 
   const query = typeof resolvedSearchParams.query === 'string' ? resolvedSearchParams.query : undefined;

--- a/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
@@ -29,7 +29,8 @@ type Provider = {
 
 async function adminFetchJSON<T>(path: string) {
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-  const cookie = headers().get('cookie') || '';
+  const requestHeaders = await headers();
+  const cookie = requestHeaders.get('cookie') || '';
   const res = await fetch(`${apiBase}${path}`, {
     cache: 'no-store',
     headers: { 'content-type': 'application/json', cookie },
@@ -50,7 +51,8 @@ async function adminFetchJSON<T>(path: string) {
 async function adminPatch(path: string, body: unknown) {
   'use server';
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
-  const cookie = headers().get('cookie') || '';
+  const requestHeaders = await headers();
+  const cookie = requestHeaders.get('cookie') || '';
 
   const res = await fetch(`${apiBase}${path}`, {
     method: 'PATCH',

--- a/marketlink-frontend/src/components/AppHeader.tsx
+++ b/marketlink-frontend/src/components/AppHeader.tsx
@@ -9,6 +9,19 @@ import { useMarketLinkTheme } from '@/components/ThemeToggle';
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
 type Role = 'provider' | 'admin' | '' | null | string;
+type NavItem = {
+  href: string;
+  label: string;
+  active: boolean;
+};
+
+function canAccessDashboard(role: Role) {
+  return role === 'provider' || role === 'admin';
+}
+
+function getDashboardHref(role: Role) {
+  return role === 'admin' ? '/dashboard/admin' : '/dashboard';
+}
 
 export default function AppHeader() {
   const pathname = usePathname();
@@ -57,11 +70,18 @@ export default function AppHeader() {
     setMobileOpen(false);
   }, [pathname]);
 
-  const canSeeDashboard = role === 'provider' || role === 'admin';
+  const canSeeDashboard = canAccessDashboard(role);
+  const dashboardHref = getDashboardHref(role);
+  const isHomePage = pathname === '/';
   const isProvidersPage = pathname?.startsWith('/providers');
   const isLoginPage = pathname === '/login';
   const isDashboardPage = pathname?.startsWith('/dashboard');
   const showLoginAction = !canSeeDashboard && !isLoginPage;
+  const navItems: NavItem[] = [
+    { href: '/', label: 'Home', active: isHomePage },
+    { href: '/providers', label: 'Browse experts', active: Boolean(isProvidersPage) },
+    ...(canSeeDashboard ? [{ href: dashboardHref, label: 'Dashboard', active: Boolean(isDashboardPage) }] : []),
+  ];
   const mobileMenuBaseClass = 'inline-flex min-h-12 items-center justify-between rounded-xl border px-4 text-sm font-medium transition';
   const mobileMenuRowClass = `${mobileMenuBaseClass} ${t.secondaryBtn}`;
   const mobileMenuActiveClass = `${mobileMenuBaseClass} ml-btn-primary border-transparent text-white`;
@@ -89,17 +109,11 @@ export default function AppHeader() {
         <div className="flex items-center gap-3">
           <div className="hidden lg:flex items-center gap-3">
             <nav className={desktopNavShellClass}>
-              <Link href="/" className={pathname === '/' ? desktopActiveLinkClass : desktopLinkClass}>
-                Home
-              </Link>
-              <Link href="/providers" className={isProvidersPage ? desktopActiveLinkClass : desktopLinkClass}>
-                Browse providers
-              </Link>
-              {canSeeDashboard ? (
-                <Link href="/dashboard" className={isDashboardPage ? desktopActiveLinkClass : desktopLinkClass}>
-                  Dashboard
+              {navItems.map((item) => (
+                <Link key={item.href} href={item.href} className={item.active ? desktopActiveLinkClass : desktopLinkClass}>
+                  {item.label}
                 </Link>
-              ) : null}
+              ))}
             </nav>
 
             {role === null ? (
@@ -136,32 +150,21 @@ export default function AppHeader() {
               <div className={`text-[11px] font-medium uppercase tracking-[0.26em] ${t.headerMutedText}`}>Navigate</div>
             </div>
             <div className="flex flex-col gap-3 px-4 py-4">
-              <Link
-                href="/providers"
-                className={isProvidersPage ? mobileMenuActiveClass : mobileMenuRowClass}
-              >
-                <span>Browse providers</span>
-                <span className="text-base leading-none text-current/55" aria-hidden="true">&rarr;</span>
-              </Link>
-              <Link
-                href="/"
-                className={pathname === '/' ? mobileMenuActiveClass : mobileMenuRowClass}
-              >
-                <span>Home</span>
-                <span className="text-base leading-none text-current/55" aria-hidden="true">&rarr;</span>
-              </Link>
+              {navItems.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={item.active ? mobileMenuActiveClass : mobileMenuRowClass}
+                >
+                  <span>{item.label}</span>
+                  <span className="text-base leading-none text-current/55" aria-hidden="true">&rarr;</span>
+                </Link>
+              ))}
 
               {role === null ? (
                 <div className="h-12 rounded-xl border border-white/10 bg-white/8 opacity-60" aria-hidden="true" />
               ) : canSeeDashboard ? (
               <>
-                <Link
-                  href="/dashboard"
-                  className={isDashboardPage ? mobileMenuActiveClass : mobileMenuRowClass}
-                >
-                  <span>Dashboard</span>
-                  <span className="text-base leading-none text-current/55" aria-hidden="true">&rarr;</span>
-                </Link>
                 <LogoutButton className={`${mobileMenuRowClass} justify-center`} />
               </>
             ) : showLoginAction ? (


### PR DESCRIPTION
Updates the shared header navigation for the new marketplace language. Replaces Browse providers with Browse experts, centralizes desktop/mobile nav item rendering, and makes the dashboard link role-aware so admins go directly to /dashboard/admin while providers keep /dashboard.

Also includes the admin runtime compatibility fix for Next headers usage by awaiting headers() before reading cookies in admin server pages.