### PR TITLE
MM-11: simplify homepage copy and category labels

### DIFF
--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -4,20 +4,20 @@ import Link from 'next/link';
 import ThemeToggle, { useMarketLinkTheme } from '@/components/ThemeToggle';
 
 const CATEGORIES = [
-  { token: 'seo', title: 'SEO', desc: 'Rank higher, get more organic leads.' },
-  { token: 'social', title: 'Social Media', desc: 'Content, growth, and engagement.' },
-  { token: 'ads', title: 'Paid Ads', desc: 'Google, Meta, TikTok, and more.' },
-  { token: 'web', title: 'Web Development', desc: 'Landing pages, sites, and conversions.' },
-  { token: 'branding', title: 'Branding', desc: 'Logos, identity, and positioning.' },
-  { token: 'email', title: 'Email Marketing', desc: 'Newsletters, automations, retention.' },
-  { token: 'content', title: 'Content', desc: 'Copywriting, blogs, and strategy.' },
-  { token: 'video', title: 'Photo + Video', desc: 'Production, editing, short-form.' },
+  { token: 'seo', title: 'Get found on Google', desc: 'Find SEO help so more people can discover your business online.' },
+  { token: 'social', title: 'Social media help', desc: 'Find experts to manage posts, content, and social growth.' },
+  { token: 'ads', title: 'Run ads', desc: 'Find people who can run Google, Facebook, Instagram, and other ads.' },
+  { token: 'web', title: 'Build a website', desc: 'Find website help for a new site, redesign, or landing page.' },
+  { token: 'branding', title: 'Branding & design', desc: 'Find help with logos, business identity, and visual design.' },
+  { token: 'email', title: 'Email marketing', desc: 'Find help with newsletters, follow-ups, and repeat customers.' },
+  { token: 'content', title: 'Writing & content', desc: 'Find help with website copy, blogs, and marketing content.' },
+  { token: 'video', title: 'Photos & video', desc: 'Find creators for product shoots, videos, and short-form content.' },
 ];
 
 const BUYER_SIGNALS = [
-  { label: 'Use case', value: 'Local growth teams', detail: 'Search by city, category, and fit.' },
-  { label: 'Best for', value: 'Fast provider discovery', detail: 'Go from need to shortlist in minutes.' },
-  { label: 'Workflow', value: 'Browse, compare, inquire', detail: 'No map clutter, just decision-ready profiles.' },
+  { label: 'Built for', value: 'Local businesses', detail: 'Start with the kind of help you need and narrow down fast.' },
+  { label: 'Best for', value: 'Quick shortlists', detail: 'Compare local experts without opening a dozen tabs.' },
+  { label: 'How it works', value: 'Browse, compare, contact', detail: 'Open profiles, check the fit, and reach out directly.' },
 ];
 
 export default function Home() {
@@ -31,14 +31,14 @@ export default function Home() {
             <div className="flex flex-col gap-6">
               <div className="space-y-4">
                 <div className={`inline-flex items-center rounded-xl px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] shadow-sm ${t.brandBadge}`}>
-                  MarketLink discovery
+                  Find local marketing help
                 </div>
                 <div className="max-w-3xl">
                   <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-slate-900 sm:text-5xl">
-                    Find local marketing experts without wasting time on generic directories.
+                    Find marketers, website builders, and other local experts for your business.
                   </h1>
                   <p className={`mt-4 max-w-2xl text-sm leading-7 sm:text-base sm:leading-8 ${t.mutedText}`}>
-                    Browse specialist teams by service, city, and fit. Start with the kind of work you need, then move directly into richer provider pages built for comparison.
+                    Browse by service, narrow by city, and compare real local experts in one place. When someone looks like a fit, open their profile and contact them directly.
                   </p>
                 </div>
               </div>
@@ -48,13 +48,13 @@ export default function Home() {
                   href="/providers"
                   className={`inline-flex min-h-12 items-center justify-center rounded-xl px-6 text-sm font-semibold shadow-sm ${t.primaryBtn}`}
                 >
-                  Browse all providers
+                  Browse local experts
                 </Link>
                 <Link
                   href="/providers"
                   className={`inline-flex min-h-12 items-center justify-center rounded-xl px-6 text-sm font-medium ${t.secondaryBtn}`}
                 >
-                  Use filters
+                  Search by service
                 </Link>
               </div>
 
@@ -72,19 +72,19 @@ export default function Home() {
             <aside className={`ml-dark-panel flex h-full flex-col justify-between rounded-[1.75rem] px-5 py-5 text-white shadow-[0_24px_70px_rgba(23,26,31,0.24)] sm:px-6 sm:py-6`}>
               <div>
                 <div className="text-[11px] font-medium uppercase tracking-[0.28em] text-white/60">How it works</div>
-                <h2 className="mt-3 text-2xl font-semibold tracking-tight">Start from the work, not the noise.</h2>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight">Find help in a few simple steps.</h2>
                 <div className="mt-5 space-y-3">
                   <div className="rounded-[1.35rem] border border-white/10 bg-white/7 px-4 py-3.5">
-                    <div className="text-sm font-semibold">1. Pick a category</div>
-                    <p className="mt-1 text-sm leading-6 text-white/76">SEO, paid ads, branding, web, or the exact service your team needs next.</p>
+                    <div className="text-sm font-semibold">1. Find the kind of help you need</div>
+                    <p className="mt-1 text-sm leading-6 text-white/76">Browse marketers, ad experts, website builders, influencers, and other local experts for your business.</p>
                   </div>
                   <div className="rounded-[1.35rem] border border-white/10 bg-white/7 px-4 py-3.5">
-                    <div className="text-sm font-semibold">2. Compare local options</div>
-                    <p className="mt-1 text-sm leading-6 text-white/76">Review positioning, industries served, proof of work, and direct contact details in one place.</p>
+                    <div className="text-sm font-semibold">2. Compare local experts</div>
+                    <p className="mt-1 text-sm leading-6 text-white/76">See what they do, who they help, and whether they look like the right fit for your business.</p>
                   </div>
                   <div className="rounded-[1.35rem] border border-white/10 bg-white/7 px-4 py-3.5">
-                    <div className="text-sm font-semibold">3. Reach out when it fits</div>
-                    <p className="mt-1 text-sm leading-6 text-white/76">Use the provider page to decide faster instead of bouncing across tabs and half-complete profiles.</p>
+                    <div className="text-sm font-semibold">3. Reach out directly</div>
+                    <p className="mt-1 text-sm leading-6 text-white/76">Open a profile and send an inquiry when you find someone who feels right for the job.</p>
                   </div>
                 </div>
               </div>
@@ -104,10 +104,10 @@ export default function Home() {
           <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <div className={`text-[11px] font-medium uppercase tracking-[0.24em] ${t.mutedText}`}>Browse by need</div>
-              <h2 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-slate-900">Choose the type of marketing help you need.</h2>
+              <h2 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-slate-900">What do you need help with?</h2>
             </div>
             <p className={`max-w-xl text-sm leading-7 ${t.mutedText}`}>
-              Every category routes into the same provider directory with filters already applied, so users can start broad and narrow down without learning a complicated interface.
+              Pick a category and go straight into the expert directory with the right filter already applied.
             </p>
           </div>
 
@@ -135,7 +135,7 @@ export default function Home() {
                 </div>
 
                 <div className="mt-6 flex items-center justify-between gap-4">
-                  <span className="text-sm font-semibold text-slate-900">View providers</span>
+                  <span className="text-sm font-semibold text-slate-900">See experts</span>
                     <span className="text-lg text-slate-400 transition group-hover:translate-x-1 group-hover:text-slate-600" aria-hidden="true">&rarr;</span>
                 </div>
               </Link>
@@ -146,19 +146,19 @@ export default function Home() {
         <section className="mt-8 grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
           <div className={`rounded-[1.75rem] ${t.surface} ${t.border} border px-6 py-6 shadow-[0_18px_50px_rgba(15,23,42,0.06)]`}>
             <div className={`text-[11px] font-medium uppercase tracking-[0.22em] ${t.mutedText}`}>What makes this different</div>
-            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">Built for quick local decisions.</h2>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">Made for quick business decisions.</h2>
             <div className="mt-5 space-y-4">
               <div>
-                <div className="text-sm font-semibold text-slate-900">Less browsing noise</div>
-                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>No endless agency pages with shallow metadata and no useful context.</p>
+                <div className="text-sm font-semibold text-slate-900">Simple starting points</div>
+                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>Start with the kind of help you need instead of guessing where to begin.</p>
               </div>
               <div>
-                <div className="text-sm font-semibold text-slate-900">Stronger provider pages</div>
-                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>Users see positioning, services, work examples, industries, and contact points in a single flow.</p>
+                <div className="text-sm font-semibold text-slate-900">Easier profiles to compare</div>
+                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>See what an expert does, who they help, and how to contact them without extra clutter.</p>
               </div>
               <div>
-                <div className="text-sm font-semibold text-slate-900">MVP-simple search</div>
-                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>The experience stays focused on city, service, and fit until proximity search is worth the added complexity.</p>
+                <div className="text-sm font-semibold text-slate-900">Search that stays simple</div>
+                <p className={`mt-1 text-sm leading-6 ${t.mutedText}`}>Filter by city, service, rating, and verified status without learning a complicated tool.</p>
               </div>
             </div>
           </div>
@@ -167,16 +167,16 @@ export default function Home() {
             <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
               <div>
                 <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-white/60">Next step</div>
-                <h2 className="mt-3 text-2xl font-semibold tracking-tight">Need more control than categories alone?</h2>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight">Want to narrow it down faster?</h2>
                 <p className="mt-3 max-w-xl text-sm leading-7 text-white/78">
-                  Jump into the full providers page for direct filtering by city, rating, service, and verified status.
+                  Open the expert directory and filter by city, service, rating, and verified status.
                 </p>
               </div>
               <Link
                 href="/providers"
                 className="ml-btn-secondary inline-flex min-h-12 items-center justify-center rounded-xl px-6 text-sm font-semibold transition"
               >
-                Go to filters
+                Open directory
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Updates the homepage copy in marketlink-frontend/src/app/page.tsx to use simpler, more buyer-friendly language for local business owners.

Changes include:

clearer hero copy
simpler CTA text
plain-English category labels and descriptions
updated “How it works” messaging
cleaner supporting copy across the homepage
No route or filter-token behavior changed. The homepage still routes into the existing /providers?service=... flow.