### PR TITLE
Polish placeholders and homepage card hover

### DIFF
--- a/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/admin/providers/[id]/page.tsx
@@ -169,7 +169,7 @@ export default async function AdminProviderEditPage({ params }: AdminProviderEdi
   const mutedPanelClass =
     'rounded-[24px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]';
   const inputClass =
-    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
+    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
 
   return (
     <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">

--- a/marketlink-frontend/src/app/dashboard/onboarding/OnboardingForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/OnboardingForm.tsx
@@ -94,7 +94,7 @@ export default function OnboardingForm() {
   const sectionClass =
     'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(236,242,248,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
   const fieldClass =
-    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
+    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
   return (
     <main className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_320px] lg:items-start">

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -584,7 +584,7 @@ export default function ProfileEditorPage() {
   const disableSave = saving || !data.businessName.trim() || !data.city.trim() || !data.state.trim();
   const sectionClass = 'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.98),rgba(241,245,249,0.92))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
   const fieldClass =
-    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
+    'w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
   const checkboxClass = 'h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-200';
   const subtleButtonClass =
     'rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50';

--- a/marketlink-frontend/src/app/globals.css
+++ b/marketlink-frontend/src/app/globals.css
@@ -122,6 +122,13 @@ a {
     box-shadow: 0 34px 88px rgba(23, 26, 31, 0.13);
   }
 
+  .ml-card-hover.ml-dark-panel:hover,
+  .ml-card-hover.ml-dark-panel:active,
+  .ml-card-hover.ml-dark-panel:focus-visible {
+    background: linear-gradient(180deg, rgba(38, 58, 90, 1), rgba(20, 31, 53, 1)) !important;
+    box-shadow: 0 30px 82px rgba(23, 26, 31, 0.24);
+  }
+
   .ml-header {
     border-color: var(--ml-header-border);
     background: var(--ml-header-bg);
@@ -244,8 +251,12 @@ a {
       background 180ms ease;
   }
 
-  .ml-input::placeholder {
-    color: rgba(var(--ml-muted), 0.72);
+  .ml-input::placeholder,
+  .ml-input::-webkit-input-placeholder {
+    color: rgba(var(--ml-muted), 0.12) !important;
+    font-style: normal;
+    letter-spacing: 0.01em;
+    opacity: 1;
   }
 
   .ml-input:focus {

--- a/marketlink-frontend/src/components/TaxonomyServicePicker.tsx
+++ b/marketlink-frontend/src/components/TaxonomyServicePicker.tsx
@@ -254,7 +254,7 @@ export default function TaxonomyServicePicker({ services, onChange, required = f
             }}
             placeholder={canAddMoreSubjects ? 'Search areas like creator promotion, reels, or reviews' : 'Remove one area to add another'}
             disabled={!canAddMoreSubjects}
-            className="w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 pr-10 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
+            className="w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 pr-10 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
             role="combobox"
             aria-autocomplete="list"
             aria-controls={areaListId}
@@ -336,7 +336,7 @@ export default function TaxonomyServicePicker({ services, onChange, required = f
                   : 'Remove one help type to add another'
             }
             disabled={!selectedSubjectIds.length || !canAddMoreHelp}
-            className="w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 pr-10 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
+            className="w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 pr-10 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-400"
             role="combobox"
             aria-autocomplete="list"
             aria-controls={helpListId}

--- a/marketlink-frontend/src/components/admin/InviteUserForm.tsx
+++ b/marketlink-frontend/src/components/admin/InviteUserForm.tsx
@@ -43,7 +43,7 @@ export default function InviteUserForm() {
   };
 
   const fieldClass =
-    'mt-1 w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
+    'mt-1 w-full rounded-2xl border border-slate-200/80 bg-white px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 placeholder:opacity-55 focus:border-slate-400 focus:bg-white focus:ring-2 focus:ring-slate-200/70';
   const mutedPanelClass =
     'rounded-[24px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.98),rgba(226,232,240,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]';
 


### PR DESCRIPTION
## What changed
- lighten placeholder presentation across dashboard and admin form inputs
- keep dark homepage service cards dark on hover, tap, and focus so white text stays readable

## Scope
This is a small frontend polish/regression bundle. It does not map cleanly to a single Jira ticket.

## Verification
- cd marketlink-frontend
- npm exec eslint src/app/dashboard/admin/providers/[id]/page.tsx src/app/dashboard/onboarding/OnboardingForm.tsx src/app/dashboard/profile/page.tsx src/app/globals.css src/components/TaxonomyServicePicker.tsx src/components/admin/InviteUserForm.tsx
- npm run build