### PR TITLE
MM-100 add buyer ZIP radius discovery controls

### DIFF
--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -8,7 +8,7 @@ import { geocodeExpertLocation, geocodeSearchCenter } from '../lib/geocoding';
 type SortKey = 'newest' | 'name' | 'rating' | 'verified';
 type OrderDir = 'asc' | 'desc';
 type MatchMode = 'any' | 'all';
-type RadiusMiles = 5 | 10 | 25 | 50;
+type RadiusMiles = 5 | 10 | 20 | 50 | 100;
 
 const asSortKey = (v?: string): SortKey => {
   if (v === 'name' || v === 'rating' || v === 'verified') return v;
@@ -106,7 +106,7 @@ const parseOptionalDate = (raw: unknown): Date | null | undefined => {
   return d;
 };
 
-const ALLOWED_RADIUS_MILES = new Set<RadiusMiles>([5, 10, 25, 50]);
+const ALLOWED_RADIUS_MILES = new Set<RadiusMiles>([5, 10, 20, 50, 100]);
 
 const parseRadiusMiles = (raw: unknown): RadiusMiles | undefined | 'invalid' => {
   if (typeof raw === 'undefined') return undefined;
@@ -219,7 +219,7 @@ const listQuerySchema = {
     name: { type: 'string' },
     city: { type: 'string' },
     zip: { type: 'string' },
-    radius: { type: 'string', enum: ['5', '10', '25', '50'] },
+    radius: { type: 'string', enum: ['5', '10', '20', '50', '100'] },
     service: { type: 'string' }, // comma-separated services
     minRating: { type: 'string', pattern: '^[0-9]+(\\.[0-9]+)?$' }, // keep string, we parse to number
     verified: { type: 'string' }, // "1" | "true" | "0" | "false"
@@ -432,10 +432,13 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
       const radiusMiles = parseRadiusMiles(radiusRaw);
 
       if (radiusMiles === 'invalid') {
-        return reply.code(400).send({ error: 'radius must be one of: 5, 10, 25, 50.' });
+        return reply.code(400).send({ error: 'radius must be one of: 5, 10, 20, 50, 100.' });
       }
       if (Boolean(zipQuery) !== Boolean(radiusMiles)) {
         return reply.code(400).send({ error: 'zip and radius must be provided together.' });
+      }
+      if (zipQuery && !/^\d{5}$/.test(zipQuery)) {
+        return reply.code(400).send({ error: 'zip must be a 5-digit US ZIP code.' });
       }
 
       const andFilters: Prisma.ExpertWhereInput[] = [];

--- a/marketlink-frontend/src/app/experts/page.tsx
+++ b/marketlink-frontend/src/app/experts/page.tsx
@@ -7,6 +7,7 @@ import {
   getDiscoveryServicePathsForProblem,
 } from '@/lib/discovery';
 import type { DiscoveryProblemCard } from '@/lib/discovery';
+import NearbyRadiusField from '@/components/NearbyRadiusField';
 
 export const metadata: Metadata = {
   title: 'Experts | MarketLink',
@@ -33,11 +34,13 @@ type Provider = {
   minProjectBudget?: number | null;
   currencyCode?: string | null;
   createdAt: string;
+  distanceMiles?: number;
 };
 
 type FiltersFormProps = {
   name?: string;
-  city?: string;
+  zip?: string;
+  radius?: string;
   service?: string;
   problemId?: string;
   match: 'any' | 'all';
@@ -79,7 +82,7 @@ function formatAudienceSize(value: number | null | undefined) {
   }).format(value);
 }
 
-function FiltersForm({ name, city, service, problemId, match, minRating, sort, order, limit, verified, compact = false }: FiltersFormProps) {
+function FiltersForm({ name, zip, radius, service, problemId, match, minRating, sort, order, limit, verified, compact = false }: FiltersFormProps) {
   return (
     <form method="GET" className={`grid gap-4 ${compact ? '' : 'lg:grid-cols-12'}`}>
       <input type="hidden" name="page" value="1" />
@@ -96,16 +99,16 @@ function FiltersForm({ name, city, service, problemId, match, minRating, sort, o
         />
       </label>
 
-      <label className={compact ? '' : 'lg:col-span-2'}>
-        <span className="mb-2 block text-sm font-medium text-slate-700">City</span>
-        <input
-          type="text"
-          name="city"
-          defaultValue={city ?? ''}
-          placeholder="Chicago"
-          className={FIELD_CLASS}
+      <div className={compact ? '' : 'lg:col-span-4'}>
+        <NearbyRadiusField
+          initialZip={zip}
+          initialRadius={radius}
+          fieldClassName={FIELD_CLASS}
+          zipLabel="ZIP code"
+          zipPlaceholder="60559"
+          helperText="Search nearby experts by ZIP. The slider appears once the ZIP is ready."
         />
-      </label>
+      </div>
 
       <label className={compact ? '' : 'lg:col-span-3'}>
         <span className="mb-2 block text-sm font-medium text-slate-700">Service</span>
@@ -247,6 +250,12 @@ function ProviderCard({ provider }: { provider: Provider }) {
                   <span>
                     {p.city}, {p.state}
                   </span>
+                  {typeof p.distanceMiles === 'number' ? (
+                    <>
+                      <span aria-hidden="true">/</span>
+                      <span className="text-slate-700">{p.distanceMiles} miles away</span>
+                    </>
+                  ) : null}
                   {p.verified ? (
                     <>
                       <span aria-hidden="true">/</span>
@@ -429,7 +438,8 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
   const resolvedSearchParams = await searchParams;
 
   const name = typeof resolvedSearchParams.name === 'string' ? resolvedSearchParams.name : undefined;
-  const city = typeof resolvedSearchParams.city === 'string' ? resolvedSearchParams.city : undefined;
+  const zip = typeof resolvedSearchParams.zip === 'string' ? resolvedSearchParams.zip : undefined;
+  const radius = typeof resolvedSearchParams.radius === 'string' ? resolvedSearchParams.radius : undefined;
   const service = typeof resolvedSearchParams.service === 'string' ? resolvedSearchParams.service : undefined;
   const problemId = typeof resolvedSearchParams.problem === 'string' ? resolvedSearchParams.problem : undefined;
   const problemContext = getDiscoveryProblemById(problemId);
@@ -444,7 +454,8 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
 
   const qs = toQS({
     name,
-    city,
+    zip,
+    radius,
     service,
     match,
     minRating,
@@ -481,7 +492,8 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
 
   const baseParams = {
     name,
-    city,
+    zip,
+    radius,
     service,
     problem: problemContext?.id,
     match,
@@ -498,7 +510,8 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
 
   const activeFilters = [
     name ? { label: `Name: ${name}` } : null,
-    city ? { label: `City: ${city}` } : null,
+    zip ? { label: `ZIP: ${zip}` } : null,
+    radius ? { label: `Radius: ${radius} miles` } : null,
     service ? { label: `Service: ${service}` } : null,
     minRating ? { label: `Rating ${minRating}+` } : null,
     verified === '1' || (verified ?? '').toLowerCase() === 'true' ? { label: 'Verified only' } : null,
@@ -511,9 +524,9 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl">
               <div className="text-[11px] font-medium uppercase tracking-[0.26em] text-slate-500">Expert directory</div>
-              <h1 className="mt-3 text-[2rem] font-semibold tracking-[-0.04em] text-slate-900 sm:text-4xl">Find local experts by city, service, and fit.</h1>
+              <h1 className="mt-3 text-[2rem] font-semibold tracking-[-0.04em] text-slate-900 sm:text-4xl">Find local experts by ZIP, distance, service, and fit.</h1>
               <p className="mt-3 text-sm leading-7 text-slate-600">
-                Use filters to narrow the list quickly, then open expert profiles to compare services, pricing guidance, and contact details.
+                Search by ZIP and radius, then compare nearby experts by service, trust, pricing guidance, and proof.
               </p>
             </div>
             <div className="ml-dark-panel w-full rounded-[1.4rem] px-5 py-4 text-white sm:w-auto">
@@ -551,7 +564,7 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
                     Clear filters
                   </Link>
                 </div>
-                <FiltersForm name={name} city={city} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
+                <FiltersForm name={name} zip={zip} radius={radius} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
               </div>
             </details>
           </section>
@@ -569,7 +582,7 @@ export default async function ProvidersPage({ searchParams }: ProvidersPageProps
             </div>
 
             <div className="mt-5">
-              <FiltersForm name={name} city={city} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
+              <FiltersForm name={name} zip={zip} radius={radius} service={service} problemId={problemContext?.id} match={match} minRating={minRating} sort={sort} order={order} limit={limit} verified={verified} compact />
             </div>
           </aside>
 

--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { HomepageDiscoveryAnimation } from '@/components/HomepageDiscoveryAnimation';
+import NearbyRadiusField from '@/components/NearbyRadiusField';
 import { useMarketLinkTheme } from '@/components/ThemeToggle';
 import {
   getDiscoveryProblemHref,
@@ -62,6 +63,27 @@ export default function Home() {
               Help me choose
             </Link>
           </div>
+
+          <form action="/experts" method="GET" className="mt-5 grid gap-3 rounded-[1.4rem] bg-white/85 p-4 shadow-sm ring-1 ring-slate-200/80">
+            <div>
+              <div className={`text-[11px] font-medium uppercase tracking-[0.22em] ${t.mutedText}`}>Search nearby</div>
+              <p className="mt-1 text-sm text-slate-700">Enter your ZIP and choose how far you want to search.</p>
+            </div>
+            <NearbyRadiusField
+              initialRadius="10"
+              zipRequired
+              fieldClassName="rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:ring-2 focus:ring-slate-200/70"
+              zipLabel="ZIP code"
+              zipPlaceholder="ZIP code"
+              helperText="Start with a 5-digit ZIP code. Then choose how far out to look."
+            />
+            <button
+              type="submit"
+              className={`inline-flex min-h-12 items-center justify-center rounded-2xl px-5 text-sm font-semibold shadow-sm ${t.primaryBtn}`}
+            >
+              Search nearby experts
+            </button>
+          </form>
 
           <HomepageDiscoveryAnimation compact />
 
@@ -130,6 +152,28 @@ export default function Home() {
                   Browse local experts
                 </Link>
               </div>
+
+              <form action="/experts" method="GET" className="grid max-w-xl gap-3 rounded-[1.55rem] bg-white/90 p-4 shadow-sm ring-1 ring-slate-200/80 sm:grid-cols-[minmax(0,1fr)_180px_auto]">
+                <label className="sm:col-span-3">
+                  <span className={`mb-2 block text-[11px] font-medium uppercase tracking-[0.22em] ${t.mutedText}`}>Search nearby</span>
+                </label>
+                <div className="sm:col-span-2">
+                  <NearbyRadiusField
+                    initialRadius="10"
+                    zipRequired
+                    fieldClassName="rounded-xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:ring-2 focus:ring-slate-200/70"
+                    zipLabel="ZIP code"
+                    zipPlaceholder="Enter ZIP code"
+                    helperText="Use your ZIP to unlock the distance slider and start nearby discovery."
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className={`inline-flex min-h-12 items-center justify-center rounded-xl px-5 text-sm font-semibold shadow-sm sm:self-start ${t.primaryBtn}`}
+                >
+                  Search nearby
+                </button>
+              </form>
 
               <HomepageDiscoveryAnimation />
             </div>

--- a/marketlink-frontend/src/components/NearbyRadiusField.tsx
+++ b/marketlink-frontend/src/components/NearbyRadiusField.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+const RADIUS_VALUES = [5, 10, 20, 50, 100] as const;
+
+type Props = {
+  initialZip?: string;
+  initialRadius?: string;
+  zipRequired?: boolean;
+  fieldClassName: string;
+  zipLabel?: string;
+  zipPlaceholder?: string;
+  helperText?: string;
+};
+
+function getInitialRadiusIndex(initialRadius?: string) {
+  const parsed = Number(initialRadius);
+  const index = RADIUS_VALUES.findIndex((value) => value === parsed);
+  return index >= 0 ? index : 1;
+}
+
+export default function NearbyRadiusField({
+  initialZip = '',
+  initialRadius = '10',
+  zipRequired = false,
+  fieldClassName,
+  zipLabel = 'ZIP code',
+  zipPlaceholder = '60559',
+  helperText,
+}: Props) {
+  const [zip, setZip] = useState(initialZip.replace(/\D/g, '').slice(0, 5));
+  const [radiusIndex, setRadiusIndex] = useState(getInitialRadiusIndex(initialRadius));
+  const [geolocationEnabled, setGeolocationEnabled] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let permissionStatus: PermissionStatus | null = null;
+
+    async function checkPermission() {
+      if (typeof navigator === 'undefined' || !('geolocation' in navigator) || !('permissions' in navigator)) {
+        return;
+      }
+
+      try {
+        permissionStatus = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
+        if (!active) return;
+
+        const syncState = () => {
+          if (!active) return;
+          setGeolocationEnabled(permissionStatus?.state === 'granted');
+        };
+
+        syncState();
+        permissionStatus.onchange = syncState;
+      } catch {
+        // Keep geolocation as an optional progressive enhancement only.
+      }
+    }
+
+    checkPermission();
+
+    return () => {
+      active = false;
+      if (permissionStatus) {
+        permissionStatus.onchange = null;
+      }
+    };
+  }, []);
+
+  const showSlider = zip.length === 5 || geolocationEnabled;
+  const selectedRadius = useMemo(() => RADIUS_VALUES[radiusIndex], [radiusIndex]);
+
+  return (
+    <div className="grid gap-3">
+      <label>
+        <span className="mb-2 block text-sm font-medium text-slate-700">{zipLabel}</span>
+        <input
+          type="search"
+          name="zip"
+          value={zip}
+          onChange={(e) => setZip(e.target.value.replace(/\D/g, '').slice(0, 5))}
+          inputMode="numeric"
+          pattern="\d{5}"
+          maxLength={5}
+          placeholder={zipPlaceholder}
+          className={fieldClassName}
+          title="Enter a 5-digit ZIP code."
+          required={zipRequired}
+        />
+      </label>
+
+      {zip.length > 0 && zip.length < 5 ? (
+        <p className="text-xs leading-6 text-red-600">Enter a full 5-digit ZIP code.</p>
+      ) : helperText ? (
+        <p className="text-xs leading-6 text-slate-500">{helperText}</p>
+      ) : null}
+
+      {showSlider ? (
+        <div className="rounded-[1.15rem] border border-slate-200/80 bg-white/90 px-4 py-4 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-sm font-medium text-slate-800">Radius</div>
+            <div className="text-sm font-semibold text-slate-900">{selectedRadius} miles</div>
+          </div>
+
+          <input
+            type="range"
+            min={0}
+            max={RADIUS_VALUES.length - 1}
+            step={1}
+            value={radiusIndex}
+            onChange={(e) => setRadiusIndex(Number(e.target.value))}
+            className="mt-4 h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-200 accent-slate-900"
+            aria-label="Search radius"
+          />
+
+          <div className="mt-3 flex items-center justify-between text-[11px] font-medium text-slate-500">
+            {RADIUS_VALUES.map((value) => (
+              <span key={value}>{value}</span>
+            ))}
+          </div>
+
+          <p className="mt-3 text-xs leading-6 text-slate-600">
+            {zip.length === 5
+              ? `${selectedRadius} miles from ZIP code ${zip}`
+              : `${selectedRadius} mile radius is ready. Enter a ZIP code to search nearby experts.`}
+          </p>
+
+          {zip.length === 5 ? <input type="hidden" name="radius" value={String(selectedRadius)} /> : null}
+        </div>
+      ) : (
+        <p className="text-xs leading-6 text-slate-500">Enter a 5-digit ZIP code to unlock the distance slider.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add buyer-side ZIP + radius discovery controls to the homepage and expert directory
- replace the radius dropdown with a slider that only appears when ZIP is ready or geolocation permission is already granted
- show distance labels on expert cards when radius search is active
- extend backend radius validation to support 5, 10, 20, 50, and 100 miles

## Backend
- update /experts radius validation to accept 5, 10, 20, 50, and 100
- validate ZIP as a 5-digit US ZIP when radius search is used

## Frontend
- add shared NearbyRadiusField component
- homepage now hands off to /experts?zip=...&radius=...
- expert directory now uses ZIP + radius instead of city as the primary locality filter
- radius note shows X miles from ZIP code ...
- slider only submits radius when ZIP is valid

## Live QA
- homepage ZIP field renders
- slider is hidden before ZIP entry and appears after entering a valid ZIP
- note updates to 10 miles from ZIP code 60559
- homepage handoff navigates to /experts?zip=60559&radius=10
- expert result cards show proximity labels such as 1.3 miles away
- invalid directory ZIP shows browser validation message

## Verification
- 
px tsc --noEmit in marketlink-backend
- 
px eslint src/app/page.tsx src/app/experts/page.tsx src/components/NearbyRadiusField.tsx in marketlink-frontend
- 
pm run build in marketlink-frontend

## Note
- full backend 
pm run build is still subject to the local Windows Prisma DLL file-lock issue during prisma generate; backend typecheck itself passed