### PR TITLE
MM-93 Add homepage product visual

### DIFF
--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { HomepageDiscoveryAnimation } from '@/components/HomepageDiscoveryAnimation';
 import { useMarketLinkTheme } from '@/components/ThemeToggle';
 import {
   getDiscoveryProblemHref,
@@ -28,12 +29,6 @@ const DESKTOP_HERO_PROBLEM_CARD_IDS = new Set([
   'need-more-calls',
   'website-not-helping',
 ]);
-
-const HERO_PRODUCT_STEPS = [
-  { icon: '🔎', label: 'Look up experts' },
-  { icon: '⚖', label: 'Compare the best fit' },
-  { icon: '💯', label: 'Get results' },
-];
 
 export default function Home() {
   const { t } = useMarketLinkTheme();
@@ -67,6 +62,8 @@ export default function Home() {
               Help me choose
             </Link>
           </div>
+
+          <HomepageDiscoveryAnimation compact />
 
           <div id="mobile-problems" className="mt-7">
             <div className={`text-[11px] font-medium uppercase tracking-[0.22em] ${t.mutedText}`}>Start with the problem</div>
@@ -134,85 +131,8 @@ export default function Home() {
                 </Link>
               </div>
 
-              <div data-testid="desktop-product-checklist" className="mt-1 max-w-sm">
-                {HERO_PRODUCT_STEPS.map((step, index) => {
-                  const isFinal = index === HERO_PRODUCT_STEPS.length - 1;
-                  const displayLabel = ['Find local experts', 'Compare best fits', 'Get real results'][index];
-
-                  return (
-                    <div
-                      key={displayLabel}
-                      data-testid="desktop-product-checklist-item"
-                      className="hero-step relative grid grid-cols-[minmax(0,15rem)_3.5rem] items-center gap-6 pb-4 opacity-0 last:pb-0 motion-reduce:opacity-100"
-                      style={{ animationDelay: `${index * 140}ms` }}
-                    >
-                      {index < HERO_PRODUCT_STEPS.length - 1 ? (
-                        <span className="hero-step-line absolute right-7 top-12 h-[calc(100%-2rem)] w-px origin-top scale-y-0 bg-slate-200 motion-reduce:scale-y-100" aria-hidden="true" />
-                      ) : null}
-                      <span className={`text-[1.35rem] font-semibold leading-tight tracking-[-0.015em] ${isFinal ? 'text-slate-950' : 'text-slate-800'}`}>
-                        {displayLabel}
-                      </span>
-                      <span
-                        data-testid="desktop-product-checklist-icon"
-                        className={[
-                          'relative z-10 grid h-12 w-12 shrink-0 place-items-center leading-none',
-                          isFinal
-                            ? 'bg-transparent text-[0.95rem] font-black text-rose-600'
-                            : 'rounded-full bg-white text-[1.45rem] text-slate-700 shadow-sm ring-1 ring-slate-200',
-                        ].join(' ')}
-                        aria-hidden="true"
-                      >
-                        {isFinal ? (
-                          <span className="relative inline-block after:absolute after:inset-x-0 after:-bottom-1 after:h-0.5 after:rounded-full after:bg-rose-500">
-                            100
-                          </span>
-                        ) : (
-                          step.icon
-                        )}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
+              <HomepageDiscoveryAnimation />
             </div>
-
-            <style>{`
-              @keyframes hero-step-in {
-                from {
-                  opacity: 0;
-                  transform: translateX(-18px);
-                }
-                to {
-                  opacity: 1;
-                  transform: translateX(0);
-                }
-              }
-
-              .hero-step {
-                animation: hero-step-in 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
-              }
-
-              .hero-step-line {
-                animation: hero-step-line 520ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
-                animation-delay: inherit;
-              }
-
-              @keyframes hero-step-line {
-                from {
-                  transform: scaleY(0);
-                }
-                to {
-                  transform: scaleY(1);
-                }
-              }
-
-              @media (prefers-reduced-motion: reduce) {
-                .hero-step,
-                .hero-step-line {
-                  animation: none;
-                }
-              }
-            `}</style>
 
             <aside
               data-testid="desktop-problem-panel"

--- a/marketlink-frontend/src/components/HomepageDiscoveryAnimation.tsx
+++ b/marketlink-frontend/src/components/HomepageDiscoveryAnimation.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+type HomepageDiscoveryAnimationProps = {
+  compact?: boolean;
+};
+
+export function HomepageDiscoveryAnimation({ compact = false }: HomepageDiscoveryAnimationProps) {
+  return (
+    <div
+      data-testid={compact ? 'mobile-homepage-discovery-animation' : 'desktop-homepage-discovery-animation'}
+      className={[
+        'overflow-hidden rounded-[1.75rem] bg-white/82 shadow-[0_18px_55px_rgba(15,23,42,0.08)] ring-1 ring-slate-200/80',
+        compact ? 'mt-6 p-4' : 'mt-1 max-w-2xl p-5',
+      ].join(' ')}
+      aria-label="Find local experts, compare best fits, and get real results"
+    >
+      <div
+        className={[
+          'motion-stage relative overflow-hidden rounded-[1.35rem] bg-slate-50 ring-1 ring-slate-200/75',
+          compact ? 'min-h-[190px]' : 'min-h-[250px]',
+        ].join(' ')}
+      >
+        <div className="absolute left-4 top-4 z-20 rounded-full bg-white/88 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-500 shadow-sm ring-1 ring-slate-200/70">
+          MarketLink flow
+        </div>
+
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_52%,rgba(219,242,255,0.92),rgba(248,250,252,0.68)_48%,rgba(248,250,252,0)_70%)]" />
+        <div className="absolute left-[23%] top-[42%] h-[34%] w-[54%] rounded-full border-b-2 border-r-2 border-sky-200/90" />
+
+        <div
+          data-testid={compact ? 'mobile-homepage-discovery-visual-label' : 'desktop-homepage-discovery-visual-label'}
+          className="stage-card stage-find absolute left-[7%] top-[24%] z-10 w-[45%] rounded-2xl bg-white px-4 py-3 shadow-sm ring-1 ring-slate-200/80"
+        >
+          <div className="text-[11px] font-semibold text-slate-500">Business need</div>
+          <div className="mt-2 text-sm font-semibold leading-tight text-slate-950">Find local experts</div>
+          <div className="mt-3 h-2 w-20 rounded-full bg-slate-200" />
+        </div>
+
+        <div
+          data-testid={compact ? 'mobile-homepage-discovery-visual-label' : 'desktop-homepage-discovery-visual-label'}
+          className="stage-card stage-compare absolute left-[34%] top-[46%] z-10 w-[48%] rounded-2xl bg-white px-4 py-3 shadow-sm ring-1 ring-slate-200/80"
+        >
+          <div className="text-[11px] font-semibold text-slate-500">Shortlist</div>
+          <div className="mt-2 text-sm font-semibold leading-tight text-slate-950">Compare best fits</div>
+          <div className="mt-3 grid gap-2">
+            <span className="h-2 w-28 rounded-full bg-blue-200" />
+            <span className="h-2 w-20 rounded-full bg-rose-200" />
+          </div>
+        </div>
+
+        <div
+          data-testid={compact ? 'mobile-homepage-discovery-visual-label' : 'desktop-homepage-discovery-visual-label'}
+          className="stage-result absolute bottom-[10%] right-[8%] z-20 flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-900 shadow-sm ring-2 ring-emerald-500/70"
+        >
+          <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 text-[10px] text-white">OK</span>
+          Get real results
+        </div>
+      </div>
+
+      <style jsx>{`
+        .motion-stage {
+          contain: layout paint;
+        }
+
+        .stage-card,
+        .stage-result {
+          animation: stageIn 520ms ease-out both;
+        }
+
+        .stage-compare {
+          animation-delay: 120ms;
+        }
+
+        .stage-result {
+          animation-delay: 240ms;
+        }
+
+        @keyframes stageIn {
+          from {
+            opacity: 0;
+            transform: translateY(8px);
+          }
+
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+          .stage-card,
+          .stage-result {
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/marketlink-frontend/tests/home.spec.ts
+++ b/marketlink-frontend/tests/home.spec.ts
@@ -50,20 +50,18 @@ test('desktop hero keeps the left side focused on one action', async ({ page }) 
   await expect(page.getByRole('link', { name: 'Browse local experts' })).toBeVisible();
 });
 
-test('desktop hero explains the product with a vertical checklist', async ({ page }) => {
+test('desktop hero shows the animated discovery visual', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(BASE_URL);
 
-  const checklist = page.getByTestId('desktop-product-checklist');
-  await expect(checklist).toBeVisible();
-  await expect(checklist.getByTestId('desktop-product-checklist-item')).toHaveCount(3);
-  await expect(checklist.getByText('Find local experts')).toBeVisible();
-  await expect(checklist.getByText('Compare best fits')).toBeVisible();
-  await expect(checklist.getByText('Get real results')).toBeVisible();
-  await expect(checklist.getByTestId('desktop-product-checklist-icon')).toHaveCount(3);
-  const resultIcon = checklist.getByTestId('desktop-product-checklist-item').filter({ hasText: 'Get real results' }).getByTestId('desktop-product-checklist-icon');
-  await expect(resultIcon).toContainText('100');
-  await expect(resultIcon).not.toHaveClass(/.*bg-slate-950.*/);
+  const animation = page.getByTestId('desktop-homepage-discovery-animation');
+  await expect(animation).toBeVisible();
+  await expect(animation.getByText('MarketLink flow')).toBeVisible();
+  const visualLabels = animation.getByTestId('desktop-homepage-discovery-visual-label');
+  await expect(visualLabels).toHaveCount(3);
+  await expect(visualLabels.filter({ hasText: 'Find local experts' })).toBeVisible();
+  await expect(visualLabels.filter({ hasText: 'Compare best fits' })).toBeVisible();
+  await expect(visualLabels.filter({ hasText: 'Get real results' })).toBeVisible();
 });
 
 test('desktop keeps problem choices inside the hero starting point panel', async ({ page }) => {
@@ -113,6 +111,9 @@ test.describe('mobile problem-first discovery', () => {
 
   test('shows compact problem cards before the full service grid', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Choose a starting point' })).toBeVisible();
+    const animation = page.getByTestId('mobile-homepage-discovery-animation');
+    await expect(animation).toBeVisible();
+    await expect(animation.getByTestId('mobile-homepage-discovery-visual-label')).toHaveCount(3);
     await expect(page.getByTestId('mobile-problem-card')).toHaveCount(4);
     const mobileCards = page.getByTestId('mobile-problem-card');
     await expect(mobileCards.filter({ hasText: "People can't find my business" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Replaces the old desktop checklist with a lightweight homepage product visual.
- Adds the same visual to mobile so the hero explains the MarketLink flow before problem cards.
- Updates homepage Playwright coverage for the visible product visual labels.

## Test Plan
- npx eslint src/app/page.tsx src/components/HomepageDiscoveryAnimation.tsx tests/home.spec.ts
- npx playwright test tests/home.spec.ts