### PR TITLE
MM-102 harden location privacy and map QA

### DIFF
--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -129,6 +129,48 @@ const haversineMiles = (fromLat: number, fromLng: number, toLat: number, toLng: 
   return earthRadiusMiles * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
 };
 
+const roundCoordinate = (value: number, decimals = 1) => {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+};
+
+const sanitizePublicExpertLocation = <
+  T extends {
+    expertType?: ExpertType | null;
+    locationPrecision?: LocationPrecision | null;
+    streetAddress?: string | null;
+    zip?: string | null;
+    latitude?: number | null;
+    longitude?: number | null;
+  },
+>(
+  expert: T,
+): T => {
+  if (expert.expertType !== ExpertType.creator || expert.locationPrecision !== LocationPrecision.approximate) {
+    return expert;
+  }
+
+  const next = { ...expert };
+
+  if ('streetAddress' in next) {
+    next.streetAddress = null;
+  }
+
+  if ('zip' in next) {
+    next.zip = null;
+  }
+
+  if (typeof next.latitude === 'number') {
+    next.latitude = roundCoordinate(next.latitude);
+  }
+
+  if (typeof next.longitude === 'number') {
+    next.longitude = roundCoordinate(next.longitude);
+  }
+
+  return next;
+};
+
 const expertProjectSelect = {
   id: true,
   title: true,
@@ -569,6 +611,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
         zip: true,
         latitude: true,
         longitude: true,
+        locationPrecision: true,
         verified: true,
         logo: true,
         services: true,
@@ -642,7 +685,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
           sort: sortKey,
           order: primaryOrder,
         },
-        data: rows,
+        data: rows.map((row) => sanitizePublicExpertLocation(row)),
       });
       },
     );
@@ -657,7 +700,7 @@ const expertsRoutes: FastifyPluginAsync = async (fastify) => {
         where: { slug, status: ExpertStatus.active },
         select: expertDetailSelect,
       });
-      if (active) return reply.send(active);
+      if (active) return reply.send(sanitizePublicExpertLocation(active));
 
       const nonActive = await prisma.expert.findUnique({
         where: { slug },

--- a/marketlink-frontend/src/app/experts/[slug]/page.tsx
+++ b/marketlink-frontend/src/app/experts/[slug]/page.tsx
@@ -23,6 +23,7 @@ type Provider = {
   businessName: string;
   email: string;
   expertType?: 'agency' | 'freelancer' | 'creator' | 'specialist' | null;
+  locationPrecision?: 'exact' | 'approximate' | null;
   tagline: string | null;
   shortDescription?: string | null;
   overview?: string | null;
@@ -596,6 +597,11 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                         <span className={`rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em] ${t.brandBadge}`}>
                           {locationLabel}
                         </span>
+                        {p.expertType === 'creator' && p.locationPrecision === 'approximate' ? (
+                          <span className="ml-pill-muted rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.18em]">
+                            Approximate area
+                          </span>
+                        ) : null}
                       </div>
 
                       <div className="mt-5 grid grid-cols-[auto_minmax(0,1fr)] items-start gap-4 md:gap-5">
@@ -1184,6 +1190,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                   <ExpertProfileMap
                     businessName={p.businessName}
                     locationLabel={locationLabel}
+                    locationPrecision={p.locationPrecision}
                     latitude={p.latitude}
                     longitude={p.longitude}
                   />

--- a/marketlink-frontend/src/app/experts/page.tsx
+++ b/marketlink-frontend/src/app/experts/page.tsx
@@ -18,6 +18,7 @@ type Provider = {
   slug: string;
   businessName: string;
   expertType?: 'agency' | 'freelancer' | 'creator' | 'specialist' | null;
+  locationPrecision?: 'exact' | 'approximate' | null;
   tagline: string | null;
   shortDescription?: string | null;
   city: string;
@@ -378,7 +379,13 @@ function ProviderCard({ provider }: { provider: Provider }) {
               <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">Starting price</div>
               <div className="mt-2 text-lg font-semibold text-slate-900">{pricingLabel}</div>
               <div className="mt-2 text-sm text-slate-600">
-                {provider.zip ? `ZIP ${provider.zip}` : provider.verified ? 'Verified expert' : 'Profile available'}
+                {provider.expertType === 'creator' && provider.locationPrecision === 'approximate'
+                  ? 'Approximate area shown'
+                  : provider.zip
+                  ? `ZIP ${provider.zip}`
+                  : provider.verified
+                  ? 'Verified expert'
+                  : 'Profile available'}
               </div>
               <div className="mt-5 inline-flex items-center gap-2 text-sm font-semibold text-slate-900">
                 Open profile

--- a/marketlink-frontend/src/components/ExpertProfileMap.tsx
+++ b/marketlink-frontend/src/components/ExpertProfileMap.tsx
@@ -7,6 +7,7 @@ import maplibregl from 'maplibre-gl';
 type Props = {
   businessName: string;
   locationLabel: string;
+  locationPrecision?: 'exact' | 'approximate' | null;
   latitude?: number | null;
   longitude?: number | null;
 };
@@ -30,13 +31,17 @@ const MAP_STYLE = {
   ],
 } as const;
 
-export default function ExpertProfileMap({ businessName, locationLabel, latitude, longitude }: Props) {
+export default function ExpertProfileMap({ businessName, locationLabel, locationPrecision, latitude, longitude }: Props) {
+  const isApproximate = locationPrecision === 'approximate';
+
   if (typeof latitude !== 'number' || typeof longitude !== 'number') {
     return (
       <div className="rounded-[1.25rem] border border-white/10 bg-white/5 px-4 py-4 text-sm text-slate-200">
         <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-400">Map view</div>
         <div className="mt-2 text-white">{locationLabel}</div>
-        <div className="mt-2 text-slate-300">Map coordinates are not available for this expert yet.</div>
+        <div className="mt-2 text-slate-300">
+          {isApproximate ? 'This expert shares an approximate service area instead of an exact pin.' : 'Map coordinates are not available for this expert yet.'}
+        </div>
       </div>
     );
   }
@@ -49,7 +54,7 @@ export default function ExpertProfileMap({ businessName, locationLabel, latitude
           initialViewState={{
             longitude,
             latitude,
-            zoom: 12,
+            zoom: isApproximate ? 10 : 12,
           }}
           mapStyle={MAP_STYLE}
         >
@@ -66,9 +71,12 @@ export default function ExpertProfileMap({ businessName, locationLabel, latitude
         </Map>
 
         <div className="pointer-events-none absolute inset-x-4 bottom-4 rounded-[1.2rem] bg-white/96 px-4 py-4 shadow-[0_18px_40px_rgba(15,23,42,0.16)] ring-1 ring-slate-200/90">
-          <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">Location</div>
+          <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-500">
+            {isApproximate ? 'Approximate area' : 'Location'}
+          </div>
           <div className="mt-1 text-base font-semibold text-slate-900">{businessName}</div>
           <div className="mt-1 text-sm text-slate-600">{locationLabel}</div>
+          {isApproximate ? <div className="mt-1 text-xs font-medium text-slate-500">Shown as a broader city-level area for privacy.</div> : null}
         </div>
       </div>
     </div>

--- a/marketlink-frontend/src/components/ExpertsDiscoveryMap.tsx
+++ b/marketlink-frontend/src/components/ExpertsDiscoveryMap.tsx
@@ -10,6 +10,8 @@ type MapProvider = {
   id: string;
   slug: string;
   businessName: string;
+  expertType?: 'agency' | 'freelancer' | 'creator' | 'specialist' | null;
+  locationPrecision?: 'exact' | 'approximate' | null;
   city: string;
   state: string;
   verified: boolean;
@@ -117,9 +119,14 @@ export default function ExpertsDiscoveryMap({ providers, showDesktop = true, sho
 
     for (const mapInstance of mapRefs) {
       if (cameraProvider) {
+        const targetZoom =
+          cameraProvider.expertType === 'creator' && cameraProvider.locationPrecision === 'approximate'
+            ? 9.5
+            : Math.max(mapInstance.getZoom(), 11);
+
         mapInstance.flyTo({
           center: [cameraProvider.longitude, cameraProvider.latitude],
-          zoom: Math.max(mapInstance.getZoom(), 11),
+          zoom: targetZoom,
           duration: 500,
         });
       } else {
@@ -251,6 +258,9 @@ export default function ExpertsDiscoveryMap({ providers, showDesktop = true, sho
               {focusedProvider.city}, {focusedProvider.state}
               {typeof focusedProvider.distanceMiles === 'number' ? ` | ${focusedProvider.distanceMiles} miles away` : ''}
             </div>
+            {focusedProvider.expertType === 'creator' && focusedProvider.locationPrecision === 'approximate' ? (
+              <div className="mt-1 text-xs font-medium text-slate-500">Approximate area shown for privacy.</div>
+            ) : null}
           </div>
           <div className="flex flex-col items-end gap-2">
             {focusedProvider.verified ? (


### PR DESCRIPTION
## Summary
- harden public location privacy for creator profiles using approximate location precision
- keep ZIP/radius search and exact-location profiles working as before
- update directory and profile map UI to label approximate areas clearly

## Verification
- backend typecheck via local tsc path
- frontend build via npm --prefix marketlink-frontend run build
- local API checks for /location/zip/:zip, /experts?zip=60559&radius=10, and /experts/:slug
