### PR TITLE
MM-89: migrate provider terminology to expert domain model

### DIFF
--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -17,68 +17,69 @@ model User {
   mustChangePassword Boolean       @default(true)
   passwordHash       String?
   adminActions       AdminAction[]
-  providers          Provider[]
+  experts            Expert[]
   sessions           Session[]
 }
 
-model Provider {
-  id             String         @id @default(cuid())
-  email          String         @unique
-  businessName   String
-  slug           String         @unique
-  tagline        String?
-  shortDescription String?
-  overview       String?
-  websiteUrl     String?
-  phone          String?
-  linkedinUrl    String?
-  instagramUrl   String?
-  facebookUrl    String?
-  foundedYear    Int?
-  hourlyRateMin  Int?
-  hourlyRateMax  Int?
-  minProjectBudget Int?
-  currencyCode   String         @default("USD")
-  languages      String[]       @default([])
-  industries     String[]       @default([])
-  clientSizes    String[]       @default([])
-  specialties    String[]       @default([])
-  remoteFriendly Boolean        @default(false)
-  servesNationwide Boolean      @default(false)
+model Expert {
+  id                String                @id @default(cuid())
+  email             String                @unique
+  businessName      String
+  slug              String                @unique
+  tagline           String?
+  shortDescription  String?
+  overview          String?
+  websiteUrl        String?
+  phone             String?
+  linkedinUrl       String?
+  instagramUrl      String?
+  facebookUrl       String?
+  foundedYear       Int?
+  hourlyRateMin     Int?
+  hourlyRateMax     Int?
+  minProjectBudget  Int?
+  currencyCode      String                @default("USD")
+  languages         String[]              @default([])
+  industries        String[]              @default([])
+  clientSizes       String[]              @default([])
+  specialties       String[]              @default([])
+  remoteFriendly    Boolean               @default(false)
+  servesNationwide  Boolean               @default(false)
   responseTimeHours Int?
-  featured       Boolean        @default(false)
-  completionScore Int           @default(0)
-  city           String         @db.Citext
-  state          String         @db.Citext
-  zip            String?
-  rating         Float          @default(0)
-  verified       Boolean        @default(false)
-  logo           String?
-  services       String[]       @default([])
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  planTier       PlanTier       @default(free)
-  userId         String?
-  disabledReason String?
-  notes          String?
-  status         ProviderStatus @default(active)
-  AdminAction    AdminAction[]
-  owner          User?          @relation(fields: [userId], references: [id])
-  projects       ProviderProject[]
-  clients        ProviderClient[]
-  media          ProviderMedia[]
-  reviews        ProviderReview[]
-  certifications ProviderCertification[]
-  awards         ProviderAward[]
+  featured          Boolean               @default(false)
+  completionScore   Int                   @default(0)
+  city              String                @db.Citext
+  state             String                @db.Citext
+  zip               String?
+  rating            Float                 @default(0)
+  verified          Boolean               @default(false)
+  logo              String?
+  services          String[]              @default([])
+  createdAt         DateTime              @default(now())
+  updatedAt         DateTime              @updatedAt
+  planTier          PlanTier              @default(free)
+  userId            String?
+  disabledReason    String?
+  notes             String?
+  status            ExpertStatus          @default(active)
+  adminActions      AdminAction[]
+  owner             User?                 @relation(fields: [userId], references: [id])
+  projects          ExpertProject[]
+  clients           ExpertClient[]
+  media             ExpertMedia[]
+  reviews           ExpertReview[]
+  certifications    ExpertCertification[]
+  awards            ExpertAward[]
 
-  // ✅ New: inquiries/leads for this provider
-  inquiries      Inquiry[]
+  // Inquiry / lead records attached to this expert
+  inquiries Inquiry[]
 
   @@index([status, createdAt])
   @@index([status, verified])
   @@index([status, city])
   @@index([status, rating])
   @@index([status, businessName])
+  @@map("Provider")
 }
 
 model Session {
@@ -101,14 +102,14 @@ model Session {
 model AdminAction {
   id          String          @id @default(cuid())
   adminUserId String?
-  providerId  String
+  expertId    String          @map("providerId")
   type        AdminActionType
   metadata    Json?
   createdAt   DateTime        @default(now())
   admin       User?           @relation(fields: [adminUserId], references: [id])
-  provider    Provider        @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  expert      Expert          @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, createdAt])
+  @@index([expertId, createdAt])
 }
 
 enum UserRole {
@@ -122,11 +123,13 @@ enum PlanTier {
 }
 
 ///
-/// New: Provider status for moderation
-enum ProviderStatus {
+/// Expert status used for moderation while preserving the existing DB enum mapping
+enum ExpertStatus {
   pending
   active
   disabled
+
+  @@map("ProviderStatus")
 }
 
 ///
@@ -149,12 +152,12 @@ enum InquiryStatus {
 }
 
 ///
-/// ✅ New: inquiry/messages sent by business owners to a provider
+/// Inquiry / lead submitted by a business owner to an expert
 model Inquiry {
   id String @id @default(cuid())
 
-  providerId String
-  provider   Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  expertId String @map("providerId")
+  expert   Expert @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
   name    String
   email   String
@@ -164,36 +167,37 @@ model Inquiry {
   status    InquiryStatus @default(NEW)
   createdAt DateTime      @default(now())
 
-  @@index([providerId, createdAt])
+  @@index([expertId, createdAt])
   @@index([status, createdAt])
 }
 
-model ProviderProject {
-  id            String   @id @default(cuid())
-  providerId    String
+model ExpertProject {
+  id            String    @id @default(cuid())
+  expertId      String    @map("providerId")
   title         String
   summary       String?
   challenge     String?
   solution      String?
   results       String?
-  services      String[] @default([])
+  services      String[]  @default([])
   projectBudget Int?
   startedAt     DateTime?
   completedAt   DateTime?
-  isFeatured    Boolean  @default(false)
+  isFeatured    Boolean   @default(false)
   coverImageUrl String?
-  sortOrder     Int      @default(0)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
-  provider      Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  sortOrder     Int       @default(0)
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  expert        Expert    @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, sortOrder, createdAt])
-  @@index([providerId, isFeatured])
+  @@index([expertId, sortOrder, createdAt])
+  @@index([expertId, isFeatured])
+  @@map("ProviderProject")
 }
 
-model ProviderClient {
+model ExpertClient {
   id         String   @id @default(cuid())
-  providerId String
+  expertId   String   @map("providerId")
   name       String
   logoUrl    String?
   websiteUrl String?
@@ -201,85 +205,92 @@ model ProviderClient {
   sortOrder  Int      @default(0)
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
-  provider   Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  expert     Expert   @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, sortOrder, createdAt])
-  @@index([providerId, isFeatured])
+  @@index([expertId, sortOrder, createdAt])
+  @@index([expertId, isFeatured])
+  @@map("ProviderClient")
 }
 
-model ProviderMedia {
-  id         String            @id @default(cuid())
-  providerId String
-  type       ProviderMediaType
-  url        String
-  altText    String?
-  sortOrder  Int               @default(0)
-  createdAt  DateTime          @default(now())
-  updatedAt  DateTime          @updatedAt
-  provider   Provider          @relation(fields: [providerId], references: [id], onDelete: Cascade)
+model ExpertMedia {
+  id        String          @id @default(cuid())
+  expertId  String          @map("providerId")
+  type      ExpertMediaType
+  url       String
+  altText   String?
+  sortOrder Int             @default(0)
+  createdAt DateTime        @default(now())
+  updatedAt DateTime        @updatedAt
+  expert    Expert          @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, type, sortOrder, createdAt])
+  @@index([expertId, type, sortOrder, createdAt])
+  @@map("ProviderMedia")
 }
 
-enum ProviderMediaType {
+enum ExpertMediaType {
   logo
   cover
   gallery
   video
+
+  @@map("ProviderMediaType")
 }
 
-model ProviderReview {
-  id                    String   @id @default(cuid())
-  providerId            String
-  reviewerName          String
-  company               String?
-  rating                Float
-  communicationRating   Float?
-  qualityRating         Float?
-  valueRating           Float?
-  title                 String?
-  body                  String
-  projectSummary        String?
-  verified              Boolean  @default(false)
-  source                String?
-  publishedAt           DateTime?
-  sortOrder             Int      @default(0)
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
-  provider              Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+model ExpertReview {
+  id                  String    @id @default(cuid())
+  expertId            String    @map("providerId")
+  reviewerName        String
+  company             String?
+  rating              Float
+  communicationRating Float?
+  qualityRating       Float?
+  valueRating         Float?
+  title               String?
+  body                String
+  projectSummary      String?
+  verified            Boolean   @default(false)
+  source              String?
+  publishedAt         DateTime?
+  sortOrder           Int       @default(0)
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+  expert              Expert    @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, sortOrder, createdAt])
-  @@index([providerId, verified, publishedAt])
+  @@index([expertId, sortOrder, createdAt])
+  @@index([expertId, verified, publishedAt])
+  @@map("ProviderReview")
 }
 
-model ProviderCertification {
-  id           String   @id @default(cuid())
-  providerId   String
-  title        String
-  issuer       String
-  year         Int?
-  url          String?
+model ExpertCertification {
+  id            String   @id @default(cuid())
+  expertId      String   @map("providerId")
+  title         String
+  issuer        String
+  year          Int?
+  url           String?
   badgeImageUrl String?
-  sortOrder    Int      @default(0)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  provider     Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  sortOrder     Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  expert        Expert   @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, sortOrder, createdAt])
+  @@index([expertId, sortOrder, createdAt])
+  @@map("ProviderCertification")
 }
 
-model ProviderAward {
-  id           String   @id @default(cuid())
-  providerId   String
-  title        String
-  issuer       String
-  year         Int?
-  url          String?
+model ExpertAward {
+  id            String   @id @default(cuid())
+  expertId      String   @map("providerId")
+  title         String
+  issuer        String
+  year          Int?
+  url           String?
   badgeImageUrl String?
-  sortOrder    Int      @default(0)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  provider     Provider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  sortOrder     Int      @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  expert        Expert   @relation(fields: [expertId], references: [id], onDelete: Cascade)
 
-  @@index([providerId, sortOrder, createdAt])
+  @@index([expertId, sortOrder, createdAt])
+  @@map("ProviderAward")
 }

--- a/marketlink-backend/src/lib/mailer.ts
+++ b/marketlink-backend/src/lib/mailer.ts
@@ -69,6 +69,8 @@ export async function sendMagicLinkEmail(to: string, verifyUrl: string): Promise
 }
 
 export async function sendInviteEmail(to: string, tempPassword: string, loginUrl: string, role: 'provider' | 'admin'): Promise<SendResult> {
+  const displayRole = role === 'provider' ? 'expert' : role;
+
   if (!RESEND_API_KEY || !MAIL_FROM) {
     console.log('[mailer] Missing RESEND_API_KEY or MAIL_FROM; logging invite instead:', {
       to,
@@ -83,7 +85,7 @@ export async function sendInviteEmail(to: string, tempPassword: string, loginUrl
   const text = [
     `Hi,`,
     ``,
-    `An admin created a ${role} account for you.`,
+    `An admin created an ${displayRole} account for you.`,
     `Email: ${to}`,
     `Temporary password: ${tempPassword}`,
     ``,
@@ -97,7 +99,7 @@ export async function sendInviteEmail(to: string, tempPassword: string, loginUrl
   const html = `
     <div style="font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica,Arial;">
       <p>Hi,</p>
-      <p>An admin created a <strong>${role}</strong> account for you.</p>
+      <p>An admin created an <strong>${displayRole}</strong> account for you.</p>
       <p><strong>Email:</strong> ${to}</p>
       <p><strong>Temporary password:</strong> ${tempPassword}</p>
       <p>

--- a/marketlink-backend/src/routes/account.ts
+++ b/marketlink-backend/src/routes/account.ts
@@ -10,12 +10,12 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
     return { ok: true, user: { id: user.id, email: user.email, role: user.role } };
   });
 
-  // GET /me/summary → user + owned provider (if any)
+  // GET /me/summary → user + owned expert (with provider alias for compatibility)
   fastify.get('/me/summary', async (req, reply) => {
     const user = await getUserFromRequest(fastify, req);
     if (!user) return reply.code(401).send({ error: 'Not authenticated' });
 
-    const provider = await prisma.provider.findFirst({
+    const expert = await prisma.expert.findFirst({
       where: { userId: user.id },
       select: {
         id: true,
@@ -99,7 +99,8 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
     return {
       ok: true,
       user: { id: user.id, email: user.email, role: user.role },
-      provider,
+      expert,
+      provider: expert,
     };
   });
 };

--- a/marketlink-backend/src/routes/admin.ts
+++ b/marketlink-backend/src/routes/admin.ts
@@ -5,7 +5,7 @@ import bcrypt from 'bcryptjs';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
 import { sendInviteEmail } from '../lib/mailer';
-import { ProviderStatus, InquiryStatus } from '@prisma/client';
+import { ExpertStatus, InquiryStatus } from '@prisma/client';
 
 const requireAdmin = async (fastify: any, req: any) => {
   const user = await getUserFromRequest(fastify, req);
@@ -26,10 +26,10 @@ const parsePage = (raw: unknown, fallback = 1) => {
   return Math.max(1, Math.trunc(n));
 };
 
-const asProviderStatus = (v?: string): ProviderStatus | undefined => {
+const asExpertStatus = (v?: string): ExpertStatus | undefined => {
   if (!v) return undefined;
-  const s = String(v) as ProviderStatus;
-  return Object.values(ProviderStatus).includes(s) ? s : undefined;
+  const s = String(v) as ExpertStatus;
+  return Object.values(ExpertStatus).includes(s) ? s : undefined;
 };
 
 const normalizeSlug = (raw: string) =>
@@ -64,11 +64,10 @@ const normalizeServices = (services: unknown): string[] | undefined => {
     .map((s) => String(s || '').trim())
     .filter(Boolean)
     .slice(0, 50);
-  // de-dupe
   return Array.from(new Set(cleaned));
 };
 
-const adminProviderRowSelect = {
+const adminExpertRowSelect = {
   id: true,
   slug: true,
   businessName: true,
@@ -86,7 +85,11 @@ const adminProviderRowSelect = {
   rating: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderSelect;
+} satisfies Prisma.ExpertSelect;
+
+const adminExpertCollectionPaths = ['/admin/experts', '/admin/providers'] as const;
+const adminExpertDetailPaths = ['/admin/experts/:id', '/admin/providers/:id'] as const;
+const adminExpertResetPasswordPaths = ['/admin/experts/:id/reset-password', '/admin/providers/:id/reset-password'] as const;
 
 const adminRoutes: FastifyPluginAsync = async (fastify) => {
   /**
@@ -98,11 +101,11 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
     if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
 
     const [pendingCount, activeCount, disabledCount, inquiriesNewCount, verifiedCount] = await Promise.all([
-      prisma.provider.count({ where: { status: ProviderStatus.pending } }),
-      prisma.provider.count({ where: { status: ProviderStatus.active } }),
-      prisma.provider.count({ where: { status: ProviderStatus.disabled } }),
+      prisma.expert.count({ where: { status: ExpertStatus.pending } }),
+      prisma.expert.count({ where: { status: ExpertStatus.active } }),
+      prisma.expert.count({ where: { status: ExpertStatus.disabled } }),
       prisma.inquiry.count({ where: { status: InquiryStatus.NEW } }),
-      prisma.provider.count({ where: { verified: true } }),
+      prisma.expert.count({ where: { verified: true } }),
     ]);
 
     return reply.send({
@@ -115,99 +118,103 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   /**
-   * GET /admin/providers
+   * GET /admin/experts
    * Supports:
    *  - status= (optional; if omitted => all)
    *  - query= (optional)
    *  - verified=true|false (optional)
    *  - page, limit
    */
-  fastify.get('/admin/providers', async (req, reply) => {
-    const gate = await requireAdmin(fastify, req);
-    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+  for (const path of adminExpertCollectionPaths) {
+    fastify.get(path, async (req, reply) => {
+      const gate = await requireAdmin(fastify, req);
+      if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
 
-    const { status, page, limit, query, verified } = (req.query || {}) as {
-      status?: string;
-      page?: string;
-      limit?: string;
-      query?: string;
-      verified?: string;
-    };
+      const { status, page, limit, query, verified } = (req.query || {}) as {
+        status?: string;
+        page?: string;
+        limit?: string;
+        query?: string;
+        verified?: string;
+      };
 
-    const statusVal = status ? asProviderStatus(status) : undefined;
-    if (status && !statusVal) {
-      return reply.code(400).send({ error: 'Invalid status filter. Use pending|active|disabled.' });
-    }
+      const statusVal = status ? asExpertStatus(status) : undefined;
+      if (status && !statusVal) {
+        return reply.code(400).send({ error: 'Invalid status filter. Use pending|active|disabled.' });
+      }
 
-    const verifiedVal = typeof verified === 'string' && verified !== '' ? verified === 'true' : undefined;
+      const verifiedVal = typeof verified === 'string' && verified !== '' ? verified === 'true' : undefined;
 
-    const take = parseLimit(limit, 20);
-    const pageNum = parsePage(page, 1);
-    const skip = (pageNum - 1) * take;
+      const take = parseLimit(limit, 20);
+      const pageNum = parsePage(page, 1);
+      const skip = (pageNum - 1) * take;
 
-    const q = (query || '').trim();
+      const q = (query || '').trim();
 
-    const where: Prisma.ProviderWhereInput = {
-      ...(typeof statusVal !== 'undefined' ? { status: statusVal } : {}),
-      ...(typeof verifiedVal !== 'undefined' ? { verified: verifiedVal } : {}),
-      ...(q
-        ? {
-            OR: [
-              { businessName: { contains: q, mode: 'insensitive' } },
-              { email: { contains: q, mode: 'insensitive' } },
-              { city: { contains: q, mode: 'insensitive' } },
-              { state: { contains: q, mode: 'insensitive' } },
-              { tagline: { contains: q, mode: 'insensitive' } },
-              { notes: { contains: q, mode: 'insensitive' } },
-            ],
-          }
-        : {}),
-    };
+      const where: Prisma.ExpertWhereInput = {
+        ...(typeof statusVal !== 'undefined' ? { status: statusVal } : {}),
+        ...(typeof verifiedVal !== 'undefined' ? { verified: verifiedVal } : {}),
+        ...(q
+          ? {
+              OR: [
+                { businessName: { contains: q, mode: 'insensitive' } },
+                { email: { contains: q, mode: 'insensitive' } },
+                { city: { contains: q, mode: 'insensitive' } },
+                { state: { contains: q, mode: 'insensitive' } },
+                { tagline: { contains: q, mode: 'insensitive' } },
+                { notes: { contains: q, mode: 'insensitive' } },
+              ],
+            }
+          : {}),
+      };
 
-    const [total, rows] = await Promise.all([
-      prisma.provider.count({ where }),
-      prisma.provider.findMany({
-        where,
-        orderBy: [{ createdAt: 'desc' }],
-        skip,
-        take,
-        select: adminProviderRowSelect,
-      }),
-    ]);
+      const [total, rows] = await Promise.all([
+        prisma.expert.count({ where }),
+        prisma.expert.findMany({
+          where,
+          orderBy: [{ createdAt: 'desc' }],
+          skip,
+          take,
+          select: adminExpertRowSelect,
+        }),
+      ]);
 
-    const totalPages = Math.max(1, Math.ceil(total / take));
+      const totalPages = Math.max(1, Math.ceil(total / take));
 
-    return reply.send({
-      meta: {
-        total,
-        page: pageNum,
-        limit: take,
-        totalPages,
-        status: statusVal,
-        query: q || undefined,
-        verified: typeof verifiedVal !== 'undefined' ? verifiedVal : undefined,
-      },
-      data: rows,
+      return reply.send({
+        meta: {
+          total,
+          page: pageNum,
+          limit: take,
+          totalPages,
+          status: statusVal,
+          query: q || undefined,
+          verified: typeof verifiedVal !== 'undefined' ? verifiedVal : undefined,
+        },
+        data: rows,
+      });
     });
-  });
+  }
 
   /**
-   * GET /admin/providers/:id
+   * GET /admin/experts/:id
    */
-  fastify.get('/admin/providers/:id', async (req, reply) => {
-    const gate = await requireAdmin(fastify, req);
-    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+  for (const path of adminExpertDetailPaths) {
+    fastify.get(path, async (req, reply) => {
+      const gate = await requireAdmin(fastify, req);
+      if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
 
-    const { id } = req.params as { id: string };
-    const provider = await prisma.provider.findUnique({
-      where: { id },
-      select: adminProviderRowSelect,
+      const { id } = req.params as { id: string };
+      const expert = await prisma.expert.findUnique({
+        where: { id },
+        select: adminExpertRowSelect,
+      });
+
+      if (!expert) return reply.code(404).send({ error: 'Expert not found' });
+
+      return reply.send({ ok: true, expert, provider: expert });
     });
-
-    if (!provider) return reply.code(404).send({ error: 'Provider not found' });
-
-    return reply.send({ ok: true, provider });
-  });
+  }
 
   /**
    * POST /admin/users/invite
@@ -254,206 +261,206 @@ const adminRoutes: FastifyPluginAsync = async (fastify) => {
   });
 
   /**
-   * POST /admin/providers/:id/reset-password
-   * - Ensures provider has a user, sets temp password, sends email.
+   * POST /admin/experts/:id/reset-password
+   * - Ensures the expert has a user, sets temp password, and sends email.
    */
-  fastify.post('/admin/providers/:id/reset-password', async (req, reply) => {
-    const gate = await requireAdmin(fastify, req);
-    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+  for (const path of adminExpertResetPasswordPaths) {
+    fastify.post(path, async (req, reply) => {
+      const gate = await requireAdmin(fastify, req);
+      if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
 
-    const { id } = req.params as { id: string };
-    const provider = await prisma.provider.findUnique({
-      where: { id },
-      select: { id: true, email: true, userId: true },
-    });
-    if (!provider) return reply.code(404).send({ error: 'Provider not found' });
+      const { id } = req.params as { id: string };
+      const expert = await prisma.expert.findUnique({
+        where: { id },
+        select: { id: true, email: true, userId: true },
+      });
+      if (!expert) return reply.code(404).send({ error: 'Expert not found' });
 
-    const email = String(provider.email || '')
-      .trim()
-      .toLowerCase();
-    if (!isValidEmail(email)) return reply.code(400).send({ error: 'Invalid provider email.' });
+      const email = String(expert.email || '')
+        .trim()
+        .toLowerCase();
+      if (!isValidEmail(email)) return reply.code(400).send({ error: 'Invalid expert email.' });
 
-    let userId = provider.userId || null;
-    if (!userId) {
-      const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
-      if (existing) {
-        userId = existing.id;
-      } else {
-        const created = await prisma.user.create({
-          data: { email, role: 'provider', mustChangePassword: true, isDisabled: false },
-          select: { id: true },
+      let userId = expert.userId || null;
+      if (!userId) {
+        const existing = await prisma.user.findUnique({ where: { email }, select: { id: true } });
+        if (existing) {
+          userId = existing.id;
+        } else {
+          const created = await prisma.user.create({
+            data: { email, role: 'provider', mustChangePassword: true, isDisabled: false },
+            select: { id: true },
+          });
+          userId = created.id;
+        }
+
+        await prisma.expert.update({
+          where: { id: expert.id },
+          data: { userId },
         });
-        userId = created.id;
       }
 
-      await prisma.provider.update({
-        where: { id: provider.id },
-        data: { userId },
+      const tempPassword = generateTempPassword();
+      const passwordHash = await bcrypt.hash(tempPassword, 10);
+
+      await prisma.user.update({
+        where: { id: userId },
+        data: { passwordHash, mustChangePassword: true, isDisabled: false },
       });
-    }
 
-    const tempPassword = generateTempPassword();
-    const passwordHash = await bcrypt.hash(tempPassword, 10);
+      const emailRes = await sendInviteEmail(email, tempPassword, getLoginUrl(), 'provider');
 
-    await prisma.user.update({
-      where: { id: userId },
-      data: { passwordHash, mustChangePassword: true, isDisabled: false },
+      return reply.send({
+        ok: true,
+        expertId: expert.id,
+        providerId: expert.id,
+        userId,
+        tempPassword,
+        emailSent: emailRes.ok,
+      });
     });
-
-    const emailRes = await sendInviteEmail(email, tempPassword, getLoginUrl(), 'provider');
-
-    return reply.send({
-      ok: true,
-      providerId: provider.id,
-      userId,
-      tempPassword,
-      emailSent: emailRes.ok,
-    });
-  });
+  }
 
   /**
-   * PATCH /admin/providers/:id
+   * PATCH /admin/experts/:id
    * Now supports admin edits for:
    *  - status, disabledReason, verified
    *  - businessName, email, slug, city, state, zip, tagline, logo, services, notes
    */
-  fastify.patch('/admin/providers/:id', async (req, reply) => {
-    const gate = await requireAdmin(fastify, req);
-    if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
+  for (const path of adminExpertDetailPaths) {
+    fastify.patch(path, async (req, reply) => {
+      const gate = await requireAdmin(fastify, req);
+      if (!gate.ok) return reply.code(gate.code).send({ error: gate.error });
 
-    const { id } = req.params as { id: string };
-    const body = (req.body || {}) as {
-      status?: 'active' | 'disabled' | 'pending';
-      disabledReason?: string | null;
-      verified?: boolean;
+      const { id } = req.params as { id: string };
+      const body = (req.body || {}) as {
+        status?: 'active' | 'disabled' | 'pending';
+        disabledReason?: string | null;
+        verified?: boolean;
 
-      businessName?: string;
-      email?: string;
-      slug?: string;
-      city?: string;
-      state?: string;
-      zip?: string | null;
-      tagline?: string | null;
-      logo?: string | null;
-      services?: string[];
-      notes?: string | null;
-    };
+        businessName?: string;
+        email?: string;
+        slug?: string;
+        city?: string;
+        state?: string;
+        zip?: string | null;
+        tagline?: string | null;
+        logo?: string | null;
+        services?: string[];
+        notes?: string | null;
+      };
 
-    const data: Prisma.ProviderUpdateInput = {};
+      const data: Prisma.ExpertUpdateInput = {};
 
-    // ---- editable text fields ----
-    if (typeof body.businessName !== 'undefined') {
-      const v = String(body.businessName).trim();
-      if (!v) return reply.code(400).send({ error: 'businessName cannot be empty.' });
-      (data as any).businessName = v;
-    }
+      if (typeof body.businessName !== 'undefined') {
+        const v = String(body.businessName).trim();
+        if (!v) return reply.code(400).send({ error: 'businessName cannot be empty.' });
+        (data as any).businessName = v;
+      }
 
-    if (typeof body.email !== 'undefined') {
-      const v = String(body.email).trim().toLowerCase();
-      if (!isValidEmail(v)) return reply.code(400).send({ error: 'Invalid email.' });
-      (data as any).email = v;
-    }
+      if (typeof body.email !== 'undefined') {
+        const v = String(body.email).trim().toLowerCase();
+        if (!isValidEmail(v)) return reply.code(400).send({ error: 'Invalid email.' });
+        (data as any).email = v;
+      }
 
-    if (typeof body.slug !== 'undefined') {
-      const v = normalizeSlug(String(body.slug));
-      if (!v) return reply.code(400).send({ error: 'slug cannot be empty.' });
-      (data as any).slug = v;
-    }
+      if (typeof body.slug !== 'undefined') {
+        const v = normalizeSlug(String(body.slug));
+        if (!v) return reply.code(400).send({ error: 'slug cannot be empty.' });
+        (data as any).slug = v;
+      }
 
-    if (typeof body.city !== 'undefined') {
-      const v = String(body.city).trim();
-      if (!v) return reply.code(400).send({ error: 'city cannot be empty.' });
-      (data as any).city = v;
-    }
+      if (typeof body.city !== 'undefined') {
+        const v = String(body.city).trim();
+        if (!v) return reply.code(400).send({ error: 'city cannot be empty.' });
+        (data as any).city = v;
+      }
 
-    if (typeof body.state !== 'undefined') {
-      const v = String(body.state).trim();
-      if (!v) return reply.code(400).send({ error: 'state cannot be empty.' });
-      (data as any).state = v;
-    }
+      if (typeof body.state !== 'undefined') {
+        const v = String(body.state).trim();
+        if (!v) return reply.code(400).send({ error: 'state cannot be empty.' });
+        (data as any).state = v;
+      }
 
-    if (typeof body.zip !== 'undefined') {
-      const v = String(body.zip ?? '').trim();
-      (data as any).zip = v ? v : null;
-    }
+      if (typeof body.zip !== 'undefined') {
+        const v = String(body.zip ?? '').trim();
+        (data as any).zip = v ? v : null;
+      }
 
-    if (typeof body.tagline !== 'undefined') {
-      const v = String(body.tagline ?? '').trim();
-      (data as any).tagline = v ? v : null;
-    }
+      if (typeof body.tagline !== 'undefined') {
+        const v = String(body.tagline ?? '').trim();
+        (data as any).tagline = v ? v : null;
+      }
 
-    if (typeof body.logo !== 'undefined') {
-      const v = String(body.logo ?? '').trim();
-      (data as any).logo = v ? v : null;
-    }
+      if (typeof body.logo !== 'undefined') {
+        const v = String(body.logo ?? '').trim();
+        (data as any).logo = v ? v : null;
+      }
 
-    if (typeof body.notes !== 'undefined') {
-      const v = String(body.notes ?? '').trim();
-      (data as any).notes = v ? v : null;
-    }
+      if (typeof body.notes !== 'undefined') {
+        const v = String(body.notes ?? '').trim();
+        (data as any).notes = v ? v : null;
+      }
 
-    if (typeof body.services !== 'undefined') {
-      const cleaned = normalizeServices(body.services);
-      if (!cleaned) return reply.code(400).send({ error: 'services must be an array of strings.' });
-      (data as any).services = cleaned;
-    }
+      if (typeof body.services !== 'undefined') {
+        const cleaned = normalizeServices(body.services);
+        if (!cleaned) return reply.code(400).send({ error: 'services must be an array of strings.' });
+        (data as any).services = cleaned;
+      }
 
-    // ---- status + disabledReason rules ----
-    if (typeof body.status !== 'undefined') {
-      const next = asProviderStatus(body.status);
-      if (!next) return reply.code(400).send({ error: 'Invalid status value.' });
+      if (typeof body.status !== 'undefined') {
+        const next = asExpertStatus(body.status);
+        if (!next) return reply.code(400).send({ error: 'Invalid status value.' });
 
-      (data as any).status = next;
+        (data as any).status = next;
 
-      if (next === ProviderStatus.disabled) {
-        const reason = String(body.disabledReason || '').trim();
-        if (!reason) {
-          return reply.code(400).send({ error: 'disabledReason is required when disabling a provider.' });
+        if (next === ExpertStatus.disabled) {
+          const reason = String(body.disabledReason || '').trim();
+          if (!reason) {
+            return reply.code(400).send({ error: 'disabledReason is required when disabling an expert.' });
+          }
+          (data as any).disabledReason = reason;
+        } else {
+          (data as any).disabledReason = null;
         }
+      } else if (typeof body.disabledReason !== 'undefined') {
+        const existing = await prisma.expert.findUnique({ where: { id }, select: { status: true } });
+        if (!existing) return reply.code(404).send({ error: 'Expert not found' });
+
+        if (existing.status !== ExpertStatus.disabled) {
+          return reply.code(400).send({ error: 'disabledReason can only be set when status is disabled. Provide status=\"disabled\".' });
+        }
+
+        const reason = String(body.disabledReason || '').trim() || null;
         (data as any).disabledReason = reason;
-      } else {
-        (data as any).disabledReason = null;
-      }
-    } else if (typeof body.disabledReason !== 'undefined') {
-      // disabledReason without status change: only allowed if currently disabled
-      const existing = await prisma.provider.findUnique({ where: { id }, select: { status: true } });
-      if (!existing) return reply.code(404).send({ error: 'Provider not found' });
-
-      if (existing.status !== ProviderStatus.disabled) {
-        return reply.code(400).send({ error: 'disabledReason can only be set when status is disabled. Provide status="disabled".' });
       }
 
-      const reason = String(body.disabledReason || '').trim() || null;
-      (data as any).disabledReason = reason;
-    }
-
-    // verified toggle (optional)
-    if (typeof body.verified !== 'undefined') {
-      (data as any).verified = Boolean(body.verified);
-    }
-
-    if (Object.keys(data).length === 0) {
-      return reply.code(400).send({ error: 'No fields to update' });
-    }
-
-    try {
-      const updated = await prisma.provider.update({
-        where: { id },
-        data,
-        select: adminProviderRowSelect,
-      });
-      return reply.send({ ok: true, provider: updated });
-    } catch (e: any) {
-      // Unique constraint errors (email / slug)
-      if (e?.code === 'P2002') {
-        const target = Array.isArray(e?.meta?.target) ? e.meta.target.join(', ') : 'unique field';
-        return reply.code(409).send({ error: `Duplicate value for ${target}.` });
+      if (typeof body.verified !== 'undefined') {
+        (data as any).verified = Boolean(body.verified);
       }
 
-      req.log.error({ err: e }, 'admin.patch-provider.failed');
-      return reply.code(500).send({ error: 'Failed to update provider' });
-    }
-  });
+      if (Object.keys(data).length === 0) {
+        return reply.code(400).send({ error: 'No fields to update' });
+      }
+
+      try {
+        const updated = await prisma.expert.update({
+          where: { id },
+          data,
+          select: adminExpertRowSelect,
+        });
+        return reply.send({ ok: true, expert: updated, provider: updated });
+      } catch (e: any) {
+        if (e?.code === 'P2002') {
+          const target = Array.isArray(e?.meta?.target) ? e.meta.target.join(', ') : 'unique field';
+          return reply.code(409).send({ error: `Duplicate value for ${target}.` });
+        }
+
+        req.log.error({ err: e }, 'admin.patch-expert.failed');
+        return reply.code(500).send({ error: 'Failed to update expert' });
+      }
+    });
+  }
 };
 
 export default adminRoutes;

--- a/marketlink-backend/src/routes/inquiries.ts
+++ b/marketlink-backend/src/routes/inquiries.ts
@@ -1,17 +1,18 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
-import { InquiryStatus, ProviderStatus } from '@prisma/client';
+import { ExpertStatus, InquiryStatus } from '@prisma/client';
 
 const isEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
 
 const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
   /**
    * POST /inquiries (public)
-   * Body: { providerSlug, name, email, phone?, message }
+   * Body: { expertSlug?, providerSlug?, name, email, phone?, message }
    */
   fastify.post('/inquiries', async (req, reply) => {
     const body = (req.body || {}) as {
+      expertSlug?: string;
       providerSlug?: string;
       name?: string;
       email?: string;
@@ -19,7 +20,7 @@ const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
       message?: string;
     };
 
-    const providerSlug = String(body.providerSlug || '').trim();
+    const expertSlug = String(body.expertSlug || body.providerSlug || '').trim();
     const name = String(body.name || '').trim();
     const email = String(body.email || '')
       .trim()
@@ -27,7 +28,7 @@ const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
     const phone = String(body.phone || '').trim() || null;
     const message = String(body.message || '').trim();
 
-    if (!providerSlug) return reply.code(400).send({ ok: false, error: 'providerSlug is required' });
+    if (!expertSlug) return reply.code(400).send({ ok: false, error: 'expertSlug is required' });
     if (!name) return reply.code(400).send({ ok: false, error: 'name is required' });
     if (!email || !isEmail(email)) return reply.code(400).send({ ok: false, error: 'valid email is required' });
     if (!message) return reply.code(400).send({ ok: false, error: 'message is required' });
@@ -38,18 +39,18 @@ const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
     if (phone && phone.length > 40) return reply.code(400).send({ ok: false, error: 'phone is too long' });
     if (message.length > 2000) return reply.code(400).send({ ok: false, error: 'message is too long' });
 
-    // Only allow inquiries to ACTIVE providers (matches public listing rules)
-    const provider = await prisma.provider.findFirst({
-      where: { slug: providerSlug, status: ProviderStatus.active },
+    // Only allow inquiries to ACTIVE experts (matches public listing rules)
+    const expert = await prisma.expert.findFirst({
+      where: { slug: expertSlug, status: ExpertStatus.active },
       select: { id: true },
     });
 
-    if (!provider) return reply.code(404).send({ ok: false, error: 'Provider not found' });
+    if (!expert) return reply.code(404).send({ ok: false, error: 'Expert not found' });
 
     try {
       const created = await prisma.inquiry.create({
         data: {
-          providerId: provider.id,
+          expertId: expert.id,
           name,
           email,
           phone: phone || undefined,
@@ -68,21 +69,21 @@ const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
 
   /**
    * GET /inquiries (owner-only)
-   * Lists inquiries for the provider owned by the logged-in user
+   * Lists inquiries for the expert owned by the logged-in user
    */
   fastify.get('/inquiries', async (req, reply) => {
     const user = await getUserFromRequest(fastify, req);
     if (!user) return reply.code(401).send({ error: 'Not authenticated' });
 
-    const provider = await prisma.provider.findFirst({
+    const expert = await prisma.expert.findFirst({
       where: { userId: user.id },
       select: { id: true },
     });
 
-    if (!provider) return reply.code(404).send({ error: "You don't have a provider profile yet." });
+    if (!expert) return reply.code(404).send({ error: "You don't have an expert profile yet." });
 
     const rows = await prisma.inquiry.findMany({
-      where: { providerId: provider.id },
+      where: { expertId: expert.id },
       orderBy: { createdAt: 'desc' },
       take: 100,
       select: {
@@ -119,15 +120,15 @@ const inquiriesRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.code(400).send({ ok: false, error: 'status must be NEW, READ, or ARCHIVED' });
     }
 
-    const provider = await prisma.provider.findFirst({
+    const expert = await prisma.expert.findFirst({
       where: { userId: user.id },
       select: { id: true },
     });
 
-    if (!provider) return reply.code(404).send({ ok: false, error: "You don't have a provider profile yet." });
+    if (!expert) return reply.code(404).send({ ok: false, error: "You don't have an expert profile yet." });
 
     const existing = await prisma.inquiry.findFirst({
-      where: { id, providerId: provider.id },
+      where: { id, expertId: expert.id },
       select: { id: true, status: true },
     });
 

--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
-import { ProviderMediaType, ProviderStatus } from '@prisma/client';
+import { ExpertMediaType, ExpertStatus } from '@prisma/client';
 
 type SortKey = 'newest' | 'name' | 'rating' | 'verified';
 type OrderDir = 'asc' | 'desc';
@@ -75,7 +75,7 @@ const parseOptionalDate = (raw: unknown): Date | null | undefined => {
   return d;
 };
 
-const providerProjectSelect = {
+const expertProjectSelect = {
   id: true,
   title: true,
   summary: true,
@@ -91,9 +91,9 @@ const providerProjectSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderProjectSelect;
+} satisfies Prisma.ExpertProjectSelect;
 
-const providerClientSelect = {
+const expertClientSelect = {
   id: true,
   name: true,
   logoUrl: true,
@@ -102,9 +102,9 @@ const providerClientSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderClientSelect;
+} satisfies Prisma.ExpertClientSelect;
 
-const providerMediaSelect = {
+const expertMediaSelect = {
   id: true,
   type: true,
   url: true,
@@ -112,9 +112,9 @@ const providerMediaSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderMediaSelect;
+} satisfies Prisma.ExpertMediaSelect;
 
-const providerReviewSelect = {
+const expertReviewSelect = {
   id: true,
   reviewerName: true,
   company: true,
@@ -131,9 +131,9 @@ const providerReviewSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderReviewSelect;
+} satisfies Prisma.ExpertReviewSelect;
 
-const providerCertificationSelect = {
+const expertCertificationSelect = {
   id: true,
   title: true,
   issuer: true,
@@ -143,9 +143,9 @@ const providerCertificationSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderCertificationSelect;
+} satisfies Prisma.ExpertCertificationSelect;
 
-const providerAwardSelect = {
+const expertAwardSelect = {
   id: true,
   title: true,
   issuer: true,
@@ -155,7 +155,7 @@ const providerAwardSelect = {
   sortOrder: true,
   createdAt: true,
   updatedAt: true,
-} satisfies Prisma.ProviderAwardSelect;
+} satisfies Prisma.ExpertAwardSelect;
 
 // ---- Fastify JSON schema for query validation ----
 const listQuerySchema = {
@@ -177,7 +177,7 @@ const listQuerySchema = {
 } as const;
 
 // ---- Reusable Prisma selects ----
-const providerDetailSelect = {
+const expertDetailSelect = {
   id: true,
   slug: true,
   businessName: true,
@@ -216,32 +216,32 @@ const providerDetailSelect = {
   createdAt: true,
   updatedAt: true,
   projects: {
-    select: providerProjectSelect,
+    select: expertProjectSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
   clients: {
-    select: providerClientSelect,
+    select: expertClientSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
   media: {
-    select: providerMediaSelect,
+    select: expertMediaSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
   reviews: {
-    select: providerReviewSelect,
+    select: expertReviewSelect,
     orderBy: [{ sortOrder: 'asc' }, { publishedAt: 'desc' }, { createdAt: 'desc' }],
   },
   certifications: {
-    select: providerCertificationSelect,
+    select: expertCertificationSelect,
     orderBy: [{ sortOrder: 'asc' }, { year: 'desc' }, { createdAt: 'asc' }],
   },
   awards: {
-    select: providerAwardSelect,
+    select: expertAwardSelect,
     orderBy: [{ sortOrder: 'asc' }, { year: 'desc' }, { createdAt: 'asc' }],
   },
-} satisfies Prisma.ProviderSelect;
+} satisfies Prisma.ExpertSelect;
 
-const providerEditorSelect = {
+const expertEditorSelect = {
   id: true,
   slug: true,
   businessName: true,
@@ -273,23 +273,27 @@ const providerEditorSelect = {
   status: true,
   disabledReason: true,
   projects: {
-    select: providerProjectSelect,
+    select: expertProjectSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
   clients: {
-    select: providerClientSelect,
+    select: expertClientSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
   media: {
-    select: providerMediaSelect,
+    select: expertMediaSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
-} satisfies Prisma.ProviderSelect;
+} satisfies Prisma.ExpertSelect;
 
-const providersRoutes: FastifyPluginAsync = async (fastify) => {
-  // LIST: GET /providers (public ACTIVE only)
-  fastify.get(
-    '/providers',
+const expertCollectionPaths = ['/experts', '/providers'] as const;
+const expertDetailPaths = ['/experts/:slug', '/providers/:slug'] as const;
+
+const expertsRoutes: FastifyPluginAsync = async (fastify) => {
+  // LIST: GET /experts (with /providers kept as a compatibility alias)
+  for (const path of expertCollectionPaths) {
+    fastify.get(
+      path,
     {
       schema: {
         querystring: listQuerySchema,
@@ -316,7 +320,7 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    async (req, reply) => {
+      async (req, reply) => {
       const {
         name,
         city,
@@ -348,7 +352,7 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
       const skip = (pageNum - 1) * limitNum;
       const take = limitNum;
 
-      const andFilters: Prisma.ProviderWhereInput[] = [];
+      const andFilters: Prisma.ExpertWhereInput[] = [];
 
       if (city && city.trim()) {
         andFilters.push({ city: { startsWith: city.trim(), mode: 'insensitive' } });
@@ -387,26 +391,26 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         if (v === '0' || v === 'false') andFilters.push({ verified: false });
       }
 
-      const baseFilter: Prisma.ProviderWhereInput = { status: ProviderStatus.active };
-      const where: Prisma.ProviderWhereInput = andFilters.length ? { AND: [...andFilters, baseFilter] } : baseFilter;
+      const baseFilter: Prisma.ExpertWhereInput = { status: ExpertStatus.active };
+      const where: Prisma.ExpertWhereInput = andFilters.length ? { AND: [...andFilters, baseFilter] } : baseFilter;
 
       const sortKey = asSortKey(sortRaw);
       const primaryOrder: OrderDir = asOrder(orderRaw, sortKey);
 
-      const primaryOrderBy: Prisma.ProviderOrderByWithRelationInput =
+      const primaryOrderBy: Prisma.ExpertOrderByWithRelationInput =
         sortKey === 'newest' ? { createdAt: primaryOrder } : sortKey === 'name' ? { businessName: primaryOrder } : sortKey === 'rating' ? { rating: primaryOrder } : { verified: primaryOrder };
 
-      const orderBy: Prisma.ProviderOrderByWithRelationInput[] = [primaryOrderBy];
+      const orderBy: Prisma.ExpertOrderByWithRelationInput[] = [primaryOrderBy];
 
-      const hasPrimary = (k: keyof Prisma.ProviderOrderByWithRelationInput) => k in primaryOrderBy;
+      const hasPrimary = (k: keyof Prisma.ExpertOrderByWithRelationInput) => k in primaryOrderBy;
       if (!hasPrimary('rating')) orderBy.push({ rating: 'desc' });
       if (!hasPrimary('verified')) orderBy.push({ verified: 'desc' });
       if (!hasPrimary('businessName')) orderBy.push({ businessName: 'asc' });
       if (!hasPrimary('createdAt')) orderBy.push({ createdAt: 'desc' });
 
       const [total, rows] = await Promise.all([
-        prisma.provider.count({ where }),
-        prisma.provider.findMany({
+        prisma.expert.count({ where }),
+        prisma.expert.findMany({
           where,
           orderBy,
           skip,
@@ -445,49 +449,53 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         },
         data: rows,
       });
-    },
-  );
+      },
+    );
+  }
 
-  // DETAIL: GET /providers/:slug
-  fastify.get('/providers/:slug', async (req, reply) => {
-    const { slug } = req.params as { slug: string };
+  // DETAIL: GET /experts/:slug (with /providers/:slug kept as a compatibility alias)
+  for (const path of expertDetailPaths) {
+    fastify.get(path, async (req, reply) => {
+      const { slug } = req.params as { slug: string };
 
-    const active = await prisma.provider.findFirst({
-      where: { slug, status: ProviderStatus.active },
-      select: providerDetailSelect,
+      const active = await prisma.expert.findFirst({
+        where: { slug, status: ExpertStatus.active },
+        select: expertDetailSelect,
+      });
+      if (active) return reply.send(active);
+
+      const nonActive = await prisma.expert.findUnique({
+        where: { slug },
+        select: {
+          ...expertDetailSelect,
+          userId: true,
+        } satisfies Prisma.ExpertSelect,
+      });
+
+      if (!nonActive) {
+        reply.code(404).send({ error: 'Not found' });
+        return;
+      }
+
+      const user = await getUserFromRequest(fastify, req);
+      if (!user || user.id !== (nonActive as any).userId) {
+        reply.code(404).send({ error: 'Not found' });
+        return;
+      }
+
+      const { userId, ...ownerVisible } = nonActive as any;
+      return reply.send(ownerVisible);
     });
-    if (active) return reply.send(active);
+  }
 
-    const nonActive = await prisma.provider.findUnique({
-      where: { slug },
-      select: {
-        ...providerDetailSelect,
-        userId: true,
-      } satisfies Prisma.ProviderSelect,
-    });
-
-    if (!nonActive) {
-      reply.code(404).send({ error: 'Not found' });
-      return;
-    }
-
-    const user = await getUserFromRequest(fastify, req);
-    if (!user || user.id !== (nonActive as any).userId) {
-      reply.code(404).send({ error: 'Not found' });
-      return;
-    }
-
-    const { userId, ...ownerVisible } = nonActive as any;
-    return reply.send(ownerVisible);
-  });
-
-  // CREATE: POST /providers (owner = logged-in user)
-  fastify.post('/providers', async (req, reply) => {
+  // CREATE: POST /experts (with /providers kept as a compatibility alias)
+  for (const path of expertCollectionPaths) {
+    fastify.post(path, async (req, reply) => {
     const user = await getUserFromRequest(fastify, req);
     if (!user) return reply.code(401).send({ error: 'Not authenticated' });
 
-    const existing = await prisma.provider.findFirst({ where: { userId: user.id } });
-    if (existing) return reply.code(409).send({ error: 'You already have a provider profile.' });
+    const existing = await prisma.expert.findFirst({ where: { userId: user.id } });
+    if (existing) return reply.code(409).send({ error: 'You already have an expert profile.' });
 
     const body = (req.body || {}) as {
       businessName?: string;
@@ -574,15 +582,15 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '');
 
-    const base = slugify(businessName) || `provider-${Date.now()}`;
+    const base = slugify(businessName) || `expert-${Date.now()}`;
     let slug = base;
     let i = 2;
-    while (await prisma.provider.findUnique({ where: { slug } })) {
+    while (await prisma.expert.findUnique({ where: { slug } })) {
       slug = `${base}-${i++}`;
     }
 
     try {
-      const created = await prisma.provider.create({
+      const created = await prisma.expert.create({
         data: {
           userId: user.id,
           email: user.email,
@@ -606,23 +614,25 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         },
       });
 
-      return reply.code(201).send({ ok: true, provider: created });
+      return reply.code(201).send({ ok: true, expert: created, provider: created });
     } catch (e: any) {
       if (e?.code === 'P2002') {
-        return reply.code(409).send({ error: 'A provider with this email or slug already exists.' });
+        return reply.code(409).send({ error: 'An expert with this email or slug already exists.' });
       }
-      req.log.error({ err: e }, 'create-provider.failed');
-      return reply.code(500).send({ error: 'Failed to create provider' });
+      req.log.error({ err: e }, 'create-expert.failed');
+      return reply.code(500).send({ error: 'Failed to create expert' });
     }
-  });
+    });
+  }
 
-  // UPDATE: PUT /providers (owner-only profile edits)
-  fastify.put('/providers', async (req, reply) => {
+  // UPDATE: PUT /experts (with /providers kept as a compatibility alias)
+  for (const path of expertCollectionPaths) {
+    fastify.put(path, async (req, reply) => {
     const user = await getUserFromRequest(fastify, req);
     if (!user) return reply.code(401).send({ error: 'Not authenticated' });
 
-    const provider = await prisma.provider.findFirst({ where: { userId: user.id } });
-    if (!provider) return reply.code(404).send({ error: "You don't have a provider profile yet." });
+    const expert = await prisma.expert.findFirst({ where: { userId: user.id } });
+    if (!expert) return reply.code(404).send({ error: "You don't have an expert profile yet." });
 
     const body = (req.body || {}) as {
       businessName?: string;
@@ -680,10 +690,10 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
       }>;
     };
 
-    const data: Prisma.ProviderUpdateInput = {};
-    let projectCreates: Prisma.ProviderProjectCreateManyProviderInput[] | undefined;
-    let clientCreates: Prisma.ProviderClientCreateManyProviderInput[] | undefined;
-    let mediaCreates: Prisma.ProviderMediaCreateManyProviderInput[] | undefined;
+    const data: Prisma.ExpertUpdateInput = {};
+    let projectCreates: Prisma.ExpertProjectCreateManyExpertInput[] | undefined;
+    let clientCreates: Prisma.ExpertClientCreateManyExpertInput[] | undefined;
+    let mediaCreates: Prisma.ExpertMediaCreateManyExpertInput[] | undefined;
 
     if (typeof body.businessName === 'string') {
       const v = body.businessName.trim();
@@ -882,8 +892,8 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         const type = String(item.type || '')
           .trim()
           .toLowerCase();
-        if (!type || !Object.values(ProviderMediaType).includes(type as ProviderMediaType)) {
-          return reply.code(400).send({ error: `media[${i}].type must be one of: ${Object.values(ProviderMediaType).join(', ')}.` });
+        if (!type || !Object.values(ExpertMediaType).includes(type as ExpertMediaType)) {
+          return reply.code(400).send({ error: `media[${i}].type must be one of: ${Object.values(ExpertMediaType).join(', ')}.` });
         }
         const url = String(item.url || '').trim();
         if (!url) return reply.code(400).send({ error: `media[${i}].url is required.` });
@@ -891,7 +901,7 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
         if (Number.isNaN(sortOrder)) return reply.code(400).send({ error: `media[${i}].sortOrder must be a number.` });
 
         mediaCreates.push({
-          type: type as ProviderMediaType,
+          type: type as ExpertMediaType,
           url,
           altText: String(item.altText || '').trim() || null,
           sortOrder: typeof sortOrder === 'undefined' || sortOrder === null ? i : sortOrder,
@@ -906,51 +916,52 @@ const providersRoutes: FastifyPluginAsync = async (fastify) => {
     try {
       const updated = await prisma.$transaction(async (tx) => {
         if (Object.keys(data).length > 0) {
-          await tx.provider.update({
-            where: { id: provider.id },
+          await tx.expert.update({
+            where: { id: expert.id },
             data,
           });
         }
 
         if (typeof projectCreates !== 'undefined') {
-          await tx.providerProject.deleteMany({ where: { providerId: provider.id } });
+          await tx.expertProject.deleteMany({ where: { expertId: expert.id } });
           if (projectCreates.length) {
-            await tx.providerProject.createMany({
-              data: projectCreates.map((item) => ({ ...item, providerId: provider.id })),
+            await tx.expertProject.createMany({
+              data: projectCreates.map((item) => ({ ...item, expertId: expert.id })),
             });
           }
         }
 
         if (typeof clientCreates !== 'undefined') {
-          await tx.providerClient.deleteMany({ where: { providerId: provider.id } });
+          await tx.expertClient.deleteMany({ where: { expertId: expert.id } });
           if (clientCreates.length) {
-            await tx.providerClient.createMany({
-              data: clientCreates.map((item) => ({ ...item, providerId: provider.id })),
+            await tx.expertClient.createMany({
+              data: clientCreates.map((item) => ({ ...item, expertId: expert.id })),
             });
           }
         }
 
         if (typeof mediaCreates !== 'undefined') {
-          await tx.providerMedia.deleteMany({ where: { providerId: provider.id } });
+          await tx.expertMedia.deleteMany({ where: { expertId: expert.id } });
           if (mediaCreates.length) {
-            await tx.providerMedia.createMany({
-              data: mediaCreates.map((item) => ({ ...item, providerId: provider.id })),
+            await tx.expertMedia.createMany({
+              data: mediaCreates.map((item) => ({ ...item, expertId: expert.id })),
             });
           }
         }
 
-        return tx.provider.findUniqueOrThrow({
-          where: { id: provider.id },
-          select: providerEditorSelect,
+        return tx.expert.findUniqueOrThrow({
+          where: { id: expert.id },
+          select: expertEditorSelect,
         });
       });
 
-      return reply.send({ ok: true, provider: updated });
+      return reply.send({ ok: true, expert: updated, provider: updated });
     } catch (e: any) {
-      req.log.error({ err: e }, 'update-provider.failed');
-      return reply.code(500).send({ error: 'Failed to update provider' });
+      req.log.error({ err: e }, 'update-expert.failed');
+      return reply.code(500).send({ error: 'Failed to update expert' });
     }
-  });
+    });
+  }
 };
 
-export default providersRoutes;
+export default expertsRoutes;

--- a/marketlink-backend/src/server.ts
+++ b/marketlink-backend/src/server.ts
@@ -7,7 +7,7 @@ import rateLimit from '@fastify/rate-limit';
 import adminRoutes from './routes/admin';
 import authRoutes from './routes/auth';
 import accountRoutes from './routes/account';
-import providersRoutes from './routes/providers';
+import expertsRoutes from './routes/providers';
 import inquiriesRoutes from './routes/inquiries';
 
 function normalizeOrigin(raw: string) {
@@ -57,7 +57,7 @@ async function start() {
 
   await fastify.register(authRoutes);
   await fastify.register(accountRoutes);
-  await fastify.register(providersRoutes);
+  await fastify.register(expertsRoutes);
   await fastify.register(inquiriesRoutes);
   await fastify.register(adminRoutes);
 

--- a/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
@@ -41,7 +41,7 @@ export default function OnboardingPage() {
       if (!city.trim()) throw new Error('City is required.');
       if (!state.trim()) throw new Error('State is required.');
 
-      const res = await fetch(`${API_BASE}/providers`, {
+      const res = await fetch(`${API_BASE}/experts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -62,7 +62,7 @@ export default function OnboardingPage() {
       }
 
       const data = await res.json();
-      const slug = data?.provider?.slug as string | undefined;
+      const slug = (data?.expert?.slug || data?.provider?.slug) as string | undefined;
 
       if (slug) {
         router.replace(`/providers/${slug}`);

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -9,7 +9,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
 type User = { id: string; email: string; role: 'provider' | 'admin' };
 
-type ProviderSummary = {
+type ExpertSummary = {
   id: string;
   slug: string;
   businessName: string;
@@ -37,8 +37,8 @@ export default function DashboardPage() {
     return <h2 className="text-sm font-semibold text-slate-900">{children}</h2>;
   }
 
-  const [user, setUser] = useState<User | null>(null);
-  const [provider, setProvider] = useState<ProviderSummary>(null);
+const [user, setUser] = useState<User | null>(null);
+  const [expert, setExpert] = useState<ExpertSummary>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [inquiryCount, setInquiryCount] = useState<number | null>(null);
@@ -61,7 +61,7 @@ export default function DashboardPage() {
           throw new Error(body?.error || `Failed (${res.status})`);
         }
 
-        const data = (await res.json()) as { user?: User; provider?: ProviderSummary };
+        const data = (await res.json()) as { user?: User; expert?: ExpertSummary; provider?: ExpertSummary };
 
         if (data?.user?.role === 'admin') {
           router.replace('/dashboard/admin');
@@ -69,7 +69,7 @@ export default function DashboardPage() {
         }
 
         setUser(data.user ?? null);
-        setProvider(data.provider ?? null);
+        setExpert(data.expert ?? data.provider ?? null);
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : 'Something went wrong');
       } finally {
@@ -79,7 +79,7 @@ export default function DashboardPage() {
   }, [router]);
 
   useEffect(() => {
-    if (!provider) return;
+    if (!expert) return;
 
     (async () => {
       try {
@@ -98,7 +98,7 @@ export default function DashboardPage() {
         // ignore inquiry count failures on dashboard
       }
     })();
-  }, [provider]);
+  }, [expert]);
 
   const shellClass = 'ml-card rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-6';
   const mutedCardClass = 'ml-surface-muted rounded-2xl p-4';
@@ -131,7 +131,7 @@ export default function DashboardPage() {
 
   if (!user) return null;
 
-  const providerLocation = provider ? `${provider.city}, ${provider.state}` : 'Create your profile to get listed.';
+  const expertLocation = expert ? `${expert.city}, ${expert.state}` : 'Create your profile to get listed.';
 
   return (
     <main className={`${t.pageBg} min-h-[calc(100vh-72px)]`}>
@@ -145,15 +145,15 @@ export default function DashboardPage() {
               <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">
                 <span className="font-medium text-slate-900">{user.email}</span>
                 <Pill>{user.role}</Pill>
-                {provider ? <Pill>{provider.status}</Pill> : <Pill>Setup</Pill>}
+                {expert ? <Pill>{expert.status}</Pill> : <Pill>Setup</Pill>}
               </div>
-              <p className={`${t.mutedText} mt-3 text-sm`}>{provider ? `${provider.businessName} • ${providerLocation}` : providerLocation}</p>
+              <p className={`${t.mutedText} mt-3 text-sm`}>{expert ? `${expert.businessName} • ${expertLocation}` : expertLocation}</p>
             </div>
 
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
               <div className={mutedCardClass}>
                 <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Profile</div>
-                <div className="mt-2 text-base font-semibold text-slate-900">{provider ? provider.businessName : 'Not created'}</div>
+                <div className="mt-2 text-base font-semibold text-slate-900">{expert ? expert.businessName : 'Not created'}</div>
               </div>
               <div className={mutedCardClass}>
                 <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Inquiries</div>
@@ -169,7 +169,7 @@ export default function DashboardPage() {
 
         <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.35fr)_360px]">
           <div className="order-1 space-y-5">
-            {!provider ? (
+            {!expert ? (
               <section className={shellClass}>
                 <div className="flex flex-col gap-5">
                   <div className="flex items-start justify-between gap-4">
@@ -209,9 +209,9 @@ export default function DashboardPage() {
                   <div className="flex items-start justify-between gap-4">
                     <div>
                       <h2 className="text-xl font-semibold text-slate-900">{provider.businessName}</h2>
-                      <p className={`mt-2 text-sm ${t.mutedText}`}>{providerLocation}</p>
+                      <p className={`mt-2 text-sm ${t.mutedText}`}>{expertLocation}</p>
                     </div>
-                    <Pill>{provider.status}</Pill>
+                    <Pill>{expert.status}</Pill>
                   </div>
 
                   <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
@@ -245,13 +245,13 @@ export default function DashboardPage() {
             <section className={shellClass}>
               <div className="flex items-start justify-between gap-4">
                 <SectionTitle>Quick actions</SectionTitle>
-                {provider ? <Pill>{inquiryCount === null ? 'Loading...' : `${inquiryCount} total`}</Pill> : <Pill>Setup first</Pill>}
+                {expert ? <Pill>{inquiryCount === null ? 'Loading...' : `${inquiryCount} total`}</Pill> : <Pill>Setup first</Pill>}
               </div>
 
               <div className="mt-4 grid gap-3 sm:grid-cols-2">
-                <Link href={provider ? '/dashboard/inquiries' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!provider}>
+                <Link href={expert ? '/dashboard/inquiries' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!expert}>
                   <div className="text-sm font-semibold text-slate-900">Inquiries</div>
-                  <p className={`mt-1 text-sm ${t.mutedText}`}>{provider ? 'View and respond to leads.' : 'Create a profile first to receive leads.'}</p>
+                  <p className={`mt-1 text-sm ${t.mutedText}`}>{expert ? 'View and respond to leads.' : 'Create a profile first to receive leads.'}</p>
                 </Link>
 
                 <div className={mutedCardClass}>

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -81,6 +81,11 @@ type Provider = {
 
 type MeSummaryResponse = {
   user?: { role?: Role };
+  expert?: Partial<Provider> & {
+    projects?: Array<Partial<ProviderProject>>;
+    clients?: Array<Partial<ProviderClient>>;
+    media?: Array<Partial<ProviderMedia>>;
+  };
   provider?: Partial<Provider> & {
     projects?: Array<Partial<ProviderProject>>;
     clients?: Array<Partial<ProviderClient>>;
@@ -138,9 +143,8 @@ export default function ProfileEditorPage() {
         const meRole = (me?.user?.role || 'provider') as Role;
         setRole(meRole);
 
-        if (!me.provider) return router.replace('/dashboard/onboarding');
-
-        const p = me.provider;
+        const p = me.expert ?? me.provider;
+        if (!p) return router.replace('/dashboard/onboarding');
 
         setData({
           slug: p.slug ?? '',
@@ -432,7 +436,7 @@ export default function ProfileEditorPage() {
         basePayload.disabledReason = basePayload.status === 'disabled' ? String(data.disabledReason || '').trim() : null;
       }
 
-      const res = await fetch(`${API_BASE}/providers`, {
+      const res = await fetch(`${API_BASE}/experts`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/marketlink-frontend/src/app/providers/[slug]/InquiryForm.tsx
+++ b/marketlink-frontend/src/app/providers/[slug]/InquiryForm.tsx
@@ -5,7 +5,7 @@ import { useMarketLinkTheme } from '../../../components/ThemeToggle';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4000';
 
-export default function InquiryForm({ providerSlug }: { providerSlug: string }) {
+export default function InquiryForm({ expertSlug }: { expertSlug: string }) {
   const { t } = useMarketLinkTheme();
   const [saving, setSaving] = useState(false);
   const [sent, setSent] = useState(false);
@@ -43,7 +43,7 @@ export default function InquiryForm({ providerSlug }: { providerSlug: string }) 
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
         cache: 'no-store',
-        body: JSON.stringify({ providerSlug, name, email, phone, message }),
+        body: JSON.stringify({ expertSlug, name, email, phone, message }),
       });
 
       if (!res.ok) {

--- a/marketlink-frontend/src/app/providers/[slug]/page.tsx
+++ b/marketlink-frontend/src/app/providers/[slug]/page.tsx
@@ -246,7 +246,7 @@ export default function ProviderPage({ params }: PageProps) {
 
       try {
         const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:4000';
-        const res = await fetch(`${API_BASE}/providers/${resolvedParams.slug}`);
+        const res = await fetch(`${API_BASE}/experts/${resolvedParams.slug}`);
         if (res.status === 404) {
           setMissing(true);
           return;
@@ -746,7 +746,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                 </div>
 
                 <div className="px-6 py-6">
-                  {p.status === 'active' ? <InquiryForm providerSlug={p.slug} /> : <div className="text-sm text-slate-600">Contact form will be available once this expert profile is active.</div>}
+                  {p.status === 'active' ? <InquiryForm expertSlug={p.slug} /> : <div className="text-sm text-slate-600">Contact form will be available once this expert profile is active.</div>}
                 </div>
               </section>
 

--- a/marketlink-frontend/src/app/providers/page.tsx
+++ b/marketlink-frontend/src/app/providers/page.tsx
@@ -351,7 +351,7 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
 
   const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
-  const res = await fetch(`${apiBase}/providers?${qs}`, {
+  const res = await fetch(`${apiBase}/experts?${qs}`, {
     cache: 'no-store',
     headers: { 'content-type': 'application/json' },
   });

--- a/marketlink-frontend/src/components/OwnerControls.tsx
+++ b/marketlink-frontend/src/components/OwnerControls.tsx
@@ -9,6 +9,7 @@ type MeSummary =
   | {
       ok: true;
       user: { id: string; email: string; role: 'provider' | 'admin' };
+      expert: { id: string; slug: string } | null;
       provider: { id: string; slug: string } | null;
     }
   | { ok: false };
@@ -35,7 +36,8 @@ export default function OwnerControls({ slug }: { slug: string }) {
         if (cancelled) return;
 
         if (data.ok) {
-          setOwns(Boolean(data.provider && data.provider.slug === slug));
+          const ownedProfile = data.expert ?? data.provider;
+          setOwns(Boolean(ownedProfile && ownedProfile.slug === slug));
         } else {
           setOwns(false);
         }


### PR DESCRIPTION
## Summary
- rename the backend domain model to `Expert` while preserving the existing Neon/Postgres storage through Prisma mappings
- add expert-first backend routes and payloads, keeping `/providers` and related provider aliases as compatibility shims
- switch the main frontend consumers to the expert-first contract without breaking the current public or dashboard flows

## What changed
- updated the Prisma schema and backend route layer to use `Expert`/`expertId` semantics in code
- made `/experts` and `/admin/experts` the primary API paths while keeping `/providers` aliases alive intentionally
- updated `/me/summary`, inquiry handling, admin flows, and invite mailer copy for expert-first terminology
- updated the dashboard, onboarding, profile editor, owner controls, expert list, and expert detail page consumers to prefer the expert contract

## Validation
- `npm exec prisma validate`
- `npm run build` in `marketlink-backend`
- targeted `eslint` on the changed frontend files

## Notes
- global frontend `npm run lint` still fails because of pre-existing issues in `marketlink-frontend/tests/admin.spec.ts` and `marketlink-frontend/tests/profile.spec.ts`
- compatibility shims remain intentionally in place for `/providers`, `/admin/providers`, `/me/summary.provider`, and `providerSlug` so the later route and DB cleanup tickets can land safely