### PR TITLE
MM-99 add exact location capture and onboarding guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,28 @@ Frontend should handle:
 
 ---
 
+## Product Inspiration Rules
+
+When making UX, layout, trust, discovery, or profile-page decisions, use Winnie and Thumbtack as the primary product references unless the user overrides that direction.
+
+Treat:
+
+- Winnie as the reference for warmth, clarity, and trust presentation.
+- Thumbtack as the reference for marketplace structure, local discovery, results scanning, and conversion-oriented service flows.
+
+Do not copy branding or visuals directly.
+
+Borrow:
+
+- Interaction patterns
+- Information hierarchy
+- Density
+- Trust mechanics
+
+See `docs/product/inspiration.md` for the concrete reference guidance.
+
+---
+
 ## Strict Working Rules
 
 - Always verify existing code before changing it.

--- a/docs/product/inspiration.md
+++ b/docs/product/inspiration.md
@@ -1,0 +1,114 @@
+# Product Inspiration
+
+This document defines the standing product reference points for MarketLink.
+
+These references guide UX and product decisions. They do not authorize copying another product's brand, exact visuals, exact copy, or exact layouts.
+
+If a user gives a direct instruction that conflicts with this document, follow the user.
+
+## Primary References
+
+### Winnie
+
+Use Winnie as the reference for:
+
+- Warmth
+- Clarity
+- Trust presentation
+- Softer, more reassuring content structure
+- Friendly but still structured buyer confidence signals
+
+### Thumbtack
+
+Use Thumbtack as the reference for:
+
+- Marketplace structure
+- Local discovery
+- Results scanning
+- Service comparison
+- Conversion-oriented inquiry and matching flows
+- Practical, high-signal profile organization
+
+## What To Borrow
+
+Borrow patterns, not identity.
+
+Good things to borrow:
+
+- Clear information hierarchy
+- Fast scanning layouts
+- Trust-building section order
+- Compact but readable results density
+- Strong conversion paths
+- Helpful nearby and location relevance cues
+- Inquiry flows that reduce buyer hesitation
+- Profile layouts that surface proof early
+
+## What Not To Borrow
+
+Do not copy:
+
+- Logos
+- Brand names
+- Exact copywriting
+- Exact layouts
+- Exact color systems
+- Illustrations or images
+- Unique branded interaction details that make the product feel cloned
+
+MarketLink should feel informed by strong marketplace patterns, not visually derivative.
+
+## Priority By Page Type
+
+### Homepage Discovery
+
+- Prioritize Thumbtack-style discovery structure
+- Keep the first screen easy to scan and action-oriented
+- Use Winnie-style warmth only where it improves clarity and trust
+
+### Search Results
+
+- Prioritize Thumbtack-style scanability
+- Keep cards dense, practical, and easy to compare
+- Surface location, proof, and fit quickly
+
+### Profile And Detail Pages
+
+- Use Thumbtack-style structure for proof, inquiry flow, and service comparison
+- Use Winnie-style trust presentation for tone, clarity, and reassurance
+
+### Inquiry And Contact Flows
+
+- Prioritize Thumbtack-style conversion mechanics
+- Reduce hesitation, reduce ambiguity, and keep the next step obvious
+- Use Winnie-style softness in surrounding copy only when it improves comfort
+
+### Location And Proximity UX
+
+- Prioritize Thumbtack-style local-service logic
+- Make nearby relevance obvious
+- Keep location trust practical, not decorative
+
+## Conflict Resolution
+
+When the references point in different directions:
+
+1. Thumbtack wins for marketplace mechanics, search, results, profile structure, and conversion flow.
+2. Winnie wins for trust presentation, warmth, and clarity of supporting content.
+3. Direct user instructions override both.
+
+## Examples Of Good Decisions
+
+- Moving proof and trust signals higher on profile pages
+- Making search results easier to compare at a glance
+- Making local relevance more explicit with nearby signals
+- Using calmer, clearer framing around inquiry forms
+- Reducing decorative clutter when it hurts scanning
+
+## Examples Of Bad Decisions
+
+- Copying another product's exact card layout or copy
+- Recreating another product's color palette to feel identical
+- Choosing warmth over clarity when the buyer needs fast comparison
+- Choosing dense marketplace mechanics for a section that needs softer reassurance
+- Adding visual references that feel derivative instead of functional

--- a/marketlink-backend/prisma/migrations/20260514020036_add_expert_street_address/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260514020036_add_expert_street_address/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Expert" ADD COLUMN     "streetAddress" TEXT;

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -52,6 +52,7 @@ model Expert {
   responseTimeHours   Int?
   featured            Boolean               @default(false)
   completionScore     Int                   @default(0)
+  streetAddress       String?
   city                String                @db.Citext
   state               String                @db.Citext
   zip                 String?

--- a/marketlink-backend/src/lib/geocoding.ts
+++ b/marketlink-backend/src/lib/geocoding.ts
@@ -1,4 +1,5 @@
 type ExpertLocationInput = {
+  streetAddress?: string | null;
   city: string;
   state: string;
   zip?: string | null;
@@ -8,12 +9,20 @@ type SearchCenterInput = {
   zip: string;
 };
 
+type AutocompleteType = 'city' | 'state' | 'postcode' | 'address';
+
 type GeocodeSuccess = {
   ok: true;
   latitude: number;
   longitude: number;
   geocodedAt: Date;
   geocodeProvider: 'geoapify';
+};
+
+type ZipLookupSuccess = GeocodeSuccess & {
+  city: string;
+  state: string;
+  zip: string;
 };
 
 type GeocodeFailureReason = 'missing-config' | 'bad-status' | 'bad-response' | 'not-found' | 'network';
@@ -25,13 +34,34 @@ type GeocodeFailure = {
 };
 
 export type GeocodeResult = GeocodeSuccess | GeocodeFailure;
+export type ZipLookupResult = ZipLookupSuccess | GeocodeFailure;
+
+export type LocationAutocompleteSuggestion = {
+  label: string;
+  city: string | null;
+  state: string | null;
+  stateCode: string | null;
+  zip: string | null;
+  latitude: number;
+  longitude: number;
+  resultType: string | null;
+};
+
+export type LocationAutocompleteResult =
+  | {
+      ok: true;
+      suggestions: LocationAutocompleteSuggestion[];
+    }
+  | GeocodeFailure;
 
 const GEOAPIFY_API_KEY = process.env.GEOAPIFY_API_KEY || '';
 const GEOAPIFY_BASE_URL = process.env.GEOAPIFY_BASE_URL || 'https://api.geoapify.com';
 
-function buildExpertLocationText({ city, state, zip }: ExpertLocationInput) {
+function buildExpertLocationText({ streetAddress, city, state, zip }: ExpertLocationInput) {
+  const street = String(streetAddress || '').trim();
   const cityState = `${city}, ${state}`;
-  return zip ? `${cityState} ${zip}, United States` : `${cityState}, United States`;
+  const base = street ? `${street}, ${cityState}` : cityState;
+  return zip ? `${base} ${zip}, United States` : `${base}, United States`;
 }
 
 function buildSearchCenterText({ zip }: SearchCenterInput) {
@@ -40,6 +70,44 @@ function buildSearchCenterText({ zip }: SearchCenterInput) {
 
 export function hasGeocodingConfig() {
   return Boolean(GEOAPIFY_API_KEY);
+}
+
+function normalizeAutocompleteType(type: AutocompleteType) {
+  if (type === 'address') return null;
+  if (type === 'postcode') return 'postcode';
+  return type;
+}
+
+function dedupeSuggestions(type: AutocompleteType, suggestions: LocationAutocompleteSuggestion[]) {
+  const seen = new Set<string>();
+  const output: LocationAutocompleteSuggestion[] = [];
+
+  for (const suggestion of suggestions) {
+    const key =
+      type === 'city'
+        ? `${String(suggestion.city || '').trim().toLowerCase()}|${String(suggestion.stateCode || suggestion.state || '')
+            .trim()
+            .toLowerCase()}`
+        : type === 'state'
+        ? `${String(suggestion.stateCode || suggestion.state || '').trim().toLowerCase()}`
+        : type === 'postcode'
+        ? `${String(suggestion.zip || '').trim()}`
+        : `${String(suggestion.label || '').trim().toLowerCase()}`;
+
+    if (!key || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    output.push(suggestion);
+  }
+
+  return output;
+}
+
+function isAllowedAddressSuggestion(resultType: string | null) {
+  const normalized = String(resultType || '').trim().toLowerCase();
+  return normalized !== 'city' && normalized !== 'state' && normalized !== 'postcode' && normalized !== 'country' && normalized !== 'county';
 }
 
 async function geocodeSearchText(text: string): Promise<GeocodeResult> {
@@ -83,10 +151,140 @@ async function geocodeSearchText(text: string): Promise<GeocodeResult> {
   }
 }
 
+async function geocodeStructuredSearchText(text: string): Promise<ZipLookupResult> {
+  if (!hasGeocodingConfig()) {
+    return { ok: false, error: 'missing-config' };
+  }
+
+  const url = new URL('/v1/geocode/search', GEOAPIFY_BASE_URL);
+  url.searchParams.set('text', text);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('limit', '1');
+  url.searchParams.set('apiKey', GEOAPIFY_API_KEY);
+
+  try {
+    const res = await fetch(url.toString(), { method: 'GET' });
+    if (!res.ok) {
+      return { ok: false, error: 'bad-status', status: res.status };
+    }
+
+    const body = (await res.json().catch(() => null)) as
+      | {
+          results?: Array<{
+            lat?: number | string;
+            lon?: number | string;
+            city?: string | null;
+            state?: string | null;
+            state_code?: string | null;
+            postcode?: string | null;
+          }>;
+        }
+      | null;
+
+    const first = body?.results?.[0];
+    const latitude = Number(first?.lat);
+    const longitude = Number(first?.lon);
+    const city = String(first?.city || '').trim();
+    const state = String(first?.state_code || first?.state || '').trim().toUpperCase();
+    const zip = String(first?.postcode || '').trim();
+
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude) || !city || !state || !zip) {
+      return { ok: false, error: body?.results?.length ? 'bad-response' : 'not-found' };
+    }
+
+    return {
+      ok: true,
+      latitude,
+      longitude,
+      city,
+      state,
+      zip,
+      geocodedAt: new Date(),
+      geocodeProvider: 'geoapify',
+    };
+  } catch {
+    return { ok: false, error: 'network' };
+  }
+}
+
 export async function geocodeExpertLocation(input: ExpertLocationInput): Promise<GeocodeResult> {
   return geocodeSearchText(buildExpertLocationText(input));
 }
 
 export async function geocodeSearchCenter(input: SearchCenterInput): Promise<GeocodeResult> {
   return geocodeSearchText(buildSearchCenterText(input));
+}
+
+export async function lookupZipLocation(input: SearchCenterInput): Promise<ZipLookupResult> {
+  return geocodeStructuredSearchText(buildSearchCenterText(input));
+}
+
+export async function autocompleteLocation(text: string, type: AutocompleteType): Promise<LocationAutocompleteResult> {
+  if (!hasGeocodingConfig()) {
+    return { ok: false, error: 'missing-config' };
+  }
+
+  const query = text.trim();
+  if (!query) {
+    return { ok: true, suggestions: [] };
+  }
+
+  const url = new URL('/v1/geocode/autocomplete', GEOAPIFY_BASE_URL);
+  url.searchParams.set('text', query);
+  url.searchParams.set('format', 'json');
+  url.searchParams.set('limit', '8');
+  url.searchParams.set('filter', 'countrycode:us');
+  const normalizedType = normalizeAutocompleteType(type);
+  if (normalizedType) {
+    url.searchParams.set('type', normalizedType);
+  }
+  url.searchParams.set('apiKey', GEOAPIFY_API_KEY);
+
+  try {
+    const res = await fetch(url.toString(), { method: 'GET' });
+    if (!res.ok) {
+      return { ok: false, error: 'bad-status', status: res.status };
+    }
+
+    const body = (await res.json().catch(() => null)) as
+      | {
+          results?: Array<{
+            formatted?: string | null;
+            city?: string | null;
+            state?: string | null;
+            state_code?: string | null;
+            postcode?: string | null;
+            lat?: number | string;
+            lon?: number | string;
+            result_type?: string | null;
+          }>;
+        }
+      | null;
+
+    const suggestions = (body?.results || [])
+      .map((item) => {
+        const latitude = Number(item.lat);
+        const longitude = Number(item.lon);
+        if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+          return null;
+        }
+
+        return {
+          label: String(item.formatted || '').trim(),
+          city: item.city ? String(item.city).trim() : null,
+          state: item.state ? String(item.state).trim() : null,
+          stateCode: item.state_code ? String(item.state_code).trim().toUpperCase() : null,
+          zip: item.postcode ? String(item.postcode).trim() : null,
+          latitude,
+          longitude,
+          resultType: item.result_type ? String(item.result_type).trim() : null,
+        } satisfies LocationAutocompleteSuggestion;
+      })
+      .filter((item): item is LocationAutocompleteSuggestion => Boolean(item?.label))
+      .filter((item) => (type === 'address' ? isAllowedAddressSuggestion(item.resultType) : true));
+
+    return { ok: true, suggestions: dedupeSuggestions(type, suggestions) };
+  } catch {
+    return { ok: false, error: 'network' };
+  }
 }

--- a/marketlink-backend/src/routes/account.ts
+++ b/marketlink-backend/src/routes/account.ts
@@ -25,6 +25,8 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
         city: true,
         state: true,
         zip: true,
+        streetAddress: true,
+        locationPrecision: true,
         tagline: true,
         shortDescription: true,
         overview: true,

--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -3,7 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
 import { ExpertMediaType, ExpertStatus, ExpertType, LocationPrecision } from '@prisma/client';
-import { geocodeExpertLocation, geocodeSearchCenter } from '../lib/geocoding';
+import { autocompleteLocation, geocodeExpertLocation, geocodeSearchCenter, lookupZipLocation } from '../lib/geocoding';
 
 type SortKey = 'newest' | 'name' | 'rating' | 'verified';
 type OrderDir = 'asc' | 'desc';
@@ -265,6 +265,7 @@ const expertDetailSelect = {
   city: true,
   state: true,
   zip: true,
+  streetAddress: true,
   latitude: true,
   longitude: true,
   locationPrecision: true,
@@ -328,6 +329,7 @@ const expertEditorSelect = {
   city: true,
   state: true,
   zip: true,
+  streetAddress: true,
   latitude: true,
   longitude: true,
   locationPrecision: true,
@@ -356,6 +358,47 @@ const expertCollectionPaths = ['/experts', '/providers'] as const;
 const expertDetailPaths = ['/experts/:slug', '/providers/:slug'] as const;
 
 const expertsRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/location/autocomplete', async (req, reply) => {
+    const { q, type } = (req.query || {}) as { q?: string; type?: string };
+    const query = String(q || '').trim();
+    const lookupType = String(type || '').trim().toLowerCase();
+
+    if (!query) {
+      return reply.send({ ok: true, suggestions: [] });
+    }
+
+    if (lookupType !== 'city' && lookupType !== 'state' && lookupType !== 'postcode' && lookupType !== 'address') {
+      return reply.code(400).send({ error: 'type must be one of: city, state, postcode, address.' });
+    }
+
+    const result = await autocompleteLocation(query, lookupType);
+    if (!result.ok) {
+      return reply.code(result.error === 'missing-config' ? 503 : 400).send({
+        error: result.error === 'missing-config' ? 'Location lookup is not configured.' : 'Failed to autocomplete location.',
+      });
+    }
+
+    return reply.send(result);
+  });
+
+  fastify.get('/location/zip/:zip', async (req, reply) => {
+    const { zip } = req.params as { zip: string };
+    const normalizedZip = String(zip || '').trim();
+
+    if (!normalizedZip) {
+      return reply.code(400).send({ error: 'zip is required.' });
+    }
+
+    const result = await lookupZipLocation({ zip: normalizedZip });
+    if (!result.ok) {
+      return reply.code(result.error === 'missing-config' ? 503 : 400).send({
+        error: result.error === 'missing-config' ? 'Location lookup is not configured.' : 'Could not resolve zip code.',
+      });
+    }
+
+    return reply.send(result);
+  });
+
   // LIST: GET /experts (with /providers kept as a compatibility alias)
   for (const path of expertCollectionPaths) {
     fastify.get(
@@ -651,6 +694,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       city?: string;
       state?: string;
       zip?: string;
+      streetAddress?: string;
       latitude?: number | string | null;
       longitude?: number | string | null;
       locationPrecision?: string;
@@ -715,6 +759,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
     const city = (body.city || '').trim();
     const state = (body.state || '').trim();
     const zip = (body.zip || '').trim() || null;
+    const streetAddress = (body.streetAddress || '').trim() || null;
     const latitude = parseOptionalFloat(body.latitude);
     const longitude = parseOptionalFloat(body.longitude);
     const tagline = (body.tagline || '').trim() || null;
@@ -814,7 +859,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
     let resolvedGeocodeProvider = typeof geocodeProvider === 'undefined' ? undefined : geocodeProvider;
 
     if (typeof resolvedLatitude === 'undefined' && typeof resolvedLongitude === 'undefined') {
-      const geocoded = await geocodeExpertLocation({ city, state, zip });
+      const geocoded = await geocodeExpertLocation({ streetAddress, city, state, zip });
       if (geocoded.ok) {
         resolvedLatitude = geocoded.latitude;
         resolvedLongitude = geocoded.longitude;
@@ -832,6 +877,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
           slug,
           expertType,
           tagline,
+          streetAddress: streetAddress || undefined,
           city,
           state,
           zip: zip || undefined,
@@ -851,6 +897,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
           slug: true,
           businessName: true,
           expertType: true,
+          streetAddress: true,
           city: true,
           state: true,
           zip: true,
@@ -892,6 +939,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       city?: string;
       state?: string;
       zip?: string;
+      streetAddress?: string;
       latitude?: number | string | null;
       longitude?: number | string | null;
       locationPrecision?: string;
@@ -963,6 +1011,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
     let nextCity = expert.city;
     let nextState = expert.state;
     let nextZip = expert.zip;
+    let nextStreetAddress = (expert as any).streetAddress ?? null;
     let nextExpertType = expert.expertType;
     let locationChanged = false;
     let coordinatesTouched = false;
@@ -990,6 +1039,12 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       const v = body.zip.trim();
       (data as any).zip = v || null;
       nextZip = v || null;
+      locationChanged = true;
+    }
+    if (typeof body.streetAddress === 'string') {
+      const v = body.streetAddress.trim();
+      (data as any).streetAddress = v || null;
+      nextStreetAddress = v || null;
       locationChanged = true;
     }
     if (typeof body.latitude !== 'undefined') {
@@ -1035,7 +1090,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       (data as any).geocodeProvider = null;
     }
     if (!coordinatesTouched && locationChanged) {
-      const geocoded = await geocodeExpertLocation({ city: nextCity, state: nextState, zip: nextZip });
+      const geocoded = await geocodeExpertLocation({ streetAddress: nextStreetAddress, city: nextCity, state: nextState, zip: nextZip });
       if (geocoded.ok) {
         (data as any).latitude = geocoded.latitude;
         (data as any).longitude = geocoded.longitude;

--- a/marketlink-frontend/src/app/dashboard/onboarding/OnboardingForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/OnboardingForm.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LocationAutocompleteField, { type LocationSuggestion } from '@/components/LocationAutocompleteField';
+import { getStateDisplayName, normalizeStateCode } from '@/lib/usStates';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+const SERVICE_OPTIONS = [
+  { value: 'seo', label: 'SEO' },
+  { value: 'social', label: 'Social' },
+  { value: 'ads', label: 'Ads' },
+  { value: 'web', label: 'Websites' },
+  { value: 'branding', label: 'Branding' },
+  { value: 'email', label: 'Email' },
+  { value: 'content', label: 'Content' },
+  { value: 'video', label: 'Video' },
+];
+
+const EXPERT_TYPE_OPTIONS = [
+  { value: 'agency', label: 'Agency' },
+  { value: 'freelancer', label: 'Freelancer' },
+  { value: 'creator', label: 'Creator' },
+  { value: 'specialist', label: 'Specialist' },
+];
+
+export default function OnboardingForm() {
+  const router = useRouter();
+
+  const [businessName, setBusinessName] = useState('');
+  const [streetAddress, setStreetAddress] = useState('');
+  const [city, setCity] = useState('');
+  const [state, setState] = useState('');
+  const [zip, setZip] = useState('');
+  const [expertType, setExpertType] = useState('');
+  const [services, setServices] = useState<string[]>([]);
+
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  function toggleService(val: string) {
+    setServices((prev) => (prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]));
+  }
+
+  function applyResolvedLocation(suggestion: LocationSuggestion) {
+    if (suggestion.label) setStreetAddress(suggestion.label);
+    if (suggestion.zip) setZip(suggestion.zip);
+    if (suggestion.city) setCity(suggestion.city);
+    if (suggestion.stateCode || suggestion.state) setState(getStateDisplayName(suggestion.stateCode || suggestion.state || ''));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setStatus('submitting');
+    setError(null);
+
+    try {
+      if (!businessName.trim()) throw new Error('Business name is required.');
+      if (!streetAddress.trim()) throw new Error('Address is required.');
+      if (!city.trim()) throw new Error('City is required.');
+      if (!state.trim()) throw new Error('State is required.');
+      if (!zip.trim()) throw new Error('ZIP is required.');
+      if (!expertType) throw new Error('Expert type is required.');
+      if (!services.length) throw new Error('Select at least one service.');
+
+      const normalizedState = normalizeStateCode(state);
+      if (!normalizedState) throw new Error('Select a valid US state.');
+
+      const res = await fetch(`${API_BASE}/experts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          businessName: businessName.trim(),
+          streetAddress: streetAddress.trim(),
+          city: city.trim(),
+          state: normalizedState,
+          zip: zip.trim(),
+          expertType,
+          services,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body?.error || `Failed (${res.status})`);
+      }
+
+      const data = await res.json();
+      const slug = (data?.expert?.slug || data?.provider?.slug) as string | undefined;
+
+      if (slug) {
+        router.replace(`/experts/${slug}`);
+        return;
+      }
+
+      router.replace('/dashboard');
+    } catch (err: unknown) {
+      setStatus('error');
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setStatus('idle');
+    }
+  }
+
+  const disabled = status === 'submitting' || !businessName.trim() || !streetAddress.trim() || !city.trim() || !state.trim() || !zip.trim() || !expertType || services.length === 0;
+  const sectionClass =
+    'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(236,242,248,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
+  const fieldClass =
+    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
+  const checkboxClass = 'h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-200';
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+      <div className="grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_320px] lg:items-start">
+        <section className={`${sectionClass} order-1`}>
+          <div className="flex flex-col gap-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Expert onboarding</p>
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Create your expert profile</h1>
+            <p className="text-sm leading-6 text-slate-600 sm:text-base">
+              Start with the essentials that power discovery. Choose your exact business address first, then add proof, pricing, and portfolio detail in your profile editor after this.
+            </p>
+          </div>
+
+          <form className="mt-6 grid gap-5" onSubmit={handleSubmit}>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Business name *</label>
+              <input className={fieldClass} value={businessName} onChange={(e) => setBusinessName(e.target.value)} placeholder="Windy City Growth" required />
+            </div>
+
+            <div className="grid gap-4">
+              <LocationAutocompleteField
+                label="Business address *"
+                value={streetAddress}
+                onChange={setStreetAddress}
+                onResolve={applyResolvedLocation}
+                type="address"
+                placeholder="Start typing your exact address or place name"
+                required
+                fieldClass={fieldClass}
+                autoComplete="street-address"
+                helperText="Pick the exact business location from the dropdown. City, state, and ZIP will fill in automatically."
+              />
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">City *</label>
+                <input className={`${fieldClass} bg-slate-50 text-slate-600`} value={city} readOnly />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">State *</label>
+                <input className={`${fieldClass} bg-slate-50 text-slate-600`} value={state} readOnly />
+              </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700">ZIP *</label>
+                <input className={`${fieldClass} bg-slate-50 text-slate-600`} value={zip} readOnly />
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Expert type *</label>
+              <select className={fieldClass} value={expertType} onChange={(e) => setExpertType(e.target.value)} required>
+                <option value="">Select the best fit</option>
+                {EXPERT_TYPE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-2 text-xs text-slate-500">
+                {expertType === 'creator'
+                  ? 'Creator proof, platform links, and audience detail can be added right after setup in your profile editor.'
+                  : 'Pick the closest fit for how buyers should understand your business.'}
+              </p>
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-slate-700">Services *</label>
+              <div className="flex flex-wrap gap-3">
+                {SERVICE_OPTIONS.map((opt) => (
+                  <label key={opt.value} className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-700 shadow-sm">
+                    <input type="checkbox" className={checkboxClass} checked={services.includes(opt.value)} onChange={() => toggleService(opt.value)} />
+                    {opt.label}
+                  </label>
+                ))}
+              </div>
+              <p className="mt-2 text-xs text-slate-500">These match the live discovery categories buyers already use on the homepage and expert directory.</p>
+            </div>
+
+            {error ? <p className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p> : null}
+
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-slate-500">* required</p>
+              <button
+                type="submit"
+                disabled={disabled}
+                className="rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {status === 'submitting' ? 'Creating...' : 'Create profile'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <aside className={`${sectionClass} order-2 lg:sticky lg:top-6`}>
+          <div className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">What happens next</div>
+          <div className="mt-4 grid gap-3">
+            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+              <div className="text-sm font-semibold text-slate-900">1. Create the listing</div>
+              <p className="mt-1 text-sm text-slate-600">Start with the fields buyers need first: business name, exact address, expert type, and services.</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+              <div className="text-sm font-semibold text-slate-900">2. Add proof of work</div>
+              <p className="mt-1 text-sm text-slate-600">After setup, use the profile editor to add case studies, clients, media, pricing, and creator proof.</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
+              <div className="text-sm font-semibold text-slate-900">3. Keep it focused</div>
+              <p className="mt-1 text-sm text-slate-600">A clear category match and strong proof matter more than stuffing every optional field in the first step.</p>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
@@ -1,190 +1,32 @@
-'use client';
-
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import OnboardingForm from './OnboardingForm';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
-const SERVICE_OPTIONS = [
-  { value: 'seo', label: 'SEO' },
-  { value: 'social', label: 'Social' },
-  { value: 'ads', label: 'Ads' },
-  { value: 'web', label: 'Websites' },
-  { value: 'branding', label: 'Branding' },
-  { value: 'email', label: 'Email' },
-  { value: 'content', label: 'Content' },
-  { value: 'video', label: 'Video' },
-];
+export default async function OnboardingPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
 
-const EXPERT_TYPE_OPTIONS = [
-  { value: 'agency', label: 'Agency' },
-  { value: 'freelancer', label: 'Freelancer' },
-  { value: 'creator', label: 'Creator' },
-  { value: 'specialist', label: 'Specialist' },
-];
+  const res = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
 
-export default function OnboardingPage() {
-  const router = useRouter();
-
-  const [businessName, setBusinessName] = useState('');
-  const [city, setCity] = useState('');
-  const [state, setState] = useState('');
-  const [expertType, setExpertType] = useState('');
-  const [services, setServices] = useState<string[]>([]);
-
-  const [status, setStatus] = useState<'idle' | 'submitting' | 'error'>('idle');
-  const [error, setError] = useState<string | null>(null);
-
-  function toggleService(val: string) {
-    setServices((prev) => (prev.includes(val) ? prev.filter((v) => v !== val) : [...prev, val]));
+  if (res.status === 401) {
+    redirect('/login?returnTo=/dashboard/onboarding');
   }
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setStatus('submitting');
-    setError(null);
-
-    try {
-      if (!businessName.trim()) throw new Error('Business name is required.');
-      if (!city.trim()) throw new Error('City is required.');
-      if (!state.trim()) throw new Error('State is required.');
-      if (!expertType) throw new Error('Expert type is required.');
-      if (!services.length) throw new Error('Select at least one service.');
-
-      const res = await fetch(`${API_BASE}/experts`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          businessName: businessName.trim(),
-          city: city.trim(),
-          state: state.trim(),
-          expertType,
-          services,
-        }),
-      });
-
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body?.error || `Failed (${res.status})`);
-      }
-
-      const data = await res.json();
-      const slug = (data?.expert?.slug || data?.provider?.slug) as string | undefined;
-
-      if (slug) {
-        router.replace(`/experts/${slug}`);
-        return;
-      }
-
-      router.replace('/dashboard');
-    } catch (err: unknown) {
-      setStatus('error');
-      setError(err instanceof Error ? err.message : 'Something went wrong.');
-    } finally {
-      setStatus('idle');
-    }
+  if (!res.ok) {
+    throw new Error(`Failed to load onboarding gate (${res.status})`);
   }
 
-  const disabled = status === 'submitting' || !businessName.trim() || !city.trim() || !state.trim() || !expertType || services.length === 0;
-  const sectionClass =
-    'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(236,242,248,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
-  const fieldClass =
-    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
-  const checkboxClass = 'h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-200';
+  const data = (await res.json()) as { expert?: { id: string } | null; provider?: { id: string } | null };
 
-  return (
-    <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_320px] lg:items-start">
-        <section className={`${sectionClass} order-1`}>
-          <div className="flex flex-col gap-1">
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Expert onboarding</p>
-            <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Create your expert profile</h1>
-            <p className="text-sm leading-6 text-slate-600 sm:text-base">
-              Start with the essentials that power discovery. You can add proof, pricing, and portfolio detail in your profile editor after this.
-            </p>
-          </div>
+  if (data.expert || data.provider) {
+    redirect('/dashboard/profile');
+  }
 
-          <form className="mt-6 grid gap-5" onSubmit={handleSubmit}>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">Business name *</label>
-              <input className={fieldClass} value={businessName} onChange={(e) => setBusinessName(e.target.value)} placeholder="Windy City Growth" required />
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-slate-700">City *</label>
-                <input className={fieldClass} value={city} onChange={(e) => setCity(e.target.value)} placeholder="Chicago" required />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-slate-700">State *</label>
-                <input className={fieldClass} value={state} onChange={(e) => setState(e.target.value)} placeholder="IL" maxLength={20} required />
-              </div>
-            </div>
-
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700">Expert type *</label>
-              <select className={fieldClass} value={expertType} onChange={(e) => setExpertType(e.target.value)} required>
-                <option value="">Select the best fit</option>
-                {EXPERT_TYPE_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-              <p className="mt-2 text-xs text-slate-500">
-                {expertType === 'creator'
-                  ? 'Creator proof, platform links, and audience detail can be added right after setup in your profile editor.'
-                  : 'Pick the closest fit for how buyers should understand your business.'}
-              </p>
-            </div>
-
-            <div>
-              <label className="mb-2 block text-sm font-medium text-slate-700">Services *</label>
-              <div className="flex flex-wrap gap-3">
-                {SERVICE_OPTIONS.map((opt) => (
-                  <label key={opt.value} className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm text-slate-700 shadow-sm">
-                    <input type="checkbox" className={checkboxClass} checked={services.includes(opt.value)} onChange={() => toggleService(opt.value)} />
-                    {opt.label}
-                  </label>
-                ))}
-              </div>
-              <p className="mt-2 text-xs text-slate-500">These match the live discovery categories buyers already use on the homepage and expert directory.</p>
-            </div>
-
-            {error ? <p className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</p> : null}
-
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-xs text-slate-500">* required</p>
-              <button
-                type="submit"
-                disabled={disabled}
-                className="rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {status === 'submitting' ? 'Creating...' : 'Create profile'}
-              </button>
-            </div>
-          </form>
-        </section>
-
-        <aside className={`${sectionClass} order-2 lg:sticky lg:top-6`}>
-          <div className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">What happens next</div>
-          <div className="mt-4 grid gap-3">
-            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-              <div className="text-sm font-semibold text-slate-900">1. Create the listing</div>
-              <p className="mt-1 text-sm text-slate-600">Start with the fields buyers need first: business name, city, expert type, and services.</p>
-            </div>
-            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-              <div className="text-sm font-semibold text-slate-900">2. Add proof of work</div>
-              <p className="mt-1 text-sm text-slate-600">After setup, use the profile editor to add case studies, clients, media, pricing, and creator proof.</p>
-            </div>
-            <div className="rounded-2xl border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]">
-              <div className="text-sm font-semibold text-slate-900">3. Keep it focused</div>
-              <p className="mt-1 text-sm text-slate-600">A clear category match and strong proof matter more than stuffing every optional field in the first step.</p>
-            </div>
-          </div>
-        </aside>
-      </div>
-    </main>
-  );
+  return <OnboardingForm />;
 }

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import LocationAutocompleteField, { type LocationSuggestion } from '@/components/LocationAutocompleteField';
+import { getStateDisplayName, normalizeStateCode } from '@/lib/usStates';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
@@ -48,6 +50,8 @@ type Provider = {
   slug: string;
   businessName: string;
   expertType?: 'agency' | 'freelancer' | 'creator' | 'specialist' | null;
+  locationPrecision?: 'exact' | 'approximate' | null;
+  streetAddress?: string | null;
   shortDescription?: string | null;
   overview?: string | null;
   websiteUrl?: string | null;
@@ -180,6 +184,7 @@ export default function ProfileEditorPage() {
           slug: p.slug ?? '',
           businessName: p.businessName ?? '',
           expertType: p.expertType ?? null,
+          streetAddress: p.streetAddress ?? '',
           shortDescription: p.shortDescription ?? '',
           overview: p.overview ?? '',
           websiteUrl: p.websiteUrl ?? '',
@@ -203,8 +208,9 @@ export default function ProfileEditorPage() {
           servesNationwide: Boolean(p.servesNationwide),
           responseTimeHours: p.responseTimeHours ?? '',
           city: p.city ?? '',
-          state: String(p.state ?? ''),
+          state: getStateDisplayName(String(p.state ?? '')),
           zip: p.zip ?? '',
+          locationPrecision: p.locationPrecision ?? (p.expertType === 'creator' ? 'approximate' : 'exact'),
           tagline: p.tagline ?? '',
           logo: p.logo ?? '',
           services: Array.isArray(p.services) ? p.services : [],
@@ -267,9 +273,11 @@ export default function ProfileEditorPage() {
   }, [dirty, saving]);
 
   function setField<K extends keyof Provider>(key: K, val: Provider[K]) {
-    if (!data) return;
     setDirty(true);
-    setData({ ...data, [key]: val });
+    setData((current) => {
+      if (!current) return current;
+      return { ...current, [key]: val };
+    });
   }
 
   function toggleService(val: string) {
@@ -277,6 +285,14 @@ export default function ProfileEditorPage() {
     setDirty(true);
     const next = data.services.includes(val) ? data.services.filter((v) => v !== val) : [...data.services, val];
     setData({ ...data, services: next });
+  }
+
+  function applyResolvedLocation(suggestion: LocationSuggestion) {
+    if (!data) return;
+    if (suggestion.label) setField('streetAddress', suggestion.label);
+    if (suggestion.zip) setField('zip', suggestion.zip);
+    if (suggestion.city) setField('city', suggestion.city);
+    if (suggestion.stateCode || suggestion.state) setField('state', getStateDisplayName(suggestion.stateCode || suggestion.state || ''));
   }
 
   function parseTokenInput(raw: string) {
@@ -409,16 +425,22 @@ export default function ProfileEditorPage() {
 
     try {
       if (!data.businessName.trim()) throw new Error('Business name is required.');
+      if (!(data.streetAddress || '').trim()) throw new Error('Address is required.');
       if (!data.city.trim()) throw new Error('City is required.');
       if (!data.state.trim()) throw new Error('State is required.');
       if (!data.expertType) throw new Error('Expert type is required.');
       if (!data.services.map((s) => s.trim()).filter(Boolean).length) throw new Error('Select at least one service.');
 
+      const normalizedState = normalizeStateCode(data.state);
+      if (!normalizedState) throw new Error('Select a valid US state.');
+
       const basePayload: Record<string, unknown> = {
         businessName: data.businessName.trim(),
+        streetAddress: (data.streetAddress || '').trim(),
         city: data.city.trim(),
-        state: data.state.trim().toUpperCase(),
+        state: normalizedState,
         zip: (data.zip || '').trim(),
+        locationPrecision: data.locationPrecision || (data.expertType === 'creator' ? 'approximate' : 'exact'),
         tagline: (data.tagline || '').trim(),
         logo: (data.logo || '').trim(),
         expertType: data.expertType || '',
@@ -690,18 +712,49 @@ export default function ProfileEditorPage() {
             </div>
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="sm:col-span-3">
+                <LocationAutocompleteField
+                  label="Business address *"
+                  value={data.streetAddress ?? ''}
+                  onChange={(value) => setField('streetAddress', value)}
+                  onResolve={applyResolvedLocation}
+                  type="address"
+                  placeholder="Start typing your exact address or place name"
+                  required
+                  fieldClass={fieldClass}
+                  autoComplete="street-address"
+                  helperText="Pick the exact business location from the dropdown. City, state, and ZIP will fill in automatically."
+                />
+              </div>
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700">City *</label>
-                <input autoComplete="address-level2" className={fieldClass} value={data.city} onChange={(e) => setField('city', e.target.value)} />
+                <input autoComplete="address-level2" className={`${fieldClass} bg-slate-50 text-slate-600`} value={data.city} readOnly />
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700">State *</label>
-                <input autoComplete="address-level1" className={fieldClass} value={data.state} onChange={(e) => setField('state', e.target.value)} />
+                <input autoComplete="address-level1" className={`${fieldClass} bg-slate-50 text-slate-600`} value={data.state} readOnly />
               </div>
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700">ZIP</label>
-                <input autoComplete="postal-code" className={fieldClass} value={data.zip ?? ''} onChange={(e) => setField('zip', e.target.value)} />
+                <input autoComplete="postal-code" className={`${fieldClass} bg-slate-50 text-slate-600`} value={data.zip ?? ''} readOnly />
               </div>
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-slate-700">Location display</label>
+              <select
+                className={fieldClass}
+                value={data.locationPrecision ?? (data.expertType === 'creator' ? 'approximate' : 'exact')}
+                onChange={(e) => setField('locationPrecision', e.target.value as Provider['locationPrecision'])}
+              >
+                <option value="exact">Exact area</option>
+                <option value="approximate">Approximate area</option>
+              </select>
+              <p className="mt-2 text-xs leading-6 text-slate-500">
+                {data.expertType === 'creator'
+                  ? 'Creators should usually stay approximate so the public map shows a broader city-level area.'
+                  : 'Choose how precisely your public location should appear in search and map views.'}
+              </p>
             </div>
 
             <div>

--- a/marketlink-frontend/src/components/LocationAutocompleteField.tsx
+++ b/marketlink-frontend/src/components/LocationAutocompleteField.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SuggestionType = 'city' | 'state' | 'postcode' | 'address';
+
+export type LocationSuggestion = {
+  label?: string | null;
+  city?: string | null;
+  state?: string | null;
+  stateCode?: string | null;
+  zip?: string | null;
+  latitude?: number;
+  longitude?: number;
+};
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onResolve?: (suggestion: LocationSuggestion) => void;
+  type: SuggestionType;
+  placeholder?: string;
+  required?: boolean;
+  fieldClass: string;
+  autoComplete?: string;
+  inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
+  maxLength?: number;
+  helperText?: string;
+};
+
+function getMinimumCharacters(type: SuggestionType) {
+  if (type === 'postcode') return 3;
+  return 2;
+}
+
+function getDisplayValue(type: SuggestionType, suggestion: LocationSuggestion) {
+  if (type === 'postcode') return suggestion.zip || '';
+  if (type === 'state') return suggestion.state || suggestion.stateCode || '';
+  if (type === 'address') return suggestion.label || '';
+  return suggestion.city || '';
+}
+
+function getSuggestionLabel(type: SuggestionType, suggestion: LocationSuggestion) {
+  if (type === 'address') {
+    return suggestion.label || '';
+  }
+  if (type === 'postcode') {
+    const cityState = [suggestion.city, suggestion.stateCode || suggestion.state].filter(Boolean).join(', ');
+    return [suggestion.zip, cityState].filter(Boolean).join(' - ');
+  }
+
+  if (type === 'state') {
+    if (suggestion.state && suggestion.stateCode) {
+      return `${suggestion.state} (${suggestion.stateCode})`;
+    }
+    return suggestion.state || suggestion.stateCode || suggestion.label || '';
+  }
+
+  const statePart = suggestion.stateCode || suggestion.state;
+  return [suggestion.city, statePart].filter(Boolean).join(', ');
+}
+
+export default function LocationAutocompleteField({
+  label,
+  value,
+  onChange,
+  onResolve,
+  type,
+  placeholder,
+  required,
+  fieldClass,
+  autoComplete,
+  inputMode,
+  maxLength,
+  helperText,
+}: Props) {
+  const listId = useId();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [selectionError, setSelectionError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
+  const fetchIdRef = useRef(0);
+  const confirmedSelectionRef = useRef(true);
+
+  const trimmedValue = value.trim();
+  const minCharacters = useMemo(() => getMinimumCharacters(type), [type]);
+
+  useEffect(() => {
+    if (trimmedValue.length < minCharacters) {
+      setSuggestions([]);
+      setLoading(false);
+      return;
+    }
+
+    const currentFetchId = ++fetchIdRef.current;
+    setLoading(true);
+
+    const timeout = window.setTimeout(async () => {
+      try {
+        const params = new URLSearchParams({ q: trimmedValue, type });
+        const res = await fetch(`${API_BASE}/location/autocomplete?${params.toString()}`, {
+          method: 'GET',
+          credentials: 'include',
+        });
+
+        if (!res.ok) {
+          if (currentFetchId === fetchIdRef.current) {
+            setSuggestions([]);
+          }
+          return;
+        }
+
+        const body = (await res.json().catch(() => null)) as { suggestions?: LocationSuggestion[] } | null;
+        if (currentFetchId !== fetchIdRef.current) {
+          return;
+        }
+
+        setSuggestions(Array.isArray(body?.suggestions) ? body!.suggestions! : []);
+      } finally {
+        if (currentFetchId === fetchIdRef.current) {
+          setLoading(false);
+        }
+      }
+    }, 220);
+
+    return () => window.clearTimeout(timeout);
+  }, [minCharacters, trimmedValue, type]);
+
+  const handleSelect = (suggestion: LocationSuggestion) => {
+    confirmedSelectionRef.current = true;
+    setSelectionError(null);
+    onChange(getDisplayValue(type, suggestion));
+    onResolve?.(suggestion);
+    setOpen(false);
+    setSuggestions([]);
+  };
+
+  const handleBlur = () => {
+    window.setTimeout(() => {
+      setOpen(false);
+
+      if (!trimmedValue) {
+        confirmedSelectionRef.current = true;
+        setSelectionError(null);
+        return;
+      }
+
+      if (confirmedSelectionRef.current) {
+        setSelectionError(null);
+        return;
+      }
+
+      onChange('');
+      setSuggestions([]);
+      setSelectionError('Choose a value from the dropdown.');
+    }, 120);
+  };
+
+  const showSuggestions = open && suggestions.length > 0;
+
+  return (
+    <div className="relative">
+      <label className="mb-1 block text-sm font-medium text-slate-700">{label}</label>
+      <input
+        className={fieldClass}
+        value={value}
+        onChange={(e) => {
+          confirmedSelectionRef.current = false;
+          setSelectionError(null);
+          onChange(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        required={required}
+        autoComplete={autoComplete}
+        inputMode={inputMode}
+        maxLength={maxLength}
+        aria-autocomplete="list"
+        aria-controls={listId}
+      />
+
+      {helperText ? <p className="mt-2 text-xs leading-6 text-slate-500">{helperText}</p> : null}
+      {selectionError ? <p className="mt-2 text-xs leading-6 text-red-600">{selectionError}</p> : null}
+
+      {showSuggestions ? (
+        <div id={listId} className="absolute z-30 mt-2 w-full overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-[0_18px_50px_rgba(15,23,42,0.12)]">
+          <ul className="max-h-64 overflow-y-auto py-2">
+            {suggestions.map((suggestion, index) => (
+              <li key={`${getSuggestionLabel(type, suggestion)}-${index}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(suggestion);
+                  }}
+                  className="w-full px-4 py-3 text-left text-sm text-slate-700 transition hover:bg-slate-50"
+                >
+                  {getSuggestionLabel(type, suggestion)}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {open && loading && trimmedValue.length >= minCharacters ? <p className="mt-2 text-xs text-slate-500">Looking up suggestions...</p> : null}
+    </div>
+  );
+}

--- a/marketlink-frontend/src/lib/usStates.ts
+++ b/marketlink-frontend/src/lib/usStates.ts
@@ -1,0 +1,77 @@
+export const US_STATES = [
+  { code: 'AL', name: 'Alabama' },
+  { code: 'AK', name: 'Alaska' },
+  { code: 'AZ', name: 'Arizona' },
+  { code: 'AR', name: 'Arkansas' },
+  { code: 'CA', name: 'California' },
+  { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' },
+  { code: 'DE', name: 'Delaware' },
+  { code: 'DC', name: 'District of Columbia' },
+  { code: 'FL', name: 'Florida' },
+  { code: 'GA', name: 'Georgia' },
+  { code: 'HI', name: 'Hawaii' },
+  { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' },
+  { code: 'IN', name: 'Indiana' },
+  { code: 'IA', name: 'Iowa' },
+  { code: 'KS', name: 'Kansas' },
+  { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' },
+  { code: 'ME', name: 'Maine' },
+  { code: 'MD', name: 'Maryland' },
+  { code: 'MA', name: 'Massachusetts' },
+  { code: 'MI', name: 'Michigan' },
+  { code: 'MN', name: 'Minnesota' },
+  { code: 'MS', name: 'Mississippi' },
+  { code: 'MO', name: 'Missouri' },
+  { code: 'MT', name: 'Montana' },
+  { code: 'NE', name: 'Nebraska' },
+  { code: 'NV', name: 'Nevada' },
+  { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' },
+  { code: 'NY', name: 'New York' },
+  { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' },
+  { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' },
+  { code: 'PA', name: 'Pennsylvania' },
+  { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' },
+  { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' },
+  { code: 'UT', name: 'Utah' },
+  { code: 'VT', name: 'Vermont' },
+  { code: 'VA', name: 'Virginia' },
+  { code: 'WA', name: 'Washington' },
+  { code: 'WV', name: 'West Virginia' },
+  { code: 'WI', name: 'Wisconsin' },
+  { code: 'WY', name: 'Wyoming' },
+] as const;
+
+const STATE_CODE_TO_NAME = new Map(US_STATES.map((item) => [item.code, item.name]));
+const STATE_NAME_TO_CODE = new Map(US_STATES.map((item) => [item.name.toLowerCase(), item.code]));
+
+export function normalizeStateCode(value: string) {
+  const raw = value.trim();
+  if (!raw) return '';
+
+  const upper = raw.toUpperCase();
+  if (STATE_CODE_TO_NAME.has(upper)) {
+    return upper;
+  }
+
+  return STATE_NAME_TO_CODE.get(raw.toLowerCase()) || '';
+}
+
+export function getStateDisplayName(value: string) {
+  const code = normalizeStateCode(value);
+  if (code) {
+    return STATE_CODE_TO_NAME.get(code) || value;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- add exact address capture and Geoapify-backed location autocomplete for onboarding and profile editing
- auto-fill city, state, and ZIP from the selected address
- guard onboarding so only logged-in users without an existing expert can access it
- add product inspiration guidance for Winnie and Thumbtack to the repo docs

## Backend
- add streetAddress to the Expert schema and migration
- extend geocoding helpers and location lookup routes for exact-address autocomplete
- expose streetAddress from account and provider routes

## Frontend
- add a shared LocationAutocompleteField component and US state helpers
- move onboarding to an exact-address-first flow with server-side access gating
- update profile editing to use the same exact-address flow and persist the resolved location data
- require an actual dropdown selection instead of accepting arbitrary typed values

## Verification
- 
px tsc --noEmit in marketlink-backend
- 
pm run build in marketlink-frontend

## Notes
- excluded local runtime log artifacts from the branch
- live autocomplete requires GEOAPIFY_API_KEY in backend env