### PR TITLE
MM-92 compact expert discovery filters

### DIFF
--- a/marketlink-frontend/src/app/experts/page.tsx
+++ b/marketlink-frontend/src/app/experts/page.tsx
@@ -219,7 +219,6 @@ function ProviderCard({ provider }: { provider: Provider }) {
       ? `${p.currencyCode || 'USD'} ${p.hourlyRateMin ?? ''}${p.hourlyRateMax ? `-${p.hourlyRateMax}` : '+'}/hr`
       : 'Request quote';
   const profileSummary = p.shortDescription ? p.shortDescription : p.tagline ? p.tagline : 'Explore services, fit, pricing guidance, and contact details.';
-  const sinceLabel = new Date(p.createdAt).toLocaleDateString();
   const creatorPlatformsLabel = p.creatorPlatforms?.length ? p.creatorPlatforms.join(' • ') : null;
   const creatorAudienceLabel = formatAudienceSize(p.creatorAudienceSize);
   const creatorProofBody =
@@ -228,12 +227,11 @@ function ProviderCard({ provider }: { provider: Provider }) {
     null;
 
   return (
-    <li className="ml-card ml-card-hover overflow-hidden rounded-[1.9rem] transition hover:-translate-y-0.5">
+    <li data-testid="expert-result-card" className="ml-card ml-card-hover rounded-[1.55rem] transition hover:-translate-y-0.5">
       <Link href={`/experts/${p.slug}`} className="group block">
-        <div className="h-1.5 bg-[linear-gradient(90deg,#0f172a,#25324a,#b6bdc8)]" />
         <div className="p-4 sm:p-5">
-          <div className="flex items-start gap-3 sm:gap-4">
-            <div className="ml-surface-muted h-14 w-14 shrink-0 overflow-hidden rounded-2xl shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+            <div className="ml-surface-muted h-14 w-14 shrink-0 overflow-hidden rounded-2xl shadow-sm sm:h-16 sm:w-16">
               {p.logo ? (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img src={p.logo} alt={p.businessName} className="h-full w-full object-cover" />
@@ -242,54 +240,56 @@ function ProviderCard({ provider }: { provider: Provider }) {
               )}
             </div>
 
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className={`${PILL_CLASS} px-2.5 text-[10px]`}>
-                      {p.city}, {p.state}
-                    </span>
-                    {p.verified ? (
-                      <span className={`${PILL_MUTED_CLASS} inline-flex items-center px-2.5 py-1 text-[10px]`}>
-                        Verified
+            <div className="min-w-0 flex-1 sm:grid sm:grid-cols-[minmax(0,1fr)_190px] sm:gap-5">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">
+                  <span>{expertTypeLabel}</span>
+                  <span aria-hidden="true">/</span>
+                  <span>
+                    {p.city}, {p.state}
+                  </span>
+                  {p.verified ? (
+                    <>
+                      <span aria-hidden="true">/</span>
+                      <span className="text-slate-700">Verified</span>
+                    </>
+                  ) : null}
+                </div>
+
+                <h3 className="mt-2 truncate text-[1.2rem] font-semibold tracking-tight text-slate-900 sm:text-[1.35rem]">{p.businessName}</h3>
+                <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-600">{profileSummary}</p>
+
+                {topServices.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2" title={p.services.join(', ')}>
+                    {topServices.map((service) => (
+                      <span key={service} className={`${PILL_CLASS} px-3 text-[10px]`}>
+                        {service}
+                      </span>
+                    ))}
+                    {overflow > 0 ? (
+                      <span className={`${PILL_MUTED_CLASS} px-3 text-[10px]`}>
+                        +{overflow} more
                       </span>
                     ) : null}
                   </div>
+                ) : null}
+              </div>
 
-                  <div className="mt-2 text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">{expertTypeLabel}</div>
-                  <h3 className="mt-1 truncate text-[1.2rem] font-semibold tracking-tight text-slate-900 sm:text-[1.35rem]">{p.businessName}</h3>
-                  <p className="mt-2 text-sm leading-6 text-slate-600 sm:max-w-2xl">{profileSummary}</p>
+              <div className="mt-4 flex items-center justify-between gap-4 border-t border-slate-200/75 pt-4 sm:mt-0 sm:flex-col sm:items-end sm:justify-between sm:border-t-0 sm:pt-0">
+                <div className="text-right">
+                  <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">Rating</div>
+                  <div className="mt-1 text-lg font-semibold text-slate-900">{p.rating?.toFixed?.(1) ?? '0.0'}</div>
+                  <div className="mt-2 text-sm font-semibold text-slate-900">{pricingLabel}</div>
                 </div>
 
-                <div className="grid shrink-0 grid-cols-2 gap-2 sm:min-w-[220px]">
-                  <div className="ml-surface-muted rounded-[1.15rem] px-3 py-2.5 text-right shadow-sm">
-                    <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-500">Rating</div>
-                    <div className="mt-1 text-base font-semibold text-slate-900 sm:text-lg">{p.rating?.toFixed?.(1) ?? '0.0'}</div>
-                  </div>
-                  <div className="ml-surface-muted rounded-[1.15rem] px-3 py-2.5 text-right shadow-sm">
-                    <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-500">Pricing</div>
-                    <div className="mt-1 text-sm font-semibold text-slate-900">{pricingLabel}</div>
-                  </div>
+                <div className="ml-btn-primary inline-flex min-h-10 items-center gap-2 rounded-xl px-4 text-sm font-semibold text-white">
+                  Open profile
+                  <span className="text-base transition group-hover:translate-x-1" aria-hidden="true">&rarr;</span>
                 </div>
               </div>
 
-              {topServices.length > 0 ? (
-                <div className="mt-4 flex flex-wrap gap-2" title={p.services.join(', ')}>
-                  {topServices.map((service) => (
-                    <span key={service} className={`${PILL_CLASS} px-3 text-[10px]`}>
-                      {service}
-                    </span>
-                  ))}
-                  {overflow > 0 ? (
-                    <span className={`${PILL_MUTED_CLASS} px-3 text-[10px]`}>
-                      +{overflow} more
-                    </span>
-                  ) : null}
-                </div>
-              ) : null}
-
               {p.expertType === 'creator' && creatorProofBody ? (
-                <div className="mt-4 rounded-[1.05rem] bg-slate-50 px-3 py-3 shadow-sm ring-1 ring-slate-200/80">
+                <div className="mt-4 rounded-[1.05rem] bg-slate-50 px-3 py-3 ring-1 ring-slate-200/80 sm:col-span-2">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className={`${PILL_CLASS} px-2.5 text-[10px]`}>Creator proof</span>
                     {creatorPlatformsLabel ? (
@@ -301,32 +301,6 @@ function ProviderCard({ provider }: { provider: Provider }) {
                   <p className="mt-2 text-sm leading-6 text-slate-700">{creatorProofBody}</p>
                 </div>
               ) : null}
-
-              <div className="mt-4 hidden gap-3 border-t border-slate-200/80 pt-4 sm:grid sm:grid-cols-[1.05fr_0.95fr_auto] sm:items-center">
-                <div className="ml-surface-muted rounded-[1.05rem] px-3 py-3">
-                  <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-500">Profile status</div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">{p.verified ? 'Verified expert' : 'Live expert profile'}</div>
-                </div>
-                <div className="ml-surface-muted rounded-[1.05rem] px-3 py-3">
-                  <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-500">Updated</div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">{sinceLabel}</div>
-                </div>
-                <div className="ml-dark-panel flex items-center justify-between gap-3 rounded-[1.05rem] px-4 py-3 sm:justify-center">
-                  <span className="text-sm font-semibold">Open profile</span>
-                  <span className="text-base transition group-hover:translate-x-1" aria-hidden="true">&rarr;</span>
-                </div>
-              </div>
-
-              <div className="mt-4 flex items-center justify-between gap-4 border-t border-slate-200/80 pt-4 sm:hidden">
-                <div className="min-w-0">
-                  <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-slate-500">Updated</div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">{sinceLabel}</div>
-                </div>
-                <div className="ml-btn-primary flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-semibold text-white">
-                  Open profile
-                  <span className="text-base transition group-hover:translate-x-1" aria-hidden="true">&rarr;</span>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -527,55 +501,59 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
 
         {problemContext ? <ProblemContextPanel problem={problemContext} /> : null}
 
-        <section className={`mt-6 ${SECTION_CLASS}`}>
-          <details className="group md:hidden">
-            <summary className="ml-surface flex cursor-pointer list-none items-center justify-between gap-4 rounded-[1.4rem] px-4 py-4 shadow-sm">
-              <div className="min-w-0">
+        <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
+          <section className={`${SECTION_CLASS} lg:hidden`}>
+            <details className="group">
+              <summary className="ml-surface flex cursor-pointer list-none items-center justify-between gap-4 rounded-[1.4rem] px-4 py-4 shadow-sm">
+                <div className="min-w-0">
+                  <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">Filters</div>
+                  <h2 className="mt-1 text-xl font-semibold tracking-tight text-slate-900">Refine results</h2>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {activeFilters.length > 0 ? `${activeFilters.length} active filter${activeFilters.length > 1 ? 's' : ''}` : 'Open filters to narrow the list'}
+                  </p>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <span className="ml-btn-secondary rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal group-open:hidden">Open</span>
+                  <span className="ml-btn-secondary hidden rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal group-open:inline-flex">Close</span>
+                </div>
+              </summary>
+              <div className="ml-surface mt-4 rounded-[1.4rem] p-4 shadow-sm">
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <div className="text-sm font-medium text-slate-700">Set filters and update the results when ready.</div>
+                  <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
+                    Clear filters
+                  </Link>
+                </div>
+                <FiltersForm name={name} city={city} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
+              </div>
+            </details>
+          </section>
+
+          <aside data-testid="desktop-filter-rail" className={`${SECTION_CLASS} hidden lg:sticky lg:top-24 lg:block`}>
+            <div className="flex items-start justify-between gap-4">
+              <div>
                 <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">Filters</div>
-                <h2 className="mt-1 text-xl font-semibold tracking-tight text-slate-900">Refine results</h2>
-                <p className="mt-1 text-sm text-slate-600">
-                  {activeFilters.length > 0 ? `${activeFilters.length} active filter${activeFilters.length > 1 ? 's' : ''}` : 'Open filters to narrow the list'}
-                </p>
+                <h2 className="mt-2 text-xl font-semibold tracking-tight text-slate-900">Refine results</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-600">Adjust the list while keeping experts in view.</p>
               </div>
-              <div className="flex flex-col items-end gap-2">
-                <span className="ml-btn-secondary rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal group-open:hidden">Open</span>
-                <span className="ml-btn-secondary hidden rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal group-open:inline-flex">Close</span>
-              </div>
-            </summary>
-            <div className="ml-surface mt-4 rounded-[1.4rem] p-4 shadow-sm">
-              <div className="mb-4 flex items-center justify-between gap-3">
-                <div className="text-sm font-medium text-slate-700">Set filters and update the results when ready.</div>
-                <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
-                  Clear filters
-                </Link>
-              </div>
+              <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
+                Clear
+              </Link>
+            </div>
+
+            <div className="mt-5">
               <FiltersForm name={name} city={city} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
             </div>
-          </details>
+          </aside>
 
-          <div className="hidden flex-col gap-3 md:flex md:flex-row md:items-end md:justify-between">
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">Filters</div>
-              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900">Refine results</h2>
-            </div>
-            <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
-              Clear filters
-            </Link>
-          </div>
-
-          <div className="mt-5 hidden md:block">
-            <FiltersForm name={name} city={city} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} />
-          </div>
-        </section>
-
-        <section className={`mt-6 ${SECTION_CLASS}`}>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-2xl font-semibold tracking-tight text-slate-900">Expert results</h2>
-              <p className="mt-1 text-sm text-slate-600">
-                Showing {(meta.page - 1) * meta.limit + 1}-{Math.min(meta.page * meta.limit, meta.total)} of {meta.total}
-              </p>
-            </div>
+          <section className={`${SECTION_CLASS} lg:order-first`}>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">Expert results</h2>
+                <p className="mt-1 text-sm text-slate-600">
+                  Showing {(meta.page - 1) * meta.limit + 1}-{Math.min(meta.page * meta.limit, meta.total)} of {meta.total}
+                </p>
+              </div>
 
             {activeFilters.length > 0 ? (
               <div className="flex flex-wrap gap-2">
@@ -593,7 +571,7 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
               No experts found. Try adjusting your filters.
             </div>
           ) : (
-            <ul className="mt-5 grid grid-cols-1 gap-4 xl:grid-cols-2">
+            <ul data-testid="expert-results-list" className="mt-5 grid grid-cols-1 gap-4">
               {data.map((p) => (
                 <ProviderCard key={p.id} provider={p} />
               ))}
@@ -644,7 +622,8 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
               </Link>
             </div>
           </div>
-        </section>
+          </section>
+        </div>
       </div>
     </main>
   );

--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -9,12 +9,6 @@ import {
   homepageServicePaths,
 } from '@/lib/discovery';
 
-const BUYER_SIGNALS = [
-  { label: 'Built for', value: 'Local businesses' },
-  { label: 'Best for', value: 'Quick shortlists' },
-  { label: 'How it works', value: 'Browse, compare, contact' },
-];
-
 const MOBILE_PROBLEM_CARD_IDS = new Set([
   'cant-find-business',
   'need-more-calls',
@@ -34,6 +28,12 @@ const DESKTOP_HERO_PROBLEM_CARD_IDS = new Set([
   'need-more-calls',
   'website-not-helping',
 ]);
+
+const HERO_PRODUCT_STEPS = [
+  { icon: '🔎', label: 'Look up experts' },
+  { icon: '⚖', label: 'Compare the best fit' },
+  { icon: '💯', label: 'Get results' },
+];
 
 export default function Home() {
   const { t } = useMarketLinkTheme();
@@ -70,7 +70,7 @@ export default function Home() {
 
           <div id="mobile-problems" className="mt-7">
             <div className={`text-[11px] font-medium uppercase tracking-[0.22em] ${t.mutedText}`}>Start with the problem</div>
-            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">What do you need help fixing first?</h2>
+            <h2 className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-slate-950">Choose a starting point</h2>
 
             <div className="mt-4 space-y-3">
               {mobileProblemCards.map((problem, index) => {
@@ -109,7 +109,7 @@ export default function Home() {
         </section>
 
         <section className={`hidden overflow-hidden rounded-[2rem] ${t.card} px-5 py-5 sm:px-8 sm:py-8 lg:block lg:px-10 lg:py-10`}>
-          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.72fr)] lg:items-center">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.72fr)] lg:items-start">
             <div className="flex flex-col gap-6">
               <div className="space-y-4">
                 <div className={`inline-flex items-center rounded-xl px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] shadow-sm ${t.brandBadge}`}>
@@ -117,41 +117,102 @@ export default function Home() {
                 </div>
                 <div className="max-w-3xl">
                   <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-slate-900 sm:text-5xl">
-                    Find marketers, website builders, and other local experts for your business.
+                    Find local marketing experts near you.
                   </h1>
-                  <p className={`mt-4 max-w-2xl text-sm leading-7 sm:text-base sm:leading-8 ${t.mutedText}`}>
-                    Browse by service, narrow by city, and compare real local experts in one place. When someone looks like a fit, open their profile and contact them directly.
+                  <p className={`mt-4 max-w-xl text-sm leading-7 sm:text-base sm:leading-8 ${t.mutedText}`}>
+                    Find and compare local experts for the marketing help your business needs.
                   </p>
                 </div>
               </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <div>
                 <Link
                   href="/experts"
                   className={`inline-flex min-h-12 items-center justify-center rounded-xl px-6 text-sm font-semibold shadow-sm ${t.primaryBtn}`}
                 >
                   Browse local experts
                 </Link>
-                <Link
-                  href="#browse-by-need"
-                  className={`inline-flex min-h-12 items-center justify-center rounded-xl px-6 text-sm font-medium ${t.secondaryBtn}`}
-                >
-                  Search by service
-                </Link>
               </div>
 
-              <div
-                data-testid="desktop-buyer-signal-row"
-                className={`flex flex-wrap items-center gap-x-4 gap-y-2 text-sm ${t.mutedText}`}
-              >
-                {BUYER_SIGNALS.map((item) => (
-                  <div key={item.label} data-testid="desktop-buyer-signal" className="flex items-center gap-2">
-                    <span className={`h-1.5 w-1.5 rounded-full ${t.accentDot}`} aria-hidden="true" />
-                    <span className="font-semibold text-slate-900">{item.value}</span>
-                  </div>
-                ))}
+              <div data-testid="desktop-product-checklist" className="mt-1 max-w-sm">
+                {HERO_PRODUCT_STEPS.map((step, index) => {
+                  const isFinal = index === HERO_PRODUCT_STEPS.length - 1;
+                  const displayLabel = ['Find local experts', 'Compare best fits', 'Get real results'][index];
+
+                  return (
+                    <div
+                      key={displayLabel}
+                      data-testid="desktop-product-checklist-item"
+                      className="hero-step relative grid grid-cols-[minmax(0,15rem)_3.5rem] items-center gap-6 pb-4 opacity-0 last:pb-0 motion-reduce:opacity-100"
+                      style={{ animationDelay: `${index * 140}ms` }}
+                    >
+                      {index < HERO_PRODUCT_STEPS.length - 1 ? (
+                        <span className="hero-step-line absolute right-7 top-12 h-[calc(100%-2rem)] w-px origin-top scale-y-0 bg-slate-200 motion-reduce:scale-y-100" aria-hidden="true" />
+                      ) : null}
+                      <span className={`text-[1.35rem] font-semibold leading-tight tracking-[-0.015em] ${isFinal ? 'text-slate-950' : 'text-slate-800'}`}>
+                        {displayLabel}
+                      </span>
+                      <span
+                        data-testid="desktop-product-checklist-icon"
+                        className={[
+                          'relative z-10 grid h-12 w-12 shrink-0 place-items-center leading-none',
+                          isFinal
+                            ? 'bg-transparent text-[0.95rem] font-black text-rose-600'
+                            : 'rounded-full bg-white text-[1.45rem] text-slate-700 shadow-sm ring-1 ring-slate-200',
+                        ].join(' ')}
+                        aria-hidden="true"
+                      >
+                        {isFinal ? (
+                          <span className="relative inline-block after:absolute after:inset-x-0 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-rose-500">
+                            100
+                          </span>
+                        ) : (
+                          step.icon
+                        )}
+                      </span>
+                    </div>
+                  );
+                })}
               </div>
             </div>
+
+            <style>{`
+              @keyframes hero-step-in {
+                from {
+                  opacity: 0;
+                  transform: translateX(-18px);
+                }
+                to {
+                  opacity: 1;
+                  transform: translateX(0);
+                }
+              }
+
+              .hero-step {
+                animation: hero-step-in 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+              }
+
+              .hero-step-line {
+                animation: hero-step-line 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+                animation-delay: inherit;
+              }
+
+              @keyframes hero-step-line {
+                from {
+                  transform: scaleY(0);
+                }
+                to {
+                  transform: scaleY(1);
+                }
+              }
+
+              @media (prefers-reduced-motion: reduce) {
+                .hero-step,
+                .hero-step-line {
+                  animation: none;
+                }
+              }
+            `}</style>
 
             <aside
               data-testid="desktop-problem-panel"
@@ -188,54 +249,6 @@ export default function Home() {
                 Already know the service? Use search by service or browse the full expert directory.
               </div>
             </aside>
-          </div>
-        </section>
-
-        <section id="desktop-problems" data-testid="desktop-problem-section" className="mt-6 hidden lg:block">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <div className={`text-[11px] font-medium uppercase tracking-[0.24em] ${t.mutedText}`}>Start with the problem</div>
-              <h2 className="mt-2 text-3xl font-semibold tracking-[-0.03em] text-slate-900">What do you need help fixing first?</h2>
-            </div>
-            <p className={`max-w-xl text-sm leading-7 ${t.mutedText}`}>
-              These are plain-language starting points for owners who know what feels broken, but not which marketing service to search for.
-            </p>
-          </div>
-
-          <div className="mt-5 grid gap-4 xl:grid-cols-4">
-            {desktopProblemCards.map((problem) => {
-              const suggestedPaths = getDiscoveryServicePathsForProblem(problem);
-
-              return (
-                <Link
-                  key={problem.id}
-                  href={getDiscoveryProblemHref(problem)}
-                  data-testid="desktop-problem-card"
-                  className={`group flex min-h-[230px] flex-col justify-between rounded-[1.75rem] ${t.card} p-5 transition ${t.cardHover}`}
-                >
-                  <div>
-                    <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Problem</div>
-                    <div className="mt-3 flex items-start justify-between gap-4">
-                      <div>
-                        <h3 className="text-lg font-semibold tracking-[-0.02em] text-slate-950">{problem.problemTitle}</h3>
-                        <p className={`mt-2 text-sm leading-6 ${t.mutedText}`}>{problem.customerLanguage}</p>
-                      </div>
-                      <span className="mt-1 text-lg text-slate-400 transition group-hover:translate-x-1 group-hover:text-slate-700" aria-hidden="true">
-                        &rarr;
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className="mt-5 flex flex-wrap gap-2">
-                    {suggestedPaths.slice(0, 3).map((path) => (
-                      <span key={path.id} className="rounded-full bg-slate-50 px-3 py-1 text-[11px] font-semibold text-slate-700 ring-1 ring-slate-200">
-                        {path.plainLabel}
-                      </span>
-                    ))}
-                  </div>
-                </Link>
-              );
-            })}
           </div>
         </section>
 

--- a/marketlink-frontend/tests/experts.spec.ts
+++ b/marketlink-frontend/tests/experts.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+
+test('problem-context desktop results keep filters in a side rail', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`${BASE_URL}/experts?service=seo%2Cweb%2Cads&match=any&problem=cant-find-business`);
+
+  await expect(page.getByTestId('problem-context-panel')).toBeVisible();
+  const filterRail = page.getByTestId('desktop-filter-rail');
+  await expect(filterRail).toBeVisible();
+  await expect(filterRail.getByLabel('City')).toBeVisible();
+  await expect(filterRail.getByRole('textbox', { name: 'Service' })).toBeVisible();
+  await expect(filterRail.getByLabel('Service match')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Expert results' })).toBeVisible();
+
+  const resultsList = page.getByTestId('expert-results-list');
+  await expect(resultsList).toBeVisible();
+  await expect(page.getByTestId('expert-result-card').first()).toBeVisible();
+  const columnCount = await resultsList.evaluate((node) => getComputedStyle(node).gridTemplateColumns.split(' ').length);
+  expect(columnCount).toBe(1);
+});

--- a/marketlink-frontend/tests/home.spec.ts
+++ b/marketlink-frontend/tests/home.spec.ts
@@ -13,25 +13,19 @@ test('homepage loads', async ({ page }) => {
 test('shows main heading', async ({ page }) => {
   await expect(
     page.getByRole('heading', {
-      name: 'Find marketers, website builders, and other local experts for your business.',
+      name: 'Find local marketing experts near you.',
     }),
   ).toBeVisible();
 });
 
 test('shows supporting intro copy', async ({ page }) => {
-  await expect(page.getByText('Browse by service, narrow by city, and compare real local experts in one place.')).toBeVisible();
+  await expect(page.getByText('Find and compare local experts for the marketing help your business needs.')).toBeVisible();
 });
 
 test('browse local experts link is visible', async ({ page }) => {
   const link = page.getByRole('link', { name: 'Browse local experts' });
   await expect(link).toBeVisible();
   await expect(link).toHaveAttribute('href', '/experts');
-});
-
-test('search by service link is visible', async ({ page }) => {
-  const link = page.getByRole('link', { name: 'Search by service' });
-  await expect(link).toBeVisible();
-  await expect(link).toHaveAttribute('href', '#browse-by-need');
 });
 
 test('desktop hero shows problem-first discovery choices', async ({ page }) => {
@@ -47,29 +41,39 @@ test('desktop hero shows problem-first discovery choices', async ({ page }) => {
   await expect(panel.getByText('My website is not helping')).toBeVisible();
 });
 
-test('desktop hero keeps buyer signals lightweight', async ({ page }) => {
+test('desktop hero keeps the left side focused on one action', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(BASE_URL);
 
-  const signalRow = page.getByTestId('desktop-buyer-signal-row');
-  await expect(signalRow).toBeVisible();
-  await expect(signalRow.getByTestId('desktop-buyer-signal')).toHaveCount(3);
-  await expect(signalRow.getByText('Local businesses')).toBeVisible();
-  await expect(signalRow.getByText('Quick shortlists')).toBeVisible();
-  await expect(signalRow.getByText('Browse, compare, contact')).toBeVisible();
+  await expect(page.getByTestId('desktop-buyer-flow')).not.toBeVisible();
+  await expect(page.getByRole('link', { name: 'Search by service' })).not.toBeVisible();
+  await expect(page.getByRole('link', { name: 'Browse local experts' })).toBeVisible();
 });
 
-test('desktop problem section shows fuller problem cards and suggested paths', async ({ page }) => {
+test('desktop hero explains the product with a vertical checklist', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(BASE_URL);
 
-  const section = page.getByTestId('desktop-problem-section');
-  await expect(section).toBeVisible();
-  await expect(section.getByTestId('desktop-problem-card')).toHaveCount(4);
-  await expect(section.getByText('Show up on Google').first()).toBeVisible();
-  await expect(section.getByText('Run local ads').first()).toBeVisible();
-  await expect(section.getByText('Improve my website').first()).toBeVisible();
-  await expect(section.getByText('Create better content').first()).toBeVisible();
+  const checklist = page.getByTestId('desktop-product-checklist');
+  await expect(checklist).toBeVisible();
+  await expect(checklist.getByTestId('desktop-product-checklist-item')).toHaveCount(3);
+  await expect(checklist.getByText('Find local experts')).toBeVisible();
+  await expect(checklist.getByText('Compare best fits')).toBeVisible();
+  await expect(checklist.getByText('Get real results')).toBeVisible();
+  await expect(checklist.getByTestId('desktop-product-checklist-icon')).toHaveCount(3);
+  const resultIcon = checklist.getByTestId('desktop-product-checklist-item').filter({ hasText: 'Get real results' }).getByTestId('desktop-product-checklist-icon');
+  await expect(resultIcon).toContainText('100');
+  await expect(resultIcon).not.toHaveClass(/.*bg-slate-950.*/);
+});
+
+test('desktop keeps problem choices inside the hero starting point panel', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(BASE_URL);
+
+  await expect(page.getByTestId('desktop-problem-section')).not.toBeVisible();
+  await expect(page.getByText('What do you need help fixing first?')).not.toBeVisible();
+  const panel = page.getByTestId('desktop-problem-panel');
+  await expect(panel.getByTestId('desktop-problem-link')).toHaveCount(3);
 });
 
 test('renders 8 service path cards', async ({ page }) => {
@@ -108,7 +112,7 @@ test.describe('mobile problem-first discovery', () => {
   });
 
   test('shows compact problem cards before the full service grid', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'What do you need help fixing first?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Choose a starting point' })).toBeVisible();
     await expect(page.getByTestId('mobile-problem-card')).toHaveCount(4);
     const mobileCards = page.getByTestId('mobile-problem-card');
     await expect(mobileCards.filter({ hasText: "People can't find my business" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Moves desktop expert filters into a right-side rail and keeps results in a single-column card list.
- Simplifies the homepage hero, removes duplicate problem sections, and adds the animated three-step discovery cue.
- Updates homepage coverage and adds a desktop experts layout Playwright test.

## Test Plan
- npx eslint src/app/page.tsx src/app/experts/page.tsx tests/home.spec.ts tests/experts.spec.ts
- npx playwright test tests/home.spec.ts tests/experts.spec.ts
- npm run build