### PR TITLE
MM-19: extend provider create and update validation for expert fields

### DIFF
--- a/docs/superpowers/plans/2026-04-28-one-month-mvp-roadmap.md
+++ b/docs/superpowers/plans/2026-04-28-one-month-mvp-roadmap.md
@@ -1,0 +1,158 @@
+# MarketLink One-Month MVP Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a credible public expert marketplace MVP in one month, get real business and expert feedback, and defer heavier marketplace workflow features until after learning from that launch.
+
+**Architecture:** Build only the public-facing discovery and expert-profile foundation needed to help a business owner understand the offer, browse experts, compare basic proof, and send inquiries. Stop before buyer accounts, broadcast requests, proposals, messaging, notifications, and monetization so launch is fast and feedback comes early.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, TailwindCSS, Fastify, Prisma, PostgreSQL, session auth.
+
+---
+
+## MVP Definition
+
+This first launch should prove four things:
+
+1. Businesses understand what MarketLink is.
+2. Businesses can find and compare local marketing experts.
+3. Businesses are willing to send inquiries.
+4. Experts are willing to be listed under the broader expert model.
+
+If those four are not proven yet, building buyer accounts, request broadcasting, proposals, messaging, notifications, or monetization is premature.
+
+## Epic Buckets
+
+### Ship Before Feedback
+
+- `MM-8` Public IA and Terminology Implementation
+- `MM-15` Provider Schema and Read-Model Extension for Unified Expert Model
+- `MM-22` Homepage and Discovery Implementation
+- `MM-29` Expert Card, Detail, and Inquiry Simplification
+
+### Ship After Feedback
+
+- Buyer Accounts and Dashboard Foundation
+- Broadcast Request Flow
+- Expert Proposal Flow
+
+### Defer Until There Is Clear Traction
+
+- Private Messaging
+- Notifications and Delivery Wiring
+- Admin Moderation Extension for Buyer-Side Workflows
+- Monetization Scaffolding
+
+## What "Done Enough to Launch" Means
+
+The first launch does **not** need a fully structured hiring workflow. It only needs:
+
+- clean homepage positioning
+- usable `/experts` discovery
+- stronger expert detail pages
+- expert model support for agencies, freelancers, creators, and specialists
+- inquiry submission that works reliably
+
+That is enough to launch, test demand, and gather qualitative feedback.
+
+## One-Month Roadmap
+
+### Week 1: Finish Expert Model Foundation
+
+- [ ] Finish the remaining required tickets in `MM-15`
+- [ ] Treat `MM-18` and `MM-19` as required because the new fields are not usable until read models and validation support them
+- [ ] Treat `MM-20` and `MM-21` as required if the new expert fields must be visible in the MVP
+- [ ] Defer `MM-36` to `MM-41` unless one of them fixes a direct launch blocker
+
+**Target outcome:** the system can persist, read, validate, and display the unified expert model without broken paths or confusing fallback behavior.
+
+### Week 2: Ship Discovery That Makes Sense
+
+- [ ] Start `MM-22` Homepage and Discovery Implementation
+- [ ] Keep scope tight: homepage, category/service entry, expert list framing, and basic filtering clarity
+- [ ] Do not expand into advanced recommendation, AI diagnosis, or heavy personalization
+- [ ] Make sure the path from homepage to `/experts` feels obvious and fast
+
+**Target outcome:** a local business owner can land on the site and quickly understand where to click to find marketing help.
+
+### Week 3: Improve Expert Comparison and Inquiry Confidence
+
+- [ ] Start `MM-29` Expert Card, Detail, and Inquiry Simplification
+- [ ] Focus on proof, scannability, clarity, trust, and contact confidence
+- [ ] Make cards easier to compare
+- [ ] Make expert detail pages feel more trustworthy and easier to evaluate
+- [ ] Make inquiry prompts and CTAs simple and credible
+
+**Target outcome:** a buyer can compare experts and feel comfortable sending an inquiry without needing buyer accounts or proposals.
+
+### Week 4: Launch Readiness and Feedback Setup
+
+- [ ] Run a regression pass across homepage, `/experts`, expert detail, onboarding, and inquiry flow
+- [ ] Seed enough representative experts for agency, freelancer, creator, and specialist paths
+- [ ] Tighten copy, polish obvious UX friction, and remove unfinished or misleading surfaces
+- [ ] Prepare a short feedback loop:
+  - who to show it to
+  - what questions to ask
+  - what signals matter most
+
+**Target outcome:** the product is stable enough to demo and share, and feedback collection is intentional rather than ad hoc.
+
+## MVP Ticket Cut Line
+
+### Must-Have
+
+- `MM-8` completed
+- `MM-15` core story set needed to make expert fields real:
+  - `MM-16`
+  - `MM-17`
+  - `MM-18`
+  - `MM-19`
+  - likely `MM-20`
+  - likely `MM-21`
+- `MM-22` core discovery tickets
+- `MM-29` core card/detail/inquiry tickets
+
+### Nice-to-Have but Not Launch-Critical
+
+- deeper dashboard cleanup
+- broader profile-editor polish
+- non-blocking internal terminology cleanup
+- extra admin/reporting refinements
+
+### Do Not Block Launch On
+
+- buyer account system
+- request broadcasting
+- proposal workflow
+- private messaging
+- notification system
+- monetization
+
+## Post-Launch Plan
+
+After the first launch, evaluate:
+
+1. Do businesses understand the positioning?
+2. Which expert types get the most interest?
+3. Are inquiries happening?
+4. Are experts willing to participate and maintain profiles?
+5. What do buyers complain is missing from the current flow?
+
+Use those answers to decide whether phase 2 should prioritize:
+
+- buyer accounts
+- broadcast requests
+- proposals
+
+and in what order.
+
+## Recommendation
+
+The correct move is:
+
+- finish the public marketplace MVP
+- launch in roughly a month
+- get real user feedback
+- only then decide how much of the structured marketplace workflow to build next
+
+This keeps the roadmap ambitious without forcing you to build the whole marketplace before learning whether the public expert directory already solves a meaningful problem.

--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
-import { ExpertMediaType, ExpertStatus } from '@prisma/client';
+import { ExpertMediaType, ExpertStatus, ExpertType } from '@prisma/client';
 
 type SortKey = 'newest' | 'name' | 'rating' | 'verified';
 type OrderDir = 'asc' | 'desc';
@@ -64,6 +64,16 @@ const parseOptionalBool = (raw: unknown): boolean | undefined => {
   if (s === 'true' || s === '1') return true;
   if (s === 'false' || s === '0') return false;
   return undefined;
+};
+
+const parseOptionalExpertType = (raw: unknown): ExpertType | null | undefined | 'invalid' => {
+  if (typeof raw === 'undefined') return undefined;
+  if (raw === null) return null;
+  if (typeof raw !== 'string') return 'invalid';
+
+  const value = raw.trim().toLowerCase();
+  if (!value) return null;
+  return Object.values(ExpertType).includes(value as ExpertType) ? (value as ExpertType) : 'invalid';
 };
 
 const parseOptionalDate = (raw: unknown): Date | null | undefined => {
@@ -524,6 +534,10 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       linkedinUrl?: string;
       instagramUrl?: string;
       facebookUrl?: string;
+      expertType?: string | null;
+      creatorPlatforms?: string[] | string;
+      creatorAudienceSize?: number | string;
+      creatorProofSummary?: string | null;
       foundedYear?: number | string;
       hourlyRateMin?: number | string;
       hourlyRateMax?: number | string;
@@ -571,11 +585,15 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
     const zip = (body.zip || '').trim() || null;
     const tagline = (body.tagline || '').trim() || null;
     const logo = (body.logo || '').trim() || null;
+    const expertType = parseOptionalExpertType(body.expertType);
 
     if (!businessName) return reply.code(400).send({ error: 'businessName is required' });
     if (!city) return reply.code(400).send({ error: 'city is required' });
     if (!state) return reply.code(400).send({ error: 'state is required' });
     if (state.length < 2) return reply.code(400).send({ error: 'state must be at least 2 characters' });
+    if (expertType === 'invalid') {
+      return reply.code(400).send({ error: `expertType must be one of: ${Object.values(ExpertType).join(', ')}.` });
+    }
 
     let services: string[] = [];
     if (Array.isArray(body.services)) {
@@ -585,6 +603,30 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
         .split(',')
         .map((s) => s.trim().toLowerCase())
         .filter(Boolean);
+    }
+
+    const creatorPlatforms = normalizeTokenArray(body.creatorPlatforms);
+    if (creatorPlatforms === null) {
+      return reply.code(400).send({ error: 'creatorPlatforms must be an array or comma-separated string.' });
+    }
+
+    const creatorAudienceSize = parseOptionalInt(body.creatorAudienceSize);
+    if (Number.isNaN(creatorAudienceSize)) {
+      return reply.code(400).send({ error: 'creatorAudienceSize must be a number.' });
+    }
+    if (creatorAudienceSize !== null && typeof creatorAudienceSize === 'number' && creatorAudienceSize < 0) {
+      return reply.code(400).send({ error: 'creatorAudienceSize cannot be negative.' });
+    }
+
+    let creatorProofSummary: string | null | undefined;
+    if (typeof body.creatorProofSummary !== 'undefined') {
+      if (body.creatorProofSummary === null) {
+        creatorProofSummary = null;
+      } else if (typeof body.creatorProofSummary === 'string') {
+        creatorProofSummary = body.creatorProofSummary.trim() || null;
+      } else {
+        return reply.code(400).send({ error: 'creatorProofSummary must be a string.' });
+      }
     }
 
     const slugify = (str: string) =>
@@ -608,20 +650,28 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
           email: user.email,
           businessName,
           slug,
+          expertType: expertType === null ? undefined : expertType,
           tagline,
           city,
           state,
           zip: zip || undefined,
           services,
           logo: logo || undefined,
+          creatorPlatforms: creatorPlatforms || undefined,
+          creatorAudienceSize: typeof creatorAudienceSize === 'undefined' ? undefined : creatorAudienceSize,
+          creatorProofSummary: typeof creatorProofSummary === 'undefined' ? undefined : creatorProofSummary,
         },
         select: {
           id: true,
           slug: true,
           businessName: true,
+          expertType: true,
           city: true,
           state: true,
           services: true,
+          creatorPlatforms: true,
+          creatorAudienceSize: true,
+          creatorProofSummary: true,
           status: true,
         },
       });
@@ -661,6 +711,10 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       linkedinUrl?: string;
       instagramUrl?: string;
       facebookUrl?: string;
+      expertType?: string | null;
+      creatorPlatforms?: string[] | string;
+      creatorAudienceSize?: number | string;
+      creatorProofSummary?: string | null;
       foundedYear?: number | string;
       hourlyRateMin?: number | string;
       hourlyRateMax?: number | string;
@@ -761,6 +815,33 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
     if (typeof body.facebookUrl === 'string') {
       const v = body.facebookUrl.trim();
       (data as any).facebookUrl = v || null;
+    }
+    if (typeof body.expertType !== 'undefined') {
+      const expertType = parseOptionalExpertType(body.expertType);
+      if (expertType === 'invalid') {
+        return reply.code(400).send({ error: `expertType must be one of: ${Object.values(ExpertType).join(', ')}.` });
+      }
+      (data as any).expertType = expertType;
+    }
+    const creatorPlatforms = normalizeTokenArray(body.creatorPlatforms);
+    if (creatorPlatforms === null) return reply.code(400).send({ error: 'creatorPlatforms must be an array or comma-separated string.' });
+    if (typeof creatorPlatforms !== 'undefined') (data as any).creatorPlatforms = creatorPlatforms;
+
+    const creatorAudienceSize = parseOptionalInt(body.creatorAudienceSize);
+    if (typeof creatorAudienceSize !== 'undefined') {
+      if (Number.isNaN(creatorAudienceSize)) return reply.code(400).send({ error: 'creatorAudienceSize must be a number.' });
+      if (creatorAudienceSize !== null && creatorAudienceSize < 0) return reply.code(400).send({ error: 'creatorAudienceSize cannot be negative.' });
+      (data as any).creatorAudienceSize = creatorAudienceSize;
+    }
+    if (typeof body.creatorProofSummary !== 'undefined') {
+      if (body.creatorProofSummary === null) {
+        (data as any).creatorProofSummary = null;
+      } else if (typeof body.creatorProofSummary === 'string') {
+        const v = body.creatorProofSummary.trim();
+        (data as any).creatorProofSummary = v || null;
+      } else {
+        return reply.code(400).send({ error: 'creatorProofSummary must be a string.' });
+      }
     }
     if (typeof body.currencyCode === 'string') {
       const v = body.currencyCode.trim().toUpperCase();

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -212,7 +212,7 @@ const [user, setUser] = useState<User | null>(null);
                 <div className="flex flex-col gap-5">
                   <div className="flex items-start justify-between gap-4">
                     <div>
-                      <h2 className="text-xl font-semibold text-slate-900">{provider.businessName}</h2>
+                      <h2 className="text-xl font-semibold text-slate-900">{expert.businessName}</h2>
                       <p className={`mt-2 text-sm ${t.mutedText}`}>{expertLocation}</p>
                     </div>
                     <Pill>{expert.status}</Pill>
@@ -284,17 +284,17 @@ const [user, setUser] = useState<User | null>(null);
             <section className={shellClass}>
               <SectionTitle>Status</SectionTitle>
               <p className={`mt-3 text-sm ${t.mutedText}`}>
-                {!provider
+                {!expert
                   ? 'You are not listed yet. Complete setup to get discovered.'
-                  : provider.status === 'active'
+                  : expert.status === 'active'
                   ? 'Your profile is live and visible in search.'
-                  : provider.status === 'pending'
+                  : expert.status === 'pending'
                   ? 'Your profile is pending review and not visible in search yet.'
-                  : provider.status === 'disabled'
-                  ? `Your profile is disabled and hidden from search.${provider.disabledReason ? ` Reason: ${provider.disabledReason}` : ''}`
+                  : expert.status === 'disabled'
+                  ? `Your profile is disabled and hidden from search.${expert.disabledReason ? ` Reason: ${expert.disabledReason}` : ''}`
                   : 'Your profile status is unknown.'}
               </p>
-              {provider?.status === 'pending' ? <p className={`mt-3 text-xs ${t.mutedText}`}>Tip: make sure your services and city are accurate.</p> : null}
+              {expert?.status === 'pending' ? <p className={`mt-3 text-xs ${t.mutedText}`}>Tip: make sure your services and city are accurate.</p> : null}
             </section>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- validate and persist `expertType`, `creatorPlatforms`, `creatorAudienceSize`, and `creatorProofSummary` in `POST /experts` and `PUT /experts`
- fix the dashboard runtime regression caused by leftover `provider` references after the expert rename
- add the one-month MVP roadmap doc to the repo with clean ASCII content

## Verification
- `npx tsc -p tsconfig.json` in `marketlink-backend`
- `npm run build` in `marketlink-frontend`

## Notes
- onboarding/profile UI for entering the new expert fields is still a later ticket (`MM-20`)
- the roadmap doc lives at `docs/superpowers/plans/2026-04-28-one-month-mvp-roadmap.md`