### PR TITLE
MM-94 add locality / proximity signal to expert cards

### DIFF
--- a/marketlink-frontend/src/app/experts/page.tsx
+++ b/marketlink-frontend/src/app/experts/page.tsx
@@ -199,6 +199,13 @@ function buildPricingLabel(provider: Provider) {
   return hourlyRange || 'Ask for pricing';
 }
 
+function getProximityLabel(distanceMiles: number | undefined) {
+  if (typeof distanceMiles !== 'number' || !Number.isFinite(distanceMiles)) return null;
+  if (distanceMiles <= 10) return 'Nearby';
+  if (distanceMiles <= 25) return 'In your area';
+  return 'Farther away';
+}
+
 function FiltersForm({ name, zip, radius, service, problemId, verified }: FiltersFormProps) {
   const verifiedChecked = verified === '1' || (verified ?? '').toLowerCase() === 'true';
 
@@ -308,6 +315,7 @@ function ProviderCard({ provider }: { provider: Provider }) {
     null;
   const locationLabel = formatLocation(provider);
   const pricingLabel = buildPricingLabel(provider);
+  const proximityLabel = getProximityLabel(provider.distanceMiles);
   const shortSummary =
     provider.shortDescription ||
     provider.tagline ||
@@ -384,6 +392,10 @@ function ProviderCard({ provider }: { provider: Provider }) {
               <div className="mt-2 text-sm text-slate-600">
                 {provider.expertType === 'creator' && provider.locationPrecision === 'approximate'
                   ? 'Approximate area shown'
+                  : proximityLabel && provider.zip
+                  ? `${proximityLabel} · ZIP ${provider.zip}`
+                  : proximityLabel
+                  ? proximityLabel
                   : provider.zip
                   ? `ZIP ${provider.zip}`
                   : provider.verified

--- a/marketlink-frontend/src/components/ExpertsDiscoveryMap.tsx
+++ b/marketlink-frontend/src/components/ExpertsDiscoveryMap.tsx
@@ -45,6 +45,13 @@ const MAP_STYLE = {
   ],
 } as const;
 
+function getProximityLabel(distanceMiles: number | undefined) {
+  if (typeof distanceMiles !== 'number' || !Number.isFinite(distanceMiles)) return null;
+  if (distanceMiles <= 10) return 'Nearby';
+  if (distanceMiles <= 25) return 'In your area';
+  return 'Farther away';
+}
+
 export default function ExpertsDiscoveryMap({ providers, showDesktop = true, showMobile = true }: Props) {
   const desktopMapRef = useRef<MapRef | null>(null);
   const mobileMapRef = useRef<MapRef | null>(null);
@@ -239,6 +246,8 @@ export default function ExpertsDiscoveryMap({ providers, showDesktop = true, sho
   function renderFocusedCard(position: 'desktop' | 'mobile') {
     if (!focusedProvider) return null;
 
+    const proximityLabel = getProximityLabel(focusedProvider.distanceMiles);
+
     return (
       <div
         className={`pointer-events-auto absolute z-20 rounded-[1.2rem] bg-white/96 px-4 py-4 shadow-[0_18px_40px_rgba(15,23,42,0.16)] ring-1 ring-slate-200/90 ${
@@ -256,6 +265,7 @@ export default function ExpertsDiscoveryMap({ providers, showDesktop = true, sho
             </Link>
             <div className="mt-1 text-sm text-slate-600">
               {focusedProvider.city}, {focusedProvider.state}
+              {proximityLabel ? ` | ${proximityLabel}` : ''}
               {typeof focusedProvider.distanceMiles === 'number' ? ` | ${focusedProvider.distanceMiles} miles away` : ''}
             </div>
             {focusedProvider.expertType === 'creator' && focusedProvider.locationPrecision === 'approximate' ? (


### PR DESCRIPTION
## Summary
- add a simple buyer-facing locality label model to expert cards
- keep exact mileage and zip context where available
- mirror the same proximity label in the experts map overlay

## Verification
- npm exec eslint src/app/experts/page.tsx src/components/ExpertsDiscoveryMap.tsx
- npm run build