### PR TITLE
MM-34 trim unused expert detail payload fields

### DIFF
--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -216,8 +216,6 @@ const expertDetailSelect = {
   remoteFriendly: true,
   servesNationwide: true,
   responseTimeHours: true,
-  featured: true,
-  completionScore: true,
   city: true,
   state: true,
   zip: true,
@@ -227,8 +225,6 @@ const expertDetailSelect = {
   logo: true,
   status: true,
   disabledReason: true,
-  createdAt: true,
-  updatedAt: true,
   projects: {
     select: expertProjectSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
@@ -240,10 +236,6 @@ const expertDetailSelect = {
   media: {
     select: expertMediaSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
-  },
-  reviews: {
-    select: expertReviewSelect,
-    orderBy: [{ sortOrder: 'asc' }, { publishedAt: 'desc' }, { createdAt: 'desc' }],
   },
   certifications: {
     select: expertCertificationSelect,


### PR DESCRIPTION
## Summary
- remove unused fields from the expert detail payload returned by /experts/:slug
- keep the current expert detail page response aligned with the fields it actually consumes

## Verification
- npx tsc --noEmit
- note: full backend 
pm run build was blocked by a local Prisma Windows file-lock during prisma generate, not a TypeScript or route error