### PR TITLE
MM-43 add lightweight customer account foundation

### DIFF
--- a/marketlink-backend/prisma/migrations/20260523012726_add_customer_profile/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260523012726_add_customer_profile/migration.sql
@@ -1,0 +1,20 @@
+-- AlterEnum
+ALTER TYPE "UserRole" ADD VALUE 'customer';
+
+-- CreateTable
+CREATE TABLE "CustomerProfile" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "businessName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerProfile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CustomerProfile_userId_key" ON "CustomerProfile"("userId");
+
+-- AddForeignKey
+ALTER TABLE "CustomerProfile" ADD CONSTRAINT "CustomerProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -17,8 +17,19 @@ model User {
   mustChangePassword Boolean       @default(true)
   passwordHash       String?
   adminActions       AdminAction[]
+  customerProfile    CustomerProfile?
   experts            Expert[]
   sessions           Session[]
+}
+
+model CustomerProfile {
+  id           String   @id @default(cuid())
+  userId       String   @unique
+  name         String
+  businessName String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model Expert {
@@ -123,6 +134,7 @@ model AdminAction {
 
 enum UserRole {
   provider
+  customer
   admin
 }
 

--- a/marketlink-backend/src/routes/account.ts
+++ b/marketlink-backend/src/routes/account.ts
@@ -15,6 +15,25 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
     const user = await getUserFromRequest(fastify, req);
     if (!user) return reply.code(401).send({ error: 'Not authenticated' });
 
+    if (user.role === 'customer') {
+      const customer = await prisma.customerProfile.findUnique({
+        where: { userId: user.id },
+        select: {
+          id: true,
+          name: true,
+          businessName: true,
+        },
+      });
+
+      return {
+        ok: true,
+        user: { id: user.id, email: user.email, role: user.role },
+        customer,
+        expert: null,
+        provider: null,
+      };
+    }
+
     const expert = await prisma.expert.findFirst({
       where: { userId: user.id },
       select: {
@@ -105,6 +124,7 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
     return {
       ok: true,
       user: { id: user.id, email: user.email, role: user.role },
+      customer: null,
       expert,
       provider: expert,
     };

--- a/marketlink-backend/tests/account.customer.test.js
+++ b/marketlink-backend/tests/account.customer.test.js
@@ -1,0 +1,59 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+
+const sessionModule = require('../src/lib/session');
+const prismaModule = require('../src/lib/prisma');
+const accountRoutes = require('../src/routes/account').default;
+
+test('GET /me/summary returns customer profile for customer users', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(accountRoutes);
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalFindFirstExpert = prismaModule.prisma.expert.findFirst;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'user_customer_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.expert.findFirst = async () => null;
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_1',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    }),
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/me/summary',
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.user.role, 'customer');
+    assert.deepEqual(body.customer, {
+      id: 'customer_profile_1',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    });
+    assert.equal(body.expert, null);
+    assert.equal(body.provider, null);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert.findFirst = originalFindFirstExpert;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    await fastify.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add a lightweight customer role foundation in Prisma with a minimal 1:1 customer profile
- extend `/me/summary` to return customer account data without changing provider/admin behavior
- add a backend route test covering the new customer summary response

## Test Plan
- [x] `node --test tests/account.customer.test.js`
- [x] `node_modules\\.bin\\tsc.cmd --noEmit -p tsconfig.json`
- [x] `npx prisma migrate dev --name add_customer_profile`
- [x] `npm run build` is still blocked locally by the known Prisma Windows engine file lock during `prisma generate`
