### PR TITLE
MM-20: add onboarding and profile editor inputs for expert fields

### DIFF
--- a/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
@@ -13,6 +13,13 @@ const SERVICE_OPTIONS = [
   { value: 'print', label: 'Print' },
 ];
 
+const EXPERT_TYPE_OPTIONS = [
+  { value: 'agency', label: 'Agency' },
+  { value: 'freelancer', label: 'Freelancer' },
+  { value: 'creator', label: 'Creator' },
+  { value: 'specialist', label: 'Specialist' },
+];
+
 export default function OnboardingPage() {
   const router = useRouter();
 
@@ -22,6 +29,10 @@ export default function OnboardingPage() {
   const [zip, setZip] = useState('');
   const [tagline, setTagline] = useState('');
   const [logo, setLogo] = useState('');
+  const [expertType, setExpertType] = useState('');
+  const [creatorPlatforms, setCreatorPlatforms] = useState<string[]>([]);
+  const [creatorAudienceSize, setCreatorAudienceSize] = useState('');
+  const [creatorProofSummary, setCreatorProofSummary] = useState('');
   const [services, setServices] = useState<string[]>([]);
 
   const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
@@ -29,6 +40,17 @@ export default function OnboardingPage() {
 
   function toggleService(val: string) {
     setServices((prev) => (prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]));
+  }
+
+  function parseTokenInput(raw: string) {
+    return Array.from(
+      new Set(
+        raw
+          .split(',')
+          .map((s) => s.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    );
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -52,6 +74,10 @@ export default function OnboardingPage() {
           zip: zip.trim() || undefined,
           tagline: tagline.trim() || undefined,
           logo: logo.trim() || undefined,
+          expertType: expertType || undefined,
+          creatorPlatforms: expertType === 'creator' ? creatorPlatforms : undefined,
+          creatorAudienceSize: expertType === 'creator' ? creatorAudienceSize.trim() || undefined : undefined,
+          creatorProofSummary: expertType === 'creator' ? creatorProofSummary.trim() || undefined : undefined,
           services,
         }),
       });
@@ -122,6 +148,59 @@ export default function OnboardingPage() {
               <label className="mb-1 block text-sm font-medium text-slate-700">Tagline</label>
               <input className={fieldClass} value={tagline} onChange={(e) => setTagline(e.target.value)} placeholder="Meta + Google Ads for local" />
             </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Expert type</label>
+              <select className={fieldClass} value={expertType} onChange={(e) => setExpertType(e.target.value)}>
+                <option value="">Select the best fit</option>
+                {EXPERT_TYPE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {expertType === 'creator' ? (
+              <div className="grid gap-4 rounded-3xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+                <div>
+                  <div className="text-sm font-semibold text-slate-900">Creator proof</div>
+                  <p className="mt-1 text-xs text-slate-500">Add the channels and audience signals that help buyers understand your creator reach.</p>
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Platforms (comma separated)</label>
+                  <input
+                    className={fieldClass}
+                    value={creatorPlatforms.join(', ')}
+                    onChange={(e) => setCreatorPlatforms(parseTokenInput(e.target.value))}
+                    placeholder="instagram, tiktok, youtube"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Audience size</label>
+                  <input
+                    type="number"
+                    min="0"
+                    className={fieldClass}
+                    value={creatorAudienceSize}
+                    onChange={(e) => setCreatorAudienceSize(e.target.value)}
+                    placeholder="e.g. 50000"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Proof summary</label>
+                  <textarea
+                    className={`${fieldClass} min-h-[112px]`}
+                    value={creatorProofSummary}
+                    onChange={(e) => setCreatorProofSummary(e.target.value)}
+                    placeholder="Describe your audience, content niche, and the proof buyers should know."
+                  />
+                </div>
+              </div>
+            ) : null}
 
             <div>
               <label className="mb-1 block text-sm font-medium text-slate-700">Logo URL</label>

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -105,6 +105,13 @@ const SERVICE_OPTIONS = [
   { value: 'print', label: 'Print' },
 ];
 
+const EXPERT_TYPE_OPTIONS = [
+  { value: 'agency', label: 'Agency' },
+  { value: 'freelancer', label: 'Freelancer' },
+  { value: 'creator', label: 'Creator' },
+  { value: 'specialist', label: 'Specialist' },
+];
+
 const MEDIA_TYPE_OPTIONS: Array<{ value: MediaType; label: string }> = [
   { value: 'cover', label: 'Cover' },
   { value: 'gallery', label: 'Gallery' },
@@ -153,6 +160,7 @@ export default function ProfileEditorPage() {
         setData({
           slug: p.slug ?? '',
           businessName: p.businessName ?? '',
+          expertType: p.expertType ?? null,
           shortDescription: p.shortDescription ?? '',
           overview: p.overview ?? '',
           websiteUrl: p.websiteUrl ?? '',
@@ -160,6 +168,9 @@ export default function ProfileEditorPage() {
           linkedinUrl: p.linkedinUrl ?? '',
           instagramUrl: p.instagramUrl ?? '',
           facebookUrl: p.facebookUrl ?? '',
+          creatorPlatforms: Array.isArray(p.creatorPlatforms) ? p.creatorPlatforms : [],
+          creatorAudienceSize: p.creatorAudienceSize ?? '',
+          creatorProofSummary: p.creatorProofSummary ?? '',
           foundedYear: p.foundedYear ?? '',
           hourlyRateMin: p.hourlyRateMin ?? '',
           hourlyRateMax: p.hourlyRateMax ?? '',
@@ -385,6 +396,7 @@ export default function ProfileEditorPage() {
         zip: (data.zip || '').trim(),
         tagline: (data.tagline || '').trim(),
         logo: (data.logo || '').trim(),
+        expertType: data.expertType || '',
         services: Array.from(new Set(data.services.map((s) => s.trim()).filter(Boolean))),
         shortDescription: (data.shortDescription || '').trim(),
         overview: (data.overview || '').trim(),
@@ -393,6 +405,10 @@ export default function ProfileEditorPage() {
         linkedinUrl: (data.linkedinUrl || '').trim(),
         instagramUrl: (data.instagramUrl || '').trim(),
         facebookUrl: (data.facebookUrl || '').trim(),
+        creatorPlatforms:
+          data.expertType === 'creator' ? Array.from(new Set((data.creatorPlatforms || []).map((s) => s.trim().toLowerCase()).filter(Boolean))) : [],
+        creatorAudienceSize: data.expertType === 'creator' ? data.creatorAudienceSize ?? '' : '',
+        creatorProofSummary: data.expertType === 'creator' ? (data.creatorProofSummary || '').trim() : '',
         foundedYear: data.foundedYear ?? '',
         hourlyRateMin: data.hourlyRateMin ?? '',
         hourlyRateMax: data.hourlyRateMax ?? '',
@@ -677,9 +693,62 @@ export default function ProfileEditorPage() {
             </div>
 
             <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Expert type</label>
+              <select className={fieldClass} value={data.expertType ?? ''} onChange={(e) => setField('expertType', (e.target.value || null) as Provider['expertType'])}>
+                <option value="">Select the best fit</option>
+                {EXPERT_TYPE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
               <label className="mb-1 block text-sm font-medium text-slate-700">Overview</label>
               <textarea className={`${fieldClass} min-h-[144px]`} value={data.overview ?? ''} onChange={(e) => setField('overview', e.target.value)} placeholder="Describe your agency, focus areas, and approach." />
             </div>
+
+            {data.expertType === 'creator' ? (
+              <div className="grid gap-4 rounded-3xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+                <div>
+                  <div className="text-sm font-semibold text-slate-900">Creator proof</div>
+                  <p className="mt-1 text-xs text-slate-500">Show the channels, audience size, and context that make your creator profile credible.</p>
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Platforms (comma separated)</label>
+                  <input
+                    className={fieldClass}
+                    value={(data.creatorPlatforms || []).join(', ')}
+                    onChange={(e) => setField('creatorPlatforms', parseTokenInput(e.target.value))}
+                    placeholder="instagram, tiktok, youtube"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Audience size</label>
+                  <input
+                    type="number"
+                    min="0"
+                    className={fieldClass}
+                    value={data.creatorAudienceSize ?? ''}
+                    onChange={(e) => setField('creatorAudienceSize', e.target.value)}
+                    placeholder="e.g. 50000"
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-1 block text-sm font-medium text-slate-700">Proof summary</label>
+                  <textarea
+                    className={`${fieldClass} min-h-[112px]`}
+                    value={data.creatorProofSummary ?? ''}
+                    onChange={(e) => setField('creatorProofSummary', e.target.value)}
+                    placeholder="Describe your audience, niche, or proof points buyers should know."
+                  />
+                </div>
+              </div>
+            ) : null}
 
             <div>
               <label className="mb-1 block text-sm font-medium text-slate-700">Logo URL</label>


### PR DESCRIPTION
## Summary
- add `expertType` input to onboarding and profile editor
- add creator-only proof inputs for platforms, audience size, and proof summary
- wire the new fields into the existing `/experts` create and update flows without changing the rest of the editor flow

## Verification
- `node ./node_modules/eslint/bin/eslint.js src/app/dashboard/onboarding/page.tsx src/app/dashboard/profile/page.tsx`
- `npm run build` in `marketlink-frontend`
- `npx tsc -p tsconfig.json` in `marketlink-backend`

## Notes
- creator proof fields are shown only when `expertType === 'creator'`
- switching away from creator clears creator-specific fields on save