### PR TITLE
MM-14: regression pass on shared public components

### DIFF
--- a/marketlink-frontend/src/app/providers/[slug]/not-found.tsx
+++ b/marketlink-frontend/src/app/providers/[slug]/not-found.tsx
@@ -3,10 +3,10 @@ import Link from 'next/link';
 export default function ProviderNotFound() {
   return (
     <main className="mx-auto max-w-3xl px-4 py-16 text-center">
-      <h1 className="text-2xl font-semibold">Provider not found</h1>
-      <p className="mt-2 text-gray-600">We couldn’t find that provider. It may have been removed or is awaiting verification.</p>
+      <h1 className="text-2xl font-semibold">Expert not found</h1>
+      <p className="mt-2 text-gray-600">We couldn&apos;t find that expert profile. It may have been removed or is awaiting verification.</p>
       <Link href="/providers" className="mt-6 inline-block rounded-xl border px-4 py-2 hover:bg-gray-50">
-        Back to listings
+        Back to experts
       </Link>
     </main>
   );

--- a/marketlink-frontend/src/app/providers/[slug]/page.tsx
+++ b/marketlink-frontend/src/app/providers/[slug]/page.tsx
@@ -1,9 +1,9 @@
 ﻿'use client';
 
 import React, { useEffect, useState } from 'react';
-import { notFound } from 'next/navigation';
 import { Figtree, Playfair_Display } from 'next/font/google';
 import InquiryForm from './InquiryForm';
+import ProviderNotFound from './not-found';
 import { useMarketLinkTheme } from '../../../components/ThemeToggle';
 
 const displayFont = Playfair_Display({
@@ -234,15 +234,22 @@ export default function ProviderPage({ params }: PageProps) {
   const resolvedParams = React.use(params);
   const [provider, setProvider] = useState<Provider | null>(null);
   const [loading, setLoading] = useState(true);
+  const [missing, setMissing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchProvider() {
+      setLoading(true);
+      setMissing(false);
+      setError(null);
+      setProvider(null);
+
       try {
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4000';
         const res = await fetch(`${API_BASE}/providers/${resolvedParams.slug}`);
         if (res.status === 404) {
-          notFound();
+          setMissing(true);
+          return;
         }
         if (!res.ok) {
           throw new Error(`Failed to load expert profile: ${res.status}`);
@@ -261,6 +268,10 @@ export default function ProviderPage({ params }: PageProps) {
 
   if (loading) {
     return <div className="mx-auto max-w-4xl px-4 py-8">Loading...</div>;
+  }
+
+  if (missing) {
+    return <ProviderNotFound />;
   }
 
   if (error || !provider) {

--- a/marketlink-frontend/src/components/OwnerControls.tsx
+++ b/marketlink-frontend/src/components/OwnerControls.tsx
@@ -54,8 +54,13 @@ export default function OwnerControls({ slug }: { slug: string }) {
 
   return (
     <div className="ml-auto">
-      <Link href="/dashboard/profile" prefetch className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium hover:bg-gray-50" aria-label="Edit your profile">
-        ✏️ Edit profile
+      <Link
+        href="/dashboard/profile"
+        prefetch
+        className="inline-flex items-center rounded-xl border px-3 py-2 text-sm font-medium hover:bg-gray-50"
+        aria-label="Edit your expert profile"
+      >
+        Edit expert profile
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary
- run the shared public copy regression pass on owner-facing controls and the provider detail not-found state after the recent public IA terminology updates
- update stale public wording from provider/listing language to expert/profile language where it is actually user-facing, while intentionally leaving backend contracts and internal provider type names unchanged
- fix the provider detail 404 rendering path so invalid slugs show the custom not-found UI instead of the `NEXT_HTTP_ERROR_FALLBACK;404` error

## Testing
- npm exec eslint -- "src/components/OwnerControls.tsx" "src/app/providers/[slug]/not-found.tsx" "src/app/providers/[slug]/page.tsx"
- visit `/providers/not-a-real-slug`
