### PR TITLE
MM-23: Add homepage discovery config

### DIFF
--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -2,17 +2,7 @@
 
 import Link from 'next/link';
 import ThemeToggle, { useMarketLinkTheme } from '@/components/ThemeToggle';
-
-const CATEGORIES = [
-  { token: 'seo', title: 'Get found on Google', desc: 'Find SEO help so more people can discover your business online.' },
-  { token: 'social', title: 'Social media help', desc: 'Find experts to manage posts, content, and social growth.' },
-  { token: 'ads', title: 'Run ads', desc: 'Find people who can run Google, Facebook, Instagram, and other ads.' },
-  { token: 'web', title: 'Build a website', desc: 'Find website help for a new site, redesign, or landing page.' },
-  { token: 'branding', title: 'Branding & design', desc: 'Find help with logos, business identity, and visual design.' },
-  { token: 'email', title: 'Email marketing', desc: 'Find help with newsletters, follow-ups, and repeat customers.' },
-  { token: 'content', title: 'Writing & content', desc: 'Find help with website copy, blogs, and marketing content.' },
-  { token: 'video', title: 'Photos & video', desc: 'Find creators for product shoots, videos, and short-form content.' },
-];
+import { homepageServicePaths } from '@/lib/discovery';
 
 const BUYER_SIGNALS = [
   { label: 'Built for', value: 'Local businesses', detail: 'Start with the kind of help you need and narrow down fast.' },
@@ -112,10 +102,10 @@ export default function Home() {
           </div>
 
           <div className="mt-5 grid grid-cols-1 gap-4 sm:mt-6 sm:grid-cols-2 xl:grid-cols-4">
-            {CATEGORIES.map((c, index) => (
+            {homepageServicePaths.map((path, index) => (
               <Link
-                key={c.token}
-                href={`/experts?service=${encodeURIComponent(c.token)}`}
+                key={path.id}
+                href={path.href}
                 className={[
                   'group flex min-h-[190px] flex-col justify-between rounded-[1.75rem] p-4 transition sm:min-h-[220px] sm:p-5',
                   t.card,
@@ -130,8 +120,11 @@ export default function Home() {
                     </span>
                     <span className={`inline-block h-2.5 w-2.5 rounded-full ${t.accentDot}`} />
                   </div>
-                  <h3 className="mt-5 text-xl font-semibold tracking-tight text-slate-900">{c.title}</h3>
-                  <p className={`mt-3 text-sm leading-7 ${t.mutedText}`}>{c.desc}</p>
+                  <h3 className="mt-5 text-xl font-semibold tracking-tight text-slate-900">{path.plainLabel}</h3>
+                  <div className={`mt-2 text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>
+                    {path.technicalLabel}
+                  </div>
+                  <p className={`mt-3 text-sm leading-7 ${t.mutedText}`}>{path.shortHelp}</p>
                 </div>
 
                 <div className="mt-6 flex items-center justify-between gap-4">

--- a/marketlink-frontend/src/lib/discovery.ts
+++ b/marketlink-frontend/src/lib/discovery.ts
@@ -1,0 +1,213 @@
+export type DiscoveryServicePathId =
+  | 'show-up-on-google'
+  | 'run-local-ads'
+  | 'improve-website'
+  | 'grow-on-social'
+  | 'work-with-creators'
+  | 'create-better-content'
+  | 'build-brand'
+  | 'bring-customers-back';
+
+export type DiscoveryProblemId =
+  | 'cant-find-business'
+  | 'need-more-calls'
+  | 'website-not-helping'
+  | 'social-not-working'
+  | 'launching-something-new'
+  | 'not-sure-what-i-need';
+
+export type DiscoveryVisualTone = 'search' | 'calls' | 'website' | 'social' | 'launch' | 'guide';
+export type DiscoveryAccent = 'green' | 'blue' | 'amber' | 'rose' | 'slate' | 'teal' | 'orange' | 'indigo';
+
+export type DiscoveryServicePath = {
+  id: DiscoveryServicePathId;
+  plainLabel: string;
+  technicalLabel: string;
+  shortHelp: string;
+  serviceTokens: readonly string[];
+  href: string;
+  iconKey: DiscoveryVisualTone;
+  accent: DiscoveryAccent;
+  priority: number;
+};
+
+export type DiscoveryProblemCard = {
+  id: DiscoveryProblemId;
+  problemTitle: string;
+  customerLanguage: string;
+  outcomePromise: string;
+  suggestedPathIds: readonly DiscoveryServicePathId[];
+  ctaLabel: string;
+  visualTone: DiscoveryVisualTone;
+  priority: number;
+};
+
+function buildExpertsHref(serviceTokens: readonly string[], match: 'any' | 'all' = 'any') {
+  const params = new URLSearchParams();
+  params.set('service', serviceTokens.join(','));
+  if (serviceTokens.length > 1 || match === 'all') params.set('match', match);
+  return `/experts?${params.toString()}`;
+}
+
+export const discoveryServicePaths = [
+  {
+    id: 'show-up-on-google',
+    plainLabel: 'Show up on Google',
+    technicalLabel: 'SEO / local search',
+    shortHelp: 'Helps nearby customers find you when they search for what you sell.',
+    serviceTokens: ['seo'],
+    href: buildExpertsHref(['seo']),
+    iconKey: 'search',
+    accent: 'green',
+    priority: 1,
+  },
+  {
+    id: 'run-local-ads',
+    plainLabel: 'Run local ads',
+    technicalLabel: 'Google, Facebook, Instagram ads',
+    shortHelp: 'Helps you reach people faster with paid campaigns and clear lead goals.',
+    serviceTokens: ['ads'],
+    href: buildExpertsHref(['ads']),
+    iconKey: 'calls',
+    accent: 'blue',
+    priority: 2,
+  },
+  {
+    id: 'improve-website',
+    plainLabel: 'Improve my website',
+    technicalLabel: 'Web design / landing pages',
+    shortHelp: 'Helps turn visitors into calls, bookings, messages, or purchases.',
+    serviceTokens: ['web'],
+    href: buildExpertsHref(['web']),
+    iconKey: 'website',
+    accent: 'amber',
+    priority: 3,
+  },
+  {
+    id: 'grow-on-social',
+    plainLabel: 'Grow on social media',
+    technicalLabel: 'Social media marketing',
+    shortHelp: 'Helps your business stay visible with posts, campaigns, and social content.',
+    serviceTokens: ['social'],
+    href: buildExpertsHref(['social']),
+    iconKey: 'social',
+    accent: 'rose',
+    priority: 4,
+  },
+  {
+    id: 'work-with-creators',
+    plainLabel: 'Work with local creators',
+    technicalLabel: 'Influencer / creator marketing',
+    shortHelp: 'Helps you borrow trust from people who already have a local audience.',
+    serviceTokens: ['social', 'video'],
+    href: buildExpertsHref(['social', 'video']),
+    iconKey: 'social',
+    accent: 'teal',
+    priority: 5,
+  },
+  {
+    id: 'create-better-content',
+    plainLabel: 'Create better content',
+    technicalLabel: 'Photo, video, and marketing content',
+    shortHelp: 'Helps you explain your offer with stronger photos, videos, copy, and posts.',
+    serviceTokens: ['content', 'video'],
+    href: buildExpertsHref(['content', 'video']),
+    iconKey: 'launch',
+    accent: 'orange',
+    priority: 6,
+  },
+  {
+    id: 'build-brand',
+    plainLabel: 'Make my business look professional',
+    technicalLabel: 'Branding / design / print',
+    shortHelp: 'Helps your business feel more credible across logos, menus, flyers, and visuals.',
+    serviceTokens: ['branding', 'print'],
+    href: buildExpertsHref(['branding', 'print']),
+    iconKey: 'website',
+    accent: 'indigo',
+    priority: 7,
+  },
+  {
+    id: 'bring-customers-back',
+    plainLabel: 'Bring customers back',
+    technicalLabel: 'Email / SMS / follow-up marketing',
+    shortHelp: 'Helps past customers hear about offers, reminders, updates, and repeat visits.',
+    serviceTokens: ['email'],
+    href: buildExpertsHref(['email']),
+    iconKey: 'calls',
+    accent: 'slate',
+    priority: 8,
+  },
+] as const satisfies readonly DiscoveryServicePath[];
+
+export const discoveryProblemCards = [
+  {
+    id: 'cant-find-business',
+    problemTitle: "People can't find my business",
+    customerLanguage: 'Nearby customers search online, but your business does not show up clearly.',
+    outcomePromise: 'Get discovered by people already looking for what you sell.',
+    suggestedPathIds: ['show-up-on-google', 'improve-website', 'run-local-ads'],
+    ctaLabel: 'Find experts who can help',
+    visualTone: 'search',
+    priority: 1,
+  },
+  {
+    id: 'need-more-calls',
+    problemTitle: 'I need more calls or bookings',
+    customerLanguage: 'You need more real inquiries, not just more likes or traffic.',
+    outcomePromise: 'Turn attention into calls, bookings, and messages.',
+    suggestedPathIds: ['run-local-ads', 'improve-website', 'show-up-on-google'],
+    ctaLabel: 'Find lead generation help',
+    visualTone: 'calls',
+    priority: 2,
+  },
+  {
+    id: 'website-not-helping',
+    problemTitle: 'My website is not helping',
+    customerLanguage: 'People visit your site but do not understand, trust, or contact you.',
+    outcomePromise: 'Make your website clearer and easier to act on.',
+    suggestedPathIds: ['improve-website', 'show-up-on-google', 'create-better-content'],
+    ctaLabel: 'Find website help',
+    visualTone: 'website',
+    priority: 3,
+  },
+  {
+    id: 'social-not-working',
+    problemTitle: 'My social media is not bringing customers',
+    customerLanguage: 'You post, but it does not lead to enough awareness, visits, or sales.',
+    outcomePromise: 'Build content that supports trust, reach, and local demand.',
+    suggestedPathIds: ['grow-on-social', 'create-better-content', 'work-with-creators'],
+    ctaLabel: 'Find social media help',
+    visualTone: 'social',
+    priority: 4,
+  },
+  {
+    id: 'launching-something-new',
+    problemTitle: "I'm launching something new",
+    customerLanguage: 'You need people to notice a new business, offer, event, or location.',
+    outcomePromise: 'Create attention before and after launch day.',
+    suggestedPathIds: ['run-local-ads', 'grow-on-social', 'build-brand'],
+    ctaLabel: 'Find launch support',
+    visualTone: 'launch',
+    priority: 5,
+  },
+  {
+    id: 'not-sure-what-i-need',
+    problemTitle: "I'm not sure what I need",
+    customerLanguage: 'You know the business problem, but not the marketing service name.',
+    outcomePromise: 'Start with plain-language options and compare experts from there.',
+    suggestedPathIds: ['show-up-on-google', 'run-local-ads', 'improve-website'],
+    ctaLabel: 'Start with common paths',
+    visualTone: 'guide',
+    priority: 6,
+  },
+] as const satisfies readonly DiscoveryProblemCard[];
+
+export const homepageServicePaths = discoveryServicePaths
+  .filter((path) => path.priority <= 8)
+  .sort((a, b) => a.priority - b.priority);
+
+export const homepageProblemCards = discoveryProblemCards
+  .filter((problem) => problem.priority <= 6)
+  .sort((a, b) => a.priority - b.priority);
+

--- a/marketlink-frontend/tests/home.spec.ts
+++ b/marketlink-frontend/tests/home.spec.ts
@@ -11,47 +11,54 @@ test('homepage loads', async ({ page }) => {
 });
 
 test('shows main heading', async ({ page }) => {
-  await expect(page.getByRole('heading', { name: 'Find local marketing experts' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', {
+      name: 'Find marketers, website builders, and other local experts for your business.',
+    }),
+  ).toBeVisible();
 });
 
 test('shows supporting intro copy', async ({ page }) => {
-  await expect(page.getByText('Pick a category to browse verified providers in your area.')).toBeVisible();
+  await expect(page.getByText('Browse by service, narrow by city, and compare real local experts in one place.')).toBeVisible();
 });
 
-test('browse all providers link is visible', async ({ page }) => {
-  const link = page.getByRole('link', { name: 'Browse all providers' });
+test('browse local experts link is visible', async ({ page }) => {
+  const link = page.getByRole('link', { name: 'Browse local experts' });
   await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', '/providers');
+  await expect(link).toHaveAttribute('href', '/experts');
 });
 
-test('use filters link is visible', async ({ page }) => {
-  const link = page.getByRole('link', { name: 'Use filters' });
+test('search by service link is visible', async ({ page }) => {
+  const link = page.getByRole('link', { name: 'Search by service' });
   await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', '/providers');
+  await expect(link).toHaveAttribute('href', '/experts');
 });
 
-test('renders 8 category headings', async ({ page }) => {
-  await expect(page.getByRole('heading', { level: 2 })).toHaveCount(8);
+test('renders 8 service path cards', async ({ page }) => {
+  await expect(page.getByRole('heading', { level: 3 })).toHaveCount(8);
 });
 
-test('shows SEO category card', async ({ page }) => {
-  await expect(page.getByRole('heading', { level: 2, name: 'SEO' })).toBeVisible();
+test('shows Google discovery service path', async ({ page }) => {
+  await expect(page.getByRole('heading', { level: 3, name: 'Show up on Google' })).toBeVisible();
+  await expect(page.getByText('SEO / local search')).toBeVisible();
 });
 
-test('shows Social Media category card', async ({ page }) => {
-  await expect(page.getByRole('heading', { level: 2, name: 'Social Media' })).toBeVisible();
+test('shows social media service path', async ({ page }) => {
+  await expect(page.getByRole('heading', { level: 3, name: 'Grow on social media' })).toBeVisible();
+  await expect(page.getByText('Social media marketing')).toBeVisible();
 });
 
-test('shows View providers callouts', async ({ page }) => {
-  await expect(page.getByText('View providers')).toHaveCount(8);
+test('service path cards link to expert filters', async ({ page }) => {
+  const link = page.getByRole('link', { name: /Run local ads/i });
+  await expect(link).toHaveAttribute('href', '/experts?service=ads');
 });
 
-test('footer message is visible', async ({ page }) => {
-  await expect(page.getByText('Want more control? Use filters on the providers page.')).toBeVisible();
+test('shows See experts callouts', async ({ page }) => {
+  await expect(page.getByText('See experts')).toHaveCount(8);
 });
 
-test('footer filters link is visible', async ({ page }) => {
-  const link = page.getByRole('link', { name: 'Go to filters' });
+test('footer directory link is visible', async ({ page }) => {
+  const link = page.getByRole('link', { name: 'Open directory' });
   await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', '/providers');
+  await expect(link).toHaveAttribute('href', '/experts');
 });


### PR DESCRIPTION
## Summary
- Add a shared frontend discovery config for homepage service paths and customer problem cards.
- Wire the homepage service cards to the config instead of hardcoded categories.
- Update homepage Playwright coverage for `/experts` links and plain-language service labels.

## Verification
- `npx eslint src/app/page.tsx src/lib/discovery.ts tests/home.spec.ts`
- `npm run build`
- `npx playwright test tests/home.spec.ts`

## Notes
- This is the technical/content-structure foundation for MM-24 and MM-25.
- Full visual homepage redesign is intentionally not part of MM-23.