### PR TITLE
MM-32 promote testimonials as the main proof block

### DIFF
--- a/marketlink-backend/src/routes/providers.ts
+++ b/marketlink-backend/src/routes/providers.ts
@@ -331,6 +331,10 @@ const expertDetailSelect = {
     select: expertMediaSelect,
     orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
   },
+  reviews: {
+    select: expertReviewSelect,
+    orderBy: [{ sortOrder: 'asc' }, { publishedAt: 'desc' }, { createdAt: 'asc' }],
+  },
   certifications: {
     select: expertCertificationSelect,
     orderBy: [{ sortOrder: 'asc' }, { year: 'desc' }, { createdAt: 'asc' }],

--- a/marketlink-frontend/src/app/experts/[slug]/page.tsx
+++ b/marketlink-frontend/src/app/experts/[slug]/page.tsx
@@ -239,6 +239,13 @@ function formatLocation(city: string, state: string, zip: string | null) {
   return [city, state, zip].filter(Boolean).join(', ');
 }
 
+function formatPublishedDate(value: string | null | undefined) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString();
+}
+
 function truncateCopy(value: string | null | undefined, maxLength = 220) {
   if (!value) return null;
   const normalized = value.replace(/\s+/g, ' ').trim();
@@ -369,13 +376,16 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
   const pageSurface = t.surface;
   const pageSurfaceMuted = t.surfaceMuted;
   const [instagramSlide, setInstagramSlide] = useState(0);
+  const [reviewSlide, setReviewSlide] = useState(0);
   const [projectSlide, setProjectSlide] = useState(0);
   useEffect(() => {
     setInstagramSlide(0);
+    setReviewSlide(0);
     setProjectSlide(0);
   }, [p.slug]);
   const featuredProjects = (p.projects || []).filter((project) => project.isFeatured);
   const visibleProjects = featuredProjects.length ? featuredProjects : p.projects || [];
+  const visibleReviews = p.reviews || [];
   const featuredClients = (p.clients || []).filter((client) => client.isFeatured);
   const visibleClients = featuredClients.length ? featuredClients : p.clients || [];
   const visibleCertifications = p.certifications || [];
@@ -447,6 +457,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
   const instagramProofItems = visibleMedia.filter((item) => getMediaPresentation(item).kind === 'embed').slice(0, 10);
   const activeInstagramItem = instagramProofItems.length ? instagramProofItems[instagramSlide % instagramProofItems.length] : null;
   const activeInstagramMedia = activeInstagramItem ? getMediaPresentation(activeInstagramItem) : null;
+  const activeReview = visibleReviews.length ? visibleReviews[reviewSlide % visibleReviews.length] : null;
   const activeProject = visibleProjects.length ? visibleProjects[projectSlide % visibleProjects.length] : null;
   const instagramProfilePreview = instagramProfileLink;
   const instagramProfileEmbedUrl = instagramProfilePreview ? `${instagramProfilePreview.href}?utm_source=ig_embed&utm_campaign=loading` : null;
@@ -869,12 +880,92 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                         </div>
                       ) : null}
 
+                      {activeReview ? (
+                        <section className={`mt-5 rounded-[1.35rem] ${pageSurfaceMuted} ${pageBorder} border px-4 py-4 shadow-sm`}>
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Testimonials</div>
+                              <h3 className="mt-2 text-lg font-semibold text-slate-900">What clients said after the work shipped</h3>
+                            </div>
+                            <span className="ml-pill rounded-full px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em]">
+                              {reviewSlide + 1} / {visibleReviews.length}
+                            </span>
+                          </div>
+
+                          <div className="mt-4 rounded-[1.15rem] border border-slate-200/80 bg-white/88 px-4 py-4 shadow-sm">
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Verified client feedback</div>
+                                <div className="mt-1 text-base font-semibold text-slate-900">
+                                  {activeReview.title || `${activeReview.reviewerName}${activeReview.company ? ` · ${activeReview.company}` : ''}`}
+                                </div>
+                              </div>
+                              <div className="shrink-0 rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
+                                {activeReview.rating.toFixed(1)} / 5
+                              </div>
+                            </div>
+
+                            <p className="mt-3 text-sm leading-7 text-slate-700">{truncateCopy(activeReview.body, 220)}</p>
+
+                            <div className="mt-4 flex flex-wrap gap-2">
+                              <span className="rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
+                                {activeReview.reviewerName}
+                              </span>
+                              {activeReview.company ? (
+                                <span className="rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
+                                  {activeReview.company}
+                                </span>
+                              ) : null}
+                              {activeReview.projectSummary ? (
+                                <span className="ml-pill rounded-full px-3 py-1.5 text-xs">
+                                  {truncateCopy(activeReview.projectSummary, 48)}
+                                </span>
+                              ) : null}
+                              {activeReview.source ? (
+                                <span className="rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
+                                  {activeReview.source}
+                                </span>
+                              ) : null}
+                              {formatPublishedDate(activeReview.publishedAt) ? (
+                                <span className="rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
+                                  {formatPublishedDate(activeReview.publishedAt)}
+                                </span>
+                              ) : null}
+                              {activeReview.verified ? (
+                                <span className="rounded-full border border-emerald-200/90 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700">
+                                  Verified
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+
+                          {visibleReviews.length > 1 ? (
+                            <div className="mt-3 flex items-center justify-between gap-3">
+                              <button
+                                type="button"
+                                onClick={() => setReviewSlide((current) => (current - 1 + visibleReviews.length) % visibleReviews.length)}
+                                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-900 shadow-sm"
+                              >
+                                Prev
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setReviewSlide((current) => (current + 1) % visibleReviews.length)}
+                                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-900 shadow-sm"
+                              >
+                                Next
+                              </button>
+                            </div>
+                          ) : null}
+                        </section>
+                      ) : null}
+
                       {activeProject ? (
                         <section className={`mt-5 rounded-[1.35rem] ${pageSurfaceMuted} ${pageBorder} border px-4 py-4 shadow-sm`}>
                           <div className="flex items-start justify-between gap-3">
                             <div>
-                              <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Proof of work</div>
-                              <h3 className="mt-2 text-lg font-semibold text-slate-900">What this expert has already done</h3>
+                              <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>{activeReview ? 'Supporting proof' : 'Proof of work'}</div>
+                              <h3 className="mt-2 text-lg font-semibold text-slate-900">{activeReview ? 'Selected project behind the testimonial' : 'What this expert has already done'}</h3>
                             </div>
                             <span className="ml-pill rounded-full px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em]">
                               {projectSlide + 1} / {visibleProjects.length}

--- a/marketlink-frontend/src/app/experts/[slug]/page.tsx
+++ b/marketlink-frontend/src/app/experts/[slug]/page.tsx
@@ -905,7 +905,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                               </div>
                             </div>
 
-                            <p className="mt-3 text-sm leading-7 text-slate-700">{truncateCopy(activeReview.body, 220)}</p>
+                            <p className="mt-3 text-sm leading-6 text-slate-700">{truncateCopy(activeReview.body, 170)}</p>
 
                             <div className="mt-4 flex flex-wrap gap-2">
                               <span className="rounded-full border border-slate-200/90 bg-slate-50 px-3 py-1.5 text-xs font-semibold text-slate-800">
@@ -918,7 +918,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                               ) : null}
                               {activeReview.projectSummary ? (
                                 <span className="ml-pill rounded-full px-3 py-1.5 text-xs">
-                                  {truncateCopy(activeReview.projectSummary, 48)}
+                                  {truncateCopy(activeReview.projectSummary, 38)}
                                 </span>
                               ) : null}
                               {activeReview.source ? (
@@ -965,7 +965,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                           <div className="flex items-start justify-between gap-3">
                             <div>
                               <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>{activeReview ? 'Supporting proof' : 'Proof of work'}</div>
-                              <h3 className="mt-2 text-lg font-semibold text-slate-900">{activeReview ? 'Selected project behind the testimonial' : 'What this expert has already done'}</h3>
+                              <h3 className="mt-2 text-base font-semibold text-slate-900">{activeReview ? 'Selected project behind the testimonial' : 'What this expert has already done'}</h3>
                             </div>
                             <span className="ml-pill rounded-full px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em]">
                               {projectSlide + 1} / {visibleProjects.length}
@@ -978,7 +978,7 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                                 <div className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Featured project</div>
                                 <div className="mt-1 text-base font-semibold text-slate-900">{activeProject.title}</div>
                                 {activeProject.summary ? (
-                                  <p className="mt-2 text-sm leading-6 text-slate-700">{truncateCopy(activeProject.summary, 84)}</p>
+                                  <p className="mt-2 text-sm leading-6 text-slate-700">{truncateCopy(activeProject.summary, 78)}</p>
                                 ) : null}
                               </div>
                               {activeProject.isFeatured ? <span className="ml-pill shrink-0 rounded-full px-3 py-1 text-[11px] font-medium">Featured</span> : null}
@@ -1003,23 +1003,23 @@ function ProviderPageContent({ provider: p }: { provider: Provider }) {
                             </div>
 
                             {(activeProject.challenge || activeProject.solution || activeProject.results) ? (
-                              <dl className="mt-4 grid gap-2.5 border-t border-slate-200/80 pt-4">
+                              <dl className="mt-4 grid gap-2 border-t border-slate-200/80 pt-4">
                                 {activeProject.challenge ? (
-                                  <div>
+                                  <div className="grid gap-1 sm:grid-cols-[96px_minmax(0,1fr)] sm:items-start">
                                     <dt className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Challenge</dt>
-                                    <dd className="mt-1 text-sm leading-6 text-slate-700">{truncateCopy(activeProject.challenge, 68)}</dd>
+                                    <dd className="text-sm leading-6 text-slate-700">{truncateCopy(activeProject.challenge, 64)}</dd>
                                   </div>
                                 ) : null}
                                 {activeProject.solution ? (
-                                  <div>
+                                  <div className="grid gap-1 sm:grid-cols-[96px_minmax(0,1fr)] sm:items-start">
                                     <dt className={`text-[11px] font-medium uppercase tracking-[0.18em] ${t.mutedText}`}>Approach</dt>
-                                    <dd className="mt-1 text-sm leading-6 text-slate-700">{truncateCopy(activeProject.solution, 68)}</dd>
+                                    <dd className="text-sm leading-6 text-slate-700">{truncateCopy(activeProject.solution, 64)}</dd>
                                   </div>
                                 ) : null}
                                 {activeProject.results ? (
-                                  <div className="rounded-[0.95rem] bg-[#1f314d] px-3 py-2.5 text-white">
+                                  <div className="grid gap-1 rounded-[0.95rem] bg-[#1f314d] px-3 py-2.5 text-white sm:grid-cols-[96px_minmax(0,1fr)] sm:items-start">
                                     <dt className="text-[11px] font-medium uppercase tracking-[0.18em] text-white/68">Results</dt>
-                                    <dd className="mt-1 text-sm leading-6 text-white">{truncateCopy(activeProject.results, 74)}</dd>
+                                    <dd className="text-sm leading-6 text-white">{truncateCopy(activeProject.results, 64)}</dd>
                                   </div>
                                 ) : null}
                               </dl>

--- a/marketlink-frontend/src/app/experts/page.tsx
+++ b/marketlink-frontend/src/app/experts/page.tsx
@@ -243,6 +243,13 @@ function FiltersForm({ name, zip, radius, service, problemId, verified }: Filter
         </button>
       </div>
 
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-xs text-slate-500">Use ZIP, distance, and service first. Everything else is optional.</div>
+        <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
+          Clear filters
+        </Link>
+      </div>
+
       <details className="rounded-[1.15rem] border border-slate-200/90 bg-white px-4 py-3">
         <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-slate-700 [&::-webkit-details-marker]:hidden">
           <span className="inline-flex items-center gap-2">
@@ -251,7 +258,7 @@ function FiltersForm({ name, zip, radius, service, problemId, verified }: Filter
           </span>
           <span className="text-xs font-medium uppercase tracking-[0.16em] text-slate-500">Name and verified</span>
         </summary>
-        <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_260px_auto] md:items-end">
+        <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_260px] md:items-end">
           <label className="grid gap-2">
             <span className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
               <ControlIcon kind="name" />
@@ -282,10 +289,6 @@ function FiltersForm({ name, zip, radius, service, problemId, verified }: Filter
               Verified only
             </label>
           </div>
-
-          <Link href="/experts" className="text-sm font-medium text-slate-600 underline underline-offset-4 hover:text-slate-900">
-            Clear filters
-          </Link>
         </div>
       </details>
     </form>

--- a/marketlink-frontend/src/app/page.tsx
+++ b/marketlink-frontend/src/app/page.tsx
@@ -71,14 +71,11 @@ export default function Home() {
                   <div>
                     <div className={`text-[11px] font-medium uppercase tracking-[0.24em] ${t.mutedText}`}>Start nearby</div>
                     <h2 className="mt-2 text-xl font-semibold tracking-tight text-slate-950">Search nearby first.</h2>
-                    <p className="mt-2 text-sm leading-6 text-slate-600">Use a ZIP and distance, or press search empty and we will start from Chicago.</p>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">Use a ZIP and distance. If you leave it empty, we start from Chicago.</p>
                   </div>
-                  <Link href="/experts" className="text-sm font-semibold text-slate-700 underline decoration-slate-300 underline-offset-4 hover:text-slate-950">
-                    Browse all experts
-                  </Link>
                 </div>
 
-                <form action="/experts" method="GET" onSubmit={onNearbySubmit} className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+                <form action="/experts" method="GET" onSubmit={onNearbySubmit} className="mt-5 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
                   <NearbyRadiusField
                     initialRadius="10"
                     compact
@@ -94,6 +91,13 @@ export default function Home() {
                     Search nearby experts
                   </button>
                 </form>
+
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+                  <span>One nearby search leads into the shortlist and the map.</span>
+                  <Link href="/experts" className="font-semibold text-slate-700 underline decoration-slate-300 underline-offset-4 hover:text-slate-950">
+                    Skip ZIP and browse all experts
+                  </Link>
+                </div>
               </div>
             </div>
 

--- a/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
+++ b/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
@@ -19,125 +19,125 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
         <div className="hero-command-bar inline-flex items-center gap-3 self-start rounded-full border border-white/75 bg-white/84 px-4 py-2 shadow-[0_14px_30px_rgba(18,26,42,0.09)]">
           <span className="text-[10px] font-semibold uppercase tracking-[0.22em] text-slate-500">Search mode</span>
           <span className="hero-command-track inline-flex items-center gap-2 rounded-full bg-[#1f314d] px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-white">
-            Find nearby experts in Chicago
+            Chicago nearby search
             <span className="hero-command-dot h-2 w-2 rounded-full bg-[#ffd8bd]" />
           </span>
         </div>
 
         <div className={compact ? '' : 'lg:grid lg:grid-cols-[1.02fr_0.98fr] lg:gap-4'}>
-        <div className="ml-glass-note hero-preview-panel rounded-[1.5rem] px-4 py-4">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-slate-500">Local shortlist</div>
-              <div className="mt-2 text-sm font-semibold text-slate-950">Compare experts around your business</div>
-            </div>
-            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">
-              Preview
-            </span>
-          </div>
-
-          <div className="mt-4 grid gap-3">
-            {[
-              ['SEO', 'Westmont, IL'],
-              ['Creators', 'Naperville, IL'],
-              ['Web', 'Oak Park, IL'],
-            ].map(([service, location], index) => (
-              <div
-                key={`${service}-${location}`}
-                className="hero-shortlist-card grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-[1.2rem] bg-white/90 px-3 py-3 ring-1 ring-slate-200/80"
-                style={{ animationDelay: `${index * 1.1}s`, ['--ml-shift' as string]: index === 1 ? '8px' : '0px' }}
-              >
-                <span className="grid h-10 w-10 place-items-center rounded-[1rem] bg-[#1f314d] text-xs font-semibold text-white">
-                  {service.slice(0, 1)}
-                </span>
-                <div>
-                  <div className="text-sm font-semibold text-slate-900">{service}</div>
-                  <div className="text-xs text-slate-500">{location}</div>
-                </div>
-                <span className="h-2.5 w-2.5 rounded-full bg-[#e38360]" />
+          <div className="ml-glass-note hero-preview-panel rounded-[1.5rem] px-4 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-slate-500">Local shortlist</div>
+                <div className="mt-2 text-sm font-semibold text-slate-950">Compare experts around your business</div>
               </div>
-            ))}
+              <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+                Preview
+              </span>
+            </div>
+
+            <div className="mt-4 grid gap-3">
+              {[
+                ['SEO', 'Westmont, IL'],
+                ['Creators', 'Naperville, IL'],
+                ['Web', 'Oak Park, IL'],
+              ].map(([service, location], index) => (
+                <div
+                  key={`${service}-${location}`}
+                  className="hero-shortlist-card grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-[1.2rem] bg-white/90 px-3 py-3 ring-1 ring-slate-200/80"
+                  style={{ animationDelay: `${index * 1.1}s`, ['--ml-shift' as string]: index === 1 ? '8px' : '0px' }}
+                >
+                  <span className="grid h-10 w-10 place-items-center rounded-[1rem] bg-[#1f314d] text-xs font-semibold text-white">
+                    {service.slice(0, 1)}
+                  </span>
+                  <div>
+                    <div className="text-sm font-semibold text-slate-900">{service}</div>
+                    <div className="text-xs text-slate-500">{location}</div>
+                  </div>
+                  <span className="h-2.5 w-2.5 rounded-full bg-[#e38360]" />
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
 
-        <div className="hero-map-panel relative min-h-[260px] overflow-hidden rounded-[1.7rem] bg-[#233553] px-5 py-5 text-white shadow-[0_20px_60px_rgba(18,26,42,0.2)]">
-          <div className="absolute left-6 top-6 rounded-full bg-white/14 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-white/78">
-            Map preview
+          <div className="hero-map-panel relative min-h-[260px] overflow-hidden rounded-[1.7rem] bg-[#233553] px-5 py-5 text-white shadow-[0_20px_60px_rgba(18,26,42,0.2)]">
+            <div className="absolute left-6 top-6 rounded-full bg-white/14 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-white/78">
+              Map preview
+            </div>
+            <div className="absolute right-5 top-5 grid w-[126px] grid-cols-2 gap-1 rounded-full border border-white/14 bg-white/8 p-1">
+              <span className="hero-view-pill rounded-full px-3 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70">
+                List
+              </span>
+              <span className="hero-view-pill-active rounded-full bg-white px-3 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.18em] text-[#1f314d] shadow-sm">
+                Map
+              </span>
+            </div>
+            <div className="hero-map-search absolute left-6 top-16 z-20 rounded-full border border-white/16 bg-[#15233a]/88 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/78 shadow-[0_10px_24px_rgba(15,23,42,0.2)]">
+              Search 60601
+            </div>
+
+            <svg viewBox="0 0 420 280" className="mt-10 h-full w-full" role="presentation">
+              <defs>
+                <linearGradient id="surface" x1="0%" x2="100%" y1="0%" y2="100%">
+                  <stop offset="0%" stopColor="#fbfcff" />
+                  <stop offset="100%" stopColor="#f0f4fb" />
+                </linearGradient>
+                <linearGradient id="warm" x1="0%" x2="100%" y1="0%" y2="100%">
+                  <stop offset="0%" stopColor="#ffd8bd" />
+                  <stop offset="100%" stopColor="#e38360" />
+                </linearGradient>
+                <linearGradient id="cool" x1="0%" x2="100%" y1="0%" y2="100%">
+                  <stop offset="0%" stopColor="#cae6ff" />
+                  <stop offset="100%" stopColor="#7ca6d8" />
+                </linearGradient>
+              </defs>
+
+              <rect x="20" y="48" width="220" height="170" rx="26" fill="url(#surface)" />
+              <path d="M50 90h160M50 118h120M50 145h140M50 172h110" stroke="#d8e0ec" strokeLinecap="round" strokeWidth="10" />
+              <rect x="44" y="74" width="70" height="18" rx="9" fill="#233553" opacity="0.9" />
+              <rect x="140" y="74" width="48" height="18" rx="9" fill="#ffd8bd" />
+
+              <rect x="204" y="36" width="190" height="208" rx="32" fill="#f7f4ef" />
+              <path
+                d="M229 70c31-29 62-20 87 4 23 22 48 30 76 10v126c-31 28-59 20-84-2-24-22-48-27-79-10z"
+                fill="#d7e9fb"
+              />
+              <path className="hero-map-route hero-map-route-one" d="M260 98c25 20 44 15 60 4" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
+              <path className="hero-map-route hero-map-route-two" d="M244 170c34-24 60-20 82 5" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
+              <path className="hero-map-route hero-map-route-three" d="M287 132c18 15 35 12 49 1" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
+
+              {[
+                [272, 108],
+                [336, 92],
+                [318, 168],
+              ].map(([x, y], index) => (
+                <g key={`${x}-${y}`} className={`hero-pin hero-pin-${index + 1}`}>
+                  <circle cx={x} cy={y} r={index === 0 ? 19 : 17} fill="#233553" />
+                  <circle cx={x} cy={y} r={7} fill="#fff" />
+                  <path d={`M${x} ${y + 18}l8 10h-16z`} fill="#233553" />
+                </g>
+              ))}
+
+              <rect x="274" y="190" width="118" height="44" rx="18" fill="#fff" />
+              <circle cx="300" cy="212" r="13" fill="url(#warm)" />
+              <path d="M321 203h45M321 216h32" stroke="#d8e0ec" strokeLinecap="round" strokeWidth="8" />
+
+              <circle cx="88" cy="244" r="38" fill="url(#warm)" opacity="0.55" />
+              <circle cx="154" cy="252" r="28" fill="url(#cool)" opacity="0.55" />
+            </svg>
+            <span className="hero-search-pulse absolute right-[5.4rem] top-[6.1rem] h-12 w-12 rounded-full border border-white/55" />
+            <span className="hero-search-pulse hero-search-pulse-delay absolute right-[5.1rem] top-[5.8rem] h-16 w-16 rounded-full border border-white/30" />
           </div>
-          <div className="absolute right-5 top-5 flex items-center gap-2">
-            <span className="hero-view-pill rounded-full border border-white/16 bg-white/8 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70">
-              List
-            </span>
-            <span className="hero-view-pill hero-view-pill-active rounded-full border border-white/24 bg-white px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#1f314d]">
-              Map
-            </span>
-          </div>
-          <div className="hero-map-search absolute left-6 top-16 z-20 rounded-full border border-white/16 bg-[#15233a]/88 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/78 shadow-[0_10px_24px_rgba(15,23,42,0.2)]">
-            Search 60601
-          </div>
-
-          <svg viewBox="0 0 420 280" className="mt-10 h-full w-full" role="presentation">
-            <defs>
-              <linearGradient id="surface" x1="0%" x2="100%" y1="0%" y2="100%">
-                <stop offset="0%" stopColor="#fbfcff" />
-                <stop offset="100%" stopColor="#f0f4fb" />
-              </linearGradient>
-              <linearGradient id="warm" x1="0%" x2="100%" y1="0%" y2="100%">
-                <stop offset="0%" stopColor="#ffd8bd" />
-                <stop offset="100%" stopColor="#e38360" />
-              </linearGradient>
-              <linearGradient id="cool" x1="0%" x2="100%" y1="0%" y2="100%">
-                <stop offset="0%" stopColor="#cae6ff" />
-                <stop offset="100%" stopColor="#7ca6d8" />
-              </linearGradient>
-            </defs>
-
-            <rect x="20" y="48" width="220" height="170" rx="26" fill="url(#surface)" />
-            <path d="M50 90h160M50 118h120M50 145h140M50 172h110" stroke="#d8e0ec" strokeLinecap="round" strokeWidth="10" />
-            <rect x="44" y="74" width="70" height="18" rx="9" fill="#233553" opacity="0.9" />
-            <rect x="140" y="74" width="48" height="18" rx="9" fill="#ffd8bd" />
-
-            <rect x="204" y="36" width="190" height="208" rx="32" fill="#f7f4ef" />
-            <path
-              d="M229 70c31-29 62-20 87 4 23 22 48 30 76 10v126c-31 28-59 20-84-2-24-22-48-27-79-10z"
-              fill="#d7e9fb"
-            />
-            <path className="hero-map-route hero-map-route-one" d="M260 98c25 20 44 15 60 4" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
-            <path className="hero-map-route hero-map-route-two" d="M244 170c34-24 60-20 82 5" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
-            <path className="hero-map-route hero-map-route-three" d="M287 132c18 15 35 12 49 1" stroke="#94b2d3" strokeLinecap="round" strokeWidth="6" />
-
-            {[
-              [272, 108],
-              [336, 92],
-              [318, 168],
-            ].map(([x, y], index) => (
-              <g key={`${x}-${y}`} className={`hero-pin hero-pin-${index + 1}`}>
-                <circle cx={x} cy={y} r={index === 0 ? 19 : 17} fill="#233553" />
-                <circle cx={x} cy={y} r={7} fill="#fff" />
-                <path d={`M${x} ${y + 18}l8 10h-16z`} fill="#233553" />
-              </g>
-            ))}
-
-            <rect x="274" y="190" width="118" height="44" rx="18" fill="#fff" />
-            <circle cx="300" cy="212" r="13" fill="url(#warm)" />
-            <path d="M321 203h45M321 216h32" stroke="#d8e0ec" strokeLinecap="round" strokeWidth="8" />
-
-            <circle cx="88" cy="244" r="38" fill="url(#warm)" opacity="0.55" />
-            <circle cx="154" cy="252" r="28" fill="url(#cool)" opacity="0.55" />
-          </svg>
-          <span className="hero-search-pulse absolute right-[5.4rem] top-[6.1rem] h-12 w-12 rounded-full border border-white/55" />
-          <span className="hero-search-pulse hero-search-pulse-delay absolute right-[5.1rem] top-[5.8rem] h-16 w-16 rounded-full border border-white/30" />
-        </div>
         </div>
 
         <div className="ml-glass-note hero-flow-panel rounded-[1.5rem] px-4 py-3">
           <div className="flex flex-wrap items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
             <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Search nearby</span>
-            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="hero-flow-arrow text-slate-400">&rarr;</span>
             <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Find on map</span>
-            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="hero-flow-arrow text-slate-400">&rarr;</span>
             <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Open shortlist</span>
-            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="hero-flow-arrow text-slate-400">&rarr;</span>
             <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Contact the best fit</span>
           </div>
         </div>
@@ -186,14 +186,6 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
 
         .hero-flow-arrow {
           animation: flowArrowPulse 4.8s ease-in-out infinite;
-        }
-
-        .hero-view-pill {
-          animation: pillFade 6s ease-in-out infinite;
-        }
-
-        .hero-view-pill-active {
-          animation: pillActive 6s ease-in-out infinite;
         }
 
         .hero-map-search {
@@ -300,31 +292,6 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           }
         }
 
-        @keyframes pillFade {
-          0%,
-          24%,
-          100% {
-            opacity: 0.58;
-          }
-
-          12% {
-            opacity: 1;
-          }
-        }
-
-        @keyframes pillActive {
-          0%,
-          100% {
-            transform: scale(1);
-            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
-          }
-
-          18% {
-            transform: scale(1.04);
-            box-shadow: 0 14px 28px rgba(15, 23, 42, 0.16);
-          }
-        }
-
         @keyframes searchPulse {
           0%,
           100% {
@@ -413,8 +380,6 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           .hero-preview-panel,
           .hero-map-panel,
           .hero-flow-panel,
-          .hero-view-pill,
-          .hero-view-pill-active,
           .hero-map-search,
           .hero-map-route,
           .hero-pin,

--- a/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
+++ b/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
@@ -24,15 +24,15 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           </span>
         </div>
 
-        <div className={compact ? '' : 'lg:grid lg:grid-cols-[1.05fr_0.95fr] lg:gap-4'}>
+        <div className={compact ? '' : 'lg:grid lg:grid-cols-[1.02fr_0.98fr] lg:gap-4'}>
         <div className="ml-glass-note hero-preview-panel rounded-[1.5rem] px-4 py-4">
           <div className="flex items-center justify-between gap-3">
             <div>
               <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-slate-500">Local shortlist</div>
               <div className="mt-2 text-sm font-semibold text-slate-950">Compare experts around your business</div>
             </div>
-            <span className="rounded-full bg-[#1f314d] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white">
-              Nearby
+            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              Preview
             </span>
           </div>
 
@@ -73,7 +73,7 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
             </span>
           </div>
           <div className="hero-map-search absolute left-6 top-16 z-20 rounded-full border border-white/16 bg-[#15233a]/88 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/78 shadow-[0_10px_24px_rgba(15,23,42,0.2)]">
-            Searching 60601
+            Search 60601
           </div>
 
           <svg viewBox="0 0 420 280" className="mt-10 h-full w-full" role="presentation">
@@ -130,29 +130,15 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
         </div>
         </div>
 
-        <div className="ml-glass-note hero-flow-panel rounded-[1.5rem] px-4 py-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-slate-500">MarketLink flow</div>
-            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-600">
-              Select, then choose view
-            </span>
-          </div>
-
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            {[
-              ['Step 1', 'Select nearby experts'],
-              ['Step 2', 'Open list or map view'],
-              ['Step 3', 'Contact the best fit'],
-            ].map(([step, copy], index) => (
-              <div
-                key={step}
-                className="hero-flow-card rounded-[1.15rem] bg-white/90 px-4 py-3 ring-1 ring-slate-200/80"
-                style={{ animationDelay: `${index * 1.1}s` }}
-              >
-                <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">{step}</div>
-                <div className="mt-2 text-sm font-semibold leading-6 text-slate-950">{copy}</div>
-              </div>
-            ))}
+        <div className="ml-glass-note hero-flow-panel rounded-[1.5rem] px-4 py-3">
+          <div className="flex flex-wrap items-center gap-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Search nearby</span>
+            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Find on map</span>
+            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Open shortlist</span>
+            <span className="hero-flow-arrow text-slate-400">→</span>
+            <span className="rounded-full border border-slate-200/80 bg-white/82 px-3 py-1">Contact the best fit</span>
           </div>
         </div>
       </div>
@@ -194,9 +180,12 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           animation-delay: 1.1s;
         }
 
-        .hero-shortlist-card,
-        .hero-flow-card {
+        .hero-shortlist-card {
           animation: shortlistPulse 6.6s ease-in-out infinite;
+        }
+
+        .hero-flow-arrow {
+          animation: flowArrowPulse 4.8s ease-in-out infinite;
         }
 
         .hero-view-pill {
@@ -404,6 +393,19 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           }
         }
 
+        @keyframes flowArrowPulse {
+          0%,
+          100% {
+            opacity: 0.3;
+            transform: translateX(0);
+          }
+
+          50% {
+            opacity: 1;
+            transform: translateX(3px);
+          }
+        }
+
         @media (prefers-reduced-motion: reduce) {
           .hero-command-bar,
           .hero-command-track::after,
@@ -418,7 +420,7 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
           .hero-pin,
           .hero-search-pulse,
           .hero-shortlist-card,
-          .hero-flow-card {
+          .hero-flow-arrow {
             animation: none;
           }
         }

--- a/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
+++ b/marketlink-frontend/src/components/MarketLinkHeroIllustration.tsx
@@ -64,7 +64,7 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
             <div className="absolute left-6 top-6 rounded-full bg-white/14 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.22em] text-white/78">
               Map preview
             </div>
-            <div className="absolute right-5 top-5 grid w-[126px] grid-cols-2 gap-1 rounded-full border border-white/14 bg-white/8 p-1">
+            <div className="absolute right-5 top-14 grid w-[126px] grid-cols-2 gap-1 rounded-full border border-white/14 bg-white/8 p-1">
               <span className="hero-view-pill rounded-full px-3 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70">
                 List
               </span>
@@ -72,7 +72,7 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
                 Map
               </span>
             </div>
-            <div className="hero-map-search absolute left-6 top-16 z-20 rounded-full border border-white/16 bg-[#15233a]/88 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/78 shadow-[0_10px_24px_rgba(15,23,42,0.2)]">
+            <div className="hero-map-search absolute left-6 top-24 z-20 rounded-full border border-white/16 bg-[#15233a]/88 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/78 shadow-[0_10px_24px_rgba(15,23,42,0.2)]">
               Search 60601
             </div>
 
@@ -125,8 +125,8 @@ export default function MarketLinkHeroIllustration({ compact = false }: Props) {
               <circle cx="88" cy="244" r="38" fill="url(#warm)" opacity="0.55" />
               <circle cx="154" cy="252" r="28" fill="url(#cool)" opacity="0.55" />
             </svg>
-            <span className="hero-search-pulse absolute right-[5.4rem] top-[6.1rem] h-12 w-12 rounded-full border border-white/55" />
-            <span className="hero-search-pulse hero-search-pulse-delay absolute right-[5.1rem] top-[5.8rem] h-16 w-16 rounded-full border border-white/30" />
+          <span className="hero-search-pulse absolute left-[1.4rem] top-[7.9rem] h-12 w-12 rounded-full border border-white/55" />
+          <span className="hero-search-pulse hero-search-pulse-delay absolute left-[1.1rem] top-[7.6rem] h-16 w-16 rounded-full border border-white/30" />
           </div>
         </div>
 

--- a/marketlink-frontend/src/components/NearbyRadiusField.tsx
+++ b/marketlink-frontend/src/components/NearbyRadiusField.tsx
@@ -147,7 +147,7 @@ export default function NearbyRadiusField({
           helperMessage ? (
             <p className={`text-xs leading-5 md:col-span-2 ${zip.length > 0 && zip.length < 5 ? 'text-red-600' : 'text-slate-500'}`}>{helperMessage}</p>
           ) : zip.length === 5 ? (
-            <p className="text-xs leading-5 text-slate-500 md:col-span-2">Searching within {selectedRadius} miles of {zip}.</p>
+            <p className="text-xs leading-5 text-slate-500 md:col-span-2">Within {selectedRadius} miles of {zip}.</p>
           ) : null
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- expose expert reviews on the public expert detail payload
- render testimonials as the primary proof block on expert profiles when reviews exist
- demote project proof to supporting proof behind the testimonial context
- tighten the homepage nearby-search module so the primary action is clearer and the animated explainer reads less like fake buttons
- compress the supporting project proof block so it feels like fast metadata instead of a long case study

## Verification
- backend typecheck passed
- frontend build passed
- frontend eslint passed for the touched files
- local API verification confirmed `/experts/windy-city-growth` now returns populated `reviews`
- homepage browser screenshot check passed locally

## Notes
- local demo review rows were added only for QA and are not part of this PR
- the expert profile route still stayed on `Loading...` during headless browser automation, so profile visual verification is grounded in build/lint/API checks rather than a clean automated screenshot pass