### PR TITLE
MM-45 add customer login redirect and header role handling

### DIFF
--- a/marketlink-backend/src/routes/account.ts
+++ b/marketlink-backend/src/routes/account.ts
@@ -129,6 +129,44 @@ const accountRoutes: FastifyPluginAsync = async (fastify) => {
       provider: expert,
     };
   });
+
+  fastify.put('/me/customer-profile', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can update customer profiles.' });
+
+    const { name, businessName } = (req.body || {}) as { name?: string; businessName?: string | null };
+
+    const cleanName = String(name || '').trim();
+    const cleanBusinessName = typeof businessName === 'string' ? businessName.trim() || null : null;
+
+    if (!cleanName) {
+      return reply.code(400).send({ error: 'Name is required.' });
+    }
+
+    const customer = await prisma.customerProfile.upsert({
+      where: { userId: user.id },
+      update: {
+        name: cleanName,
+        businessName: cleanBusinessName,
+      },
+      create: {
+        userId: user.id,
+        name: cleanName,
+        businessName: cleanBusinessName,
+      },
+      select: {
+        id: true,
+        name: true,
+        businessName: true,
+      },
+    });
+
+    return reply.send({
+      ok: true,
+      customer,
+    });
+  });
 };
 
 export default accountRoutes;

--- a/marketlink-backend/src/routes/auth.ts
+++ b/marketlink-backend/src/routes/auth.ts
@@ -4,6 +4,63 @@ import { prisma } from '../lib/prisma';
 import { createSessionForUser, setSessionCookie, getUserFromRequest, deleteCurrentSession } from '../lib/session';
 
 const authRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/auth/signup', async (req, reply) => {
+    const { name, email, password } = (req.body || {}) as { name?: string; email?: string; password?: string };
+
+    const cleanName = String(name || '').trim();
+    const cleanEmail = String(email || '')
+      .trim()
+      .toLowerCase();
+    const cleanPassword = String(password || '');
+
+    if (!cleanName || !cleanEmail || !cleanPassword) {
+      return reply.code(400).send({ ok: false, message: 'Name, email, and password are required.' });
+    }
+
+    if (cleanPassword.length < 8) {
+      return reply.code(400).send({ ok: false, message: 'Password must be at least 8 characters.' });
+    }
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email: cleanEmail },
+      select: { id: true },
+    });
+
+    if (existingUser) {
+      return reply.code(409).send({ ok: false, message: 'An account with that email already exists.' });
+    }
+
+    const passwordHash = await bcrypt.hash(cleanPassword, 10);
+    const user = await prisma.user.create({
+      data: {
+        email: cleanEmail,
+        role: 'customer',
+        passwordHash,
+        mustChangePassword: false,
+        customerProfile: {
+          create: {
+            name: cleanName,
+          },
+        },
+      },
+      select: {
+        id: true,
+        email: true,
+        role: true,
+        mustChangePassword: true,
+      },
+    });
+
+    const { sessionToken, expiresAt } = await createSessionForUser(user.id);
+    setSessionCookie(reply, sessionToken);
+
+    return reply.code(201).send({
+      ok: true,
+      user,
+      expiresAt,
+    });
+  });
+
   /**
    * POST /auth/login
    * Body: { email, password }

--- a/marketlink-backend/tests/account.customer.test.js
+++ b/marketlink-backend/tests/account.customer.test.js
@@ -57,3 +57,51 @@ test('GET /me/summary returns customer profile for customer users', async () => 
     await fastify.close();
   }
 });
+
+test('PUT /me/customer-profile upserts the customer profile for customer users', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(accountRoutes);
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'user_customer_2',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    upsert: async ({ create, update }) => ({
+      id: 'customer_profile_2',
+      name: update.name || create.name,
+      businessName: update.businessName || create.businessName,
+    }),
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'PUT',
+      url: '/me/customer-profile',
+      payload: {
+        name: 'Jamie Rivera',
+        businessName: 'Westmont Dental',
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.deepEqual(body.customer, {
+      id: 'customer_profile_2',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    });
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    await fastify.close();
+  }
+});

--- a/marketlink-backend/tests/auth.customer.test.js
+++ b/marketlink-backend/tests/auth.customer.test.js
@@ -1,0 +1,64 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+
+const prismaModule = require('../src/lib/prisma');
+const sessionModule = require('../src/lib/session');
+const authRoutes = require('../src/routes/auth').default;
+
+test('POST /auth/signup creates a customer account and session', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(authRoutes);
+
+  const originalFindUnique = prismaModule.prisma.user.findUnique;
+  const originalCreate = prismaModule.prisma.user.create;
+  const originalCreateSessionForUser = sessionModule.createSessionForUser;
+  const originalSetSessionCookie = sessionModule.setSessionCookie;
+
+  let cookieToken = null;
+
+  prismaModule.prisma.user.findUnique = async () => null;
+  prismaModule.prisma.user.create = async ({ data }) => ({
+    id: 'user_customer_signup_1',
+    email: data.email,
+    role: data.role,
+    mustChangePassword: data.mustChangePassword,
+  });
+  sessionModule.createSessionForUser = async () => ({
+    sessionToken: 'session_customer_signup_1',
+    expiresAt: 123456789,
+  });
+  sessionModule.setSessionCookie = (reply, token) => {
+    cookieToken = token;
+    reply.header('set-cookie', `session=${token}`);
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/auth/signup',
+      payload: {
+        name: 'Jamie Rivera',
+        email: 'customer@example.com',
+        password: 'password123',
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.user.role, 'customer');
+    assert.equal(body.user.mustChangePassword, false);
+    assert.equal(cookieToken, 'session_customer_signup_1');
+  } finally {
+    prismaModule.prisma.user.findUnique = originalFindUnique;
+    prismaModule.prisma.user.create = originalCreate;
+    sessionModule.createSessionForUser = originalCreateSessionForUser;
+    sessionModule.setSessionCookie = originalSetSessionCookie;
+    await fastify.close();
+  }
+});

--- a/marketlink-frontend/src/app/dashboard/customer/CustomerProfileForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/CustomerProfileForm.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useMarketLinkTheme } from '@/components/ThemeToggle';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type CustomerProfileFormProps = {
+  email: string;
+  initialName?: string | null;
+  initialBusinessName?: string | null;
+  mode: 'onboarding' | 'profile';
+};
+
+export default function CustomerProfileForm({ email, initialName = '', initialBusinessName = '', mode }: CustomerProfileFormProps) {
+  const router = useRouter();
+  const { t } = useMarketLinkTheme();
+  const [name, setName] = useState(initialName);
+  const [businessName, setBusinessName] = useState(initialBusinessName);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const shellClass = 'ml-card rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-6';
+  const mutedCardClass = 'ml-surface-muted rounded-2xl p-4';
+  const fieldClass = 'ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900';
+  const primaryButtonClass = 'ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white disabled:opacity-60';
+  const secondaryLinkClass = 'ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900';
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    const cleanName = name.trim();
+    const cleanBusinessName = businessName.trim();
+
+    if (!cleanName) {
+      setError('Name is required.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch(`${API_BASE}/me/customer-profile`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: cleanName,
+          businessName: cleanBusinessName,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error || `Failed (${res.status})`);
+      }
+
+      router.replace('/dashboard/customer/profile');
+      router.refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className={`${t.pageBg} min-h-[calc(100vh-72px)]`}>
+      <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_320px]">
+          <section className={`${shellClass} order-1 overflow-hidden`}>
+            <div className="h-1.5 bg-[linear-gradient(90deg,#0f172a,#25324a,#b6bdc8)] -mx-5 -mt-5 mb-5 sm:-mx-6 sm:-mt-6 sm:mb-6" />
+            <div className="flex flex-col gap-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Your account</p>
+              <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                {mode === 'onboarding' ? 'Finish the basics' : 'Your customer profile'}
+              </h1>
+              <p className={`max-w-2xl text-sm leading-6 ${t.mutedText}`}>
+                {mode === 'onboarding'
+                  ? 'Keep this lightweight. Add your name now so MarketLink knows who is signed in. Business details stay optional until you actually request help or start a conversation.'
+                  : 'This stays intentionally simple. Update the basics here, then add more context later only when a real request or message flow needs it.'}
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="mt-6 grid gap-5">
+              <div className="grid gap-2">
+                <label htmlFor="customer-name" className="text-sm font-medium text-slate-700">
+                  Name *
+                </label>
+                <input
+                  id="customer-name"
+                  name="name"
+                  className={fieldClass}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  autoComplete="name"
+                  required
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label htmlFor="customer-business-name" className="text-sm font-medium text-slate-700">
+                  Business name
+                </label>
+                <input
+                  id="customer-business-name"
+                  name="businessName"
+                  className={fieldClass}
+                  value={businessName}
+                  onChange={(e) => setBusinessName(e.target.value)}
+                  autoComplete="organization"
+                />
+                <p className={`text-xs ${t.mutedText}`}>Optional. Add it now only if it helps you keep your account organized.</p>
+              </div>
+
+              {error ? (
+                <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="flex flex-col gap-3 border-t border-slate-200/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                <p className={`text-xs ${t.mutedText}`}>* required</p>
+                <button type="submit" disabled={saving || !name.trim()} className={primaryButtonClass}>
+                  {saving ? 'Saving...' : mode === 'onboarding' ? 'Save and continue' : 'Save changes'}
+                </button>
+              </div>
+            </form>
+          </section>
+
+          <aside className={`${shellClass} order-2 lg:sticky lg:top-6 lg:self-start`}>
+            <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Account</div>
+            <div className="mt-3 text-sm font-medium text-slate-900 break-all">{email}</div>
+
+            <div className="mt-5 grid gap-3">
+              <div className={mutedCardClass}>
+                <div className="text-sm font-semibold text-slate-900">Keep it light</div>
+                <p className={`mt-1 text-sm ${t.mutedText}`}>No long business onboarding here. Just the basics needed for a signed-in customer account.</p>
+              </div>
+              <div className={mutedCardClass}>
+                <div className="text-sm font-semibold text-slate-900">Add more later</div>
+                <p className={`mt-1 text-sm ${t.mutedText}`}>Location, budget, and request details should be collected later inside actual request or messaging flows.</p>
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <Link href="/experts" className={secondaryLinkClass}>
+                Browse experts
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/onboarding/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/onboarding/page.tsx
@@ -1,0 +1,52 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import CustomerProfileForm from '../CustomerProfileForm';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+export default async function CustomerOnboardingPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const res = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer/onboarding');
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to load customer onboarding (${res.status})`);
+  }
+
+  const data = (await res.json()) as SummaryResponse;
+
+  if (data.user?.role === 'admin') {
+    redirect('/dashboard/admin');
+  }
+
+  if (data.user?.role === 'provider') {
+    redirect('/dashboard');
+  }
+
+  if ((data.customer?.name || '').trim()) {
+    redirect('/dashboard/customer/profile');
+  }
+
+  return (
+    <CustomerProfileForm
+      mode="onboarding"
+      email={data.user?.email || ''}
+      initialName={data.customer?.name || ''}
+      initialBusinessName={data.customer?.businessName || ''}
+    />
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/page.tsx
@@ -1,0 +1,44 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null } | null;
+};
+
+export default async function CustomerDashboardGatePage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const res = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer');
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to load customer account gate (${res.status})`);
+  }
+
+  const data = (await res.json()) as SummaryResponse;
+
+  if (data.user?.role === 'admin') {
+    redirect('/dashboard/admin');
+  }
+
+  if (data.user?.role === 'provider') {
+    redirect('/dashboard');
+  }
+
+  if ((data.customer?.name || '').trim()) {
+    redirect('/dashboard/customer/profile');
+  }
+
+  redirect('/dashboard/customer/onboarding');
+}

--- a/marketlink-frontend/src/app/dashboard/customer/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/profile/page.tsx
@@ -1,0 +1,52 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import CustomerProfileForm from '../CustomerProfileForm';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+export default async function CustomerProfilePage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const res = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer/profile');
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to load customer profile (${res.status})`);
+  }
+
+  const data = (await res.json()) as SummaryResponse;
+
+  if (data.user?.role === 'admin') {
+    redirect('/dashboard/admin');
+  }
+
+  if (data.user?.role === 'provider') {
+    redirect('/dashboard');
+  }
+
+  if (!(data.customer?.name || '').trim()) {
+    redirect('/dashboard/customer/onboarding');
+  }
+
+  return (
+    <CustomerProfileForm
+      mode="profile"
+      email={data.user?.email || ''}
+      initialName={data.customer?.name || ''}
+      initialBusinessName={data.customer?.businessName || ''}
+    />
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { useMarketLinkTheme } from '../../components/ThemeToggle';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
-type User = { id: string; email: string; role: 'provider' | 'admin' };
+type User = { id: string; email: string; role: 'provider' | 'customer' | 'admin' };
 
 type ExpertSummary = {
   id: string;
@@ -84,6 +84,11 @@ const [user, setUser] = useState<User | null>(null);
 
         if (data?.user?.role === 'admin') {
           router.replace('/dashboard/admin');
+          return;
+        }
+
+        if (data?.user?.role === 'customer') {
+          router.replace('/dashboard/customer');
           return;
         }
 

--- a/marketlink-frontend/src/app/signup/page.tsx
+++ b/marketlink-frontend/src/app/signup/page.tsx
@@ -11,7 +11,7 @@ type MeSummaryResponse =
   | { error?: string }
   | Record<string, unknown>;
 
-type LoginResponse = { ok: true; user?: { mustChangePassword?: boolean }; expiresAt?: string } | { ok: false; message?: string } | Record<string, unknown>;
+type SignupResponse = { ok: true; user?: { mustChangePassword?: boolean }; expiresAt?: string } | { ok: false; message?: string } | Record<string, unknown>;
 
 function safeInternalPath(raw: string | null | undefined, fallback: string) {
   const v = (raw || '').trim();
@@ -31,12 +31,12 @@ function pickRedirect(role: 'provider' | 'customer' | 'admin', desiredPath: stri
   return desiredPath;
 }
 
-function LoginLoadingState({ message }: { message: string }) {
+function SignupLoadingState({ message }: { message: string }) {
   return (
     <main className="ml-page-bg min-h-[calc(100vh-80px)]">
       <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-10">
         <div className="ml-card rounded-[2rem] px-6 py-8 shadow-[0_18px_48px_rgba(23,26,31,0.08)]">
-          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Sign in</h1>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900">Create account</h1>
           <p className="mt-2 text-sm text-slate-600">{message}</p>
         </div>
       </div>
@@ -44,21 +44,22 @@ function LoginLoadingState({ message }: { message: string }) {
   );
 }
 
-function LoginPageContent() {
+function SignupPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-
   const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
   const desiredPath = useMemo(() => {
     const returnTo = searchParams.get('returnTo');
     const next = searchParams.get('next');
-    return safeInternalPath(returnTo ?? next, '/dashboard');
+    return safeInternalPath(returnTo ?? next, '/dashboard/customer');
   }, [searchParams]);
 
   const [checkingSession, setCheckingSession] = useState(true);
+  const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
@@ -91,7 +92,7 @@ function LoginPageContent() {
         const didRedirect = await fetchRoleAndRedirect();
         if (didRedirect) return;
       } catch {
-        // ignore and show form
+        // ignore and show signup form
       } finally {
         if (!cancelled) setCheckingSession(false);
       }
@@ -106,37 +107,46 @@ function LoginPageContent() {
     e.preventDefault();
     setError('');
 
+    const cleanName = name.trim();
     const cleanEmail = email.trim().toLowerCase();
-    if (!cleanEmail || !password) {
-      setError('Enter your email and password.');
+    const cleanPassword = password.trim();
+    const cleanConfirmPassword = confirmPassword.trim();
+
+    if (!cleanName || !cleanEmail || !cleanPassword || !cleanConfirmPassword) {
+      setError('Enter your name, email, password, and confirm password.');
+      return;
+    }
+
+    if (cleanPassword !== cleanConfirmPassword) {
+      setError('Password and confirm password must match.');
       return;
     }
 
     setSubmitting(true);
     try {
-      const res = await fetch(`${API_BASE}/auth/login`, {
+      const res = await fetch(`${API_BASE}/auth/signup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ email: cleanEmail, password }),
+        body: JSON.stringify({ name: cleanName, email: cleanEmail, password: cleanPassword }),
       });
 
-      let data: LoginResponse | null = null;
+      let data: SignupResponse | null = null;
       try {
-        data = (await res.json()) as LoginResponse;
+        data = (await res.json()) as SignupResponse;
       } catch {
         // ok if backend returns empty
       }
 
       if (!res.ok) {
-        const msg = (data as { message?: string } | null)?.message || (res.status === 401 ? 'Invalid email or password.' : 'Login failed.');
+        const msg = (data as { message?: string } | null)?.message || 'Could not create the account.';
         setError(msg);
         return;
       }
 
       const didRedirect = await fetchRoleAndRedirect();
       if (!didRedirect) {
-        router.replace('/dashboard');
+        router.replace('/dashboard/customer');
         router.refresh();
       }
     } catch {
@@ -147,7 +157,7 @@ function LoginPageContent() {
   }
 
   if (checkingSession) {
-    return <LoginLoadingState message="Checking your session..." />;
+    return <SignupLoadingState message="Checking your session..." />;
   }
 
   return (
@@ -158,30 +168,30 @@ function LoginPageContent() {
             <div className="h-2 bg-[linear-gradient(90deg,#0f172a,#25324a,#b6bdc8)]" />
             <div className="bg-[radial-gradient(120%_120%_at_0%_0%,rgba(148,163,184,0.16),transparent_42%),linear-gradient(135deg,rgba(15,23,42,0.98),rgba(15,23,42,0.90))] px-5 py-6 sm:px-8 sm:py-10">
               <div className="inline-flex items-center rounded-xl border border-white/12 bg-white/6 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.24em] text-white/65">
-                Account access
+                Looking for experts?
               </div>
               <h1 className="mt-4 max-w-xl text-3xl font-semibold tracking-[-0.05em] text-white sm:mt-5 sm:text-5xl">
-                Sign in with the account you already have.
+                Create your account first, then keep the rest lightweight.
               </h1>
               <p className="mt-3 max-w-xl text-sm leading-6 text-slate-200/78 sm:mt-4 sm:text-base sm:leading-7">
-                Use this page if you already have an account. If you are just starting to look for experts, create your account first on the dedicated sign-up page.
+                We only need your name, email, and password here. Heavier business details should wait until you actually request help or start a conversation.
               </p>
 
               <div className="mt-5 grid gap-3 sm:mt-8 sm:grid-cols-2">
                 <div className="rounded-[1.3rem] border border-white/10 bg-white/6 px-4 py-4">
                   <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300">Looking for experts?</div>
-                  <div className="mt-2 text-sm font-semibold text-white">Sign up or log in</div>
-                  <p className="mt-2 text-sm leading-6 text-slate-200/72">Create your account first if you are new. If you already started one, just sign in with that same email and password.</p>
-                  <div className="mt-4">
-                    <Link href="/signup" className="inline-flex w-full justify-center rounded-xl bg-white px-4 py-3 text-sm font-semibold text-slate-900 sm:w-auto">
-                      Go to sign up
-                    </Link>
-                  </div>
+                  <div className="mt-2 text-sm font-semibold text-white">Minimal first step</div>
+                  <p className="mt-2 text-sm leading-6 text-slate-200/72">After sign up, MarketLink will route you straight into the customer area with only the minimum setup.</p>
                 </div>
                 <div className="rounded-[1.3rem] border border-white/10 bg-white/6 px-4 py-4">
                   <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300">Already an expert?</div>
-                  <div className="mt-2 text-sm font-semibold text-white">Log in here</div>
-                  <p className="mt-2 text-sm leading-6 text-slate-200/72">Experts and admins should keep using their existing login here instead of creating a new account.</p>
+                  <div className="mt-2 text-sm font-semibold text-white">Use sign in instead</div>
+                  <p className="mt-2 text-sm leading-6 text-slate-200/72">If you already have an expert or admin account, do not create a new account here. Use your existing login instead.</p>
+                  <div className="mt-4">
+                    <Link href="/login" className="inline-flex w-full justify-center rounded-xl bg-white px-4 py-3 text-sm font-semibold text-slate-900 sm:w-auto">
+                      Go to sign in
+                    </Link>
+                  </div>
                 </div>
               </div>
             </div>
@@ -190,14 +200,31 @@ function LoginPageContent() {
           <div className="ml-card order-1 rounded-[2rem] px-5 py-6 shadow-[0_18px_48px_rgba(23,26,31,0.08)] sm:px-8 sm:py-10 lg:order-2">
             <div className="flex items-start justify-between gap-4 border-b border-slate-200/80 pb-5">
               <div>
-                <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">Account access</div>
-                <h2 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-slate-900">Sign in</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-600">Enter the email and password for your existing account.</p>
+                <div className="text-[11px] font-medium uppercase tracking-[0.22em] text-slate-500">Get started</div>
+                <h2 className="mt-3 text-3xl font-semibold tracking-[-0.04em] text-slate-900">Create account</h2>
+                <p className="mt-2 text-sm leading-6 text-slate-600">Start with the basics only. You can add optional business details later.</p>
               </div>
-              <span className="ml-pill rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal">Secure</span>
+              <span className="ml-pill rounded-xl px-4 py-2 text-sm font-medium normal-case tracking-normal">Simple</span>
             </div>
 
             <form onSubmit={onSubmit} className="mt-6 grid gap-4">
+              <div className="grid gap-2">
+                <label htmlFor="name" className="text-sm font-medium text-slate-700">
+                  Name
+                </label>
+                <input
+                  id="name"
+                  name="name"
+                  type="text"
+                  autoComplete="name"
+                  className={fieldClass}
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={submitting}
+                  required
+                />
+              </div>
+
               <div className="grid gap-2">
                 <label htmlFor="email" className="text-sm font-medium text-slate-700">
                   Email
@@ -223,10 +250,27 @@ function LoginPageContent() {
                   id="password"
                   name="password"
                   type="password"
-                  autoComplete="current-password"
+                  autoComplete="new-password"
                   className={fieldClass}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
+                  disabled={submitting}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <label htmlFor="confirm-password" className="text-sm font-medium text-slate-700">
+                  Confirm password
+                </label>
+                <input
+                  id="confirm-password"
+                  name="confirmPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  className={fieldClass}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
                   disabled={submitting}
                   required
                 />
@@ -239,19 +283,19 @@ function LoginPageContent() {
               ) : null}
 
               <div className="flex flex-col gap-3 border-t border-slate-200/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
-                <div className="text-sm text-slate-600">Wrong email or password will show the message above so you can retry without leaving the page.</div>
+                <div className="text-sm text-slate-600">Already have an account? Use sign in instead.</div>
                 <button
                   type="submit"
                   disabled={submitting}
                   className="ml-btn-primary inline-flex min-h-11 w-full items-center justify-center rounded-xl px-6 py-3 text-sm font-semibold text-white disabled:opacity-60 sm:w-auto"
                 >
-                  {submitting ? 'Signing in...' : 'Sign in'}
+                  {submitting ? 'Creating...' : 'Create account'}
                 </button>
               </div>
 
               <div className="flex flex-col gap-2 pt-2 text-sm sm:flex-row sm:items-center sm:justify-between">
-                <Link href="/signup" className="font-medium text-slate-700 underline underline-offset-4 hover:text-slate-900">
-                  Looking for experts? Sign up
+                <Link href="/login" className="font-medium text-slate-700 underline underline-offset-4 hover:text-slate-900">
+                  Already have an account? Sign in
                 </Link>
                 <Link href="/experts" className="font-medium text-slate-700 underline underline-offset-4 hover:text-slate-900">
                   Browse experts
@@ -265,10 +309,10 @@ function LoginPageContent() {
   );
 }
 
-export default function LoginPage() {
+export default function SignupPage() {
   return (
-    <Suspense fallback={<LoginLoadingState message="Loading sign-in..." />}>
-      <LoginPageContent />
+    <Suspense fallback={<SignupLoadingState message="Loading sign up..." />}>
+      <SignupPageContent />
     </Suspense>
   );
 }

--- a/marketlink-frontend/src/components/AppHeader.tsx
+++ b/marketlink-frontend/src/components/AppHeader.tsx
@@ -7,7 +7,7 @@ import LogoutButton from '@/components/LogoutButton';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
-type Role = 'provider' | 'admin' | '' | null | string;
+type Role = 'provider' | 'customer' | 'admin' | '' | null | string;
 type NavItem = {
   href: string;
   label: string;
@@ -15,11 +15,13 @@ type NavItem = {
 };
 
 function canAccessDashboard(role: Role) {
-  return role === 'provider' || role === 'admin';
+  return role === 'provider' || role === 'customer' || role === 'admin';
 }
 
 function getDashboardHref(role: Role) {
-  return role === 'admin' ? '/dashboard/admin' : '/dashboard';
+  if (role === 'admin') return '/dashboard/admin';
+  if (role === 'customer') return '/dashboard/customer';
+  return '/dashboard';
 }
 
 export default function AppHeader() {


### PR DESCRIPTION
## Summary
- add dedicated customer signup and customer profile update backend endpoints
- route signed-in customers through a lightweight customer dashboard gate, onboarding, and profile flow
- split auth UI into sign-in and signup pages and make header/dashboard redirects customer-aware

## Verification
- node --test tests/account.customer.test.js tests/auth.customer.test.js
- node_modules\\.bin\\tsc.cmd --noEmit -p tsconfig.json
- npm exec eslint src/app/login/page.tsx src/app/signup/page.tsx src/app/dashboard/page.tsx src/app/dashboard/customer/page.tsx src/app/dashboard/customer/onboarding/page.tsx src/app/dashboard/customer/profile/page.tsx src/app/dashboard/customer/CustomerProfileForm.tsx src/components/AppHeader.tsx
- npm run build
- curl.exe -s -o NUL -w "%{http_code}" http://127.0.0.1:3000/login
- curl.exe -s -o NUL -w "%{http_code}" http://127.0.0.1:3000/signup
- curl.exe -s -o NUL -w "%{http_code}" http://127.0.0.1:3000/dashboard/customer
