### PR TITLE
MM-48 regression pass for provider and admin auth

### DIFF
--- a/marketlink-backend/tests/account.roles.test.js
+++ b/marketlink-backend/tests/account.roles.test.js
@@ -1,0 +1,152 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+
+const sessionModule = require('../src/lib/session');
+const prismaModule = require('../src/lib/prisma');
+const accountRoutes = require('../src/routes/account').default;
+
+test('GET /me/summary keeps provider expert data and compatibility alias intact', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(accountRoutes);
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalFindFirstExpert = prismaModule.prisma.expert.findFirst;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert.findFirst = async () => ({
+    id: 'expert_1',
+    slug: 'provider-profile',
+    businessName: 'Provider Profile',
+    expertType: 'agency',
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60601',
+    streetAddress: '123 Main St',
+    locationPrecision: 'exact',
+    tagline: 'Local growth partner',
+    shortDescription: 'Short summary',
+    overview: 'Overview',
+    websiteUrl: 'https://example.com',
+    phone: '555-111-2222',
+    linkedinUrl: '',
+    instagramUrl: '',
+    facebookUrl: '',
+    creatorPlatforms: [],
+    creatorAudienceSize: null,
+    creatorProofSummary: null,
+    foundedYear: 2020,
+    hourlyRateMin: 100,
+    hourlyRateMax: 150,
+    minProjectBudget: 5000,
+    currencyCode: 'USD',
+    languages: [],
+    industries: [],
+    clientSizes: [],
+    specialties: [],
+    remoteFriendly: true,
+    servesNationwide: false,
+    responseTimeHours: 24,
+    logo: null,
+    services: ['ads'],
+    status: 'active',
+    disabledReason: null,
+    projects: [],
+    clients: [],
+    media: [],
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/me/summary',
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.user.role, 'provider');
+    assert.equal(body.customer, null);
+    assert.equal(body.expert.id, 'expert_1');
+    assert.equal(body.provider.id, 'expert_1');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert.findFirst = originalFindFirstExpert;
+    await fastify.close();
+  }
+});
+
+test('GET /me/summary keeps admin accounts out of customer and provider data', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(accountRoutes);
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalFindFirstExpert = prismaModule.prisma.expert.findFirst;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'admin_user_1',
+    email: 'admin@example.com',
+    role: 'admin',
+  });
+
+  prismaModule.prisma.expert.findFirst = async () => null;
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/me/summary',
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.user.role, 'admin');
+    assert.equal(body.customer, null);
+    assert.equal(body.expert, null);
+    assert.equal(body.provider, null);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert.findFirst = originalFindFirstExpert;
+    await fastify.close();
+  }
+});
+
+test('PUT /me/customer-profile rejects provider accounts', async () => {
+  const fastify = Fastify();
+  await fastify.register(cookie, { secret: 'test-secret' });
+  await fastify.register(accountRoutes);
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_2',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'PUT',
+      url: '/me/customer-profile',
+      payload: {
+        name: 'Jamie Rivera',
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.json().error, 'Only customers can update customer profiles.');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    await fastify.close();
+  }
+});

--- a/marketlink-backend/tests/auth.roles.test.js
+++ b/marketlink-backend/tests/auth.roles.test.js
@@ -1,0 +1,67 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+const bcrypt = require('bcryptjs');
+
+const prismaModule = require('../src/lib/prisma');
+const sessionModule = require('../src/lib/session');
+const authRoutes = require('../src/routes/auth').default;
+
+for (const role of ['provider', 'admin']) {
+  test(`POST /auth/login preserves ${role} role in the auth response`, async () => {
+    const fastify = Fastify();
+    await fastify.register(cookie, { secret: 'test-secret' });
+    await fastify.register(authRoutes);
+
+    const originalFindUnique = prismaModule.prisma.user.findUnique;
+    const originalCreateSessionForUser = sessionModule.createSessionForUser;
+    const originalSetSessionCookie = sessionModule.setSessionCookie;
+
+    let cookieToken = null;
+    const passwordHash = await bcrypt.hash('password123', 10);
+
+    prismaModule.prisma.user.findUnique = async () => ({
+      id: `${role}_user_1`,
+      email: `${role}@example.com`,
+      role,
+      passwordHash,
+      mustChangePassword: role === 'provider',
+      isDisabled: false,
+    });
+
+    sessionModule.createSessionForUser = async () => ({
+      sessionToken: `session_${role}_1`,
+      expiresAt: 123456789,
+    });
+
+    sessionModule.setSessionCookie = (reply, token) => {
+      cookieToken = token;
+      reply.header('set-cookie', `session=${token}`);
+    };
+
+    try {
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/auth/login',
+        payload: {
+          email: `${role}@example.com`,
+          password: 'password123',
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      const body = response.json();
+      assert.equal(body.ok, true);
+      assert.equal(body.user.role, role);
+      assert.equal(cookieToken, `session_${role}_1`);
+    } finally {
+      prismaModule.prisma.user.findUnique = originalFindUnique;
+      sessionModule.createSessionForUser = originalCreateSessionForUser;
+      sessionModule.setSessionCookie = originalSetSessionCookie;
+      await fastify.close();
+    }
+  });
+}

--- a/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/onboarding/page.tsx
@@ -4,6 +4,12 @@ import OnboardingForm from './OnboardingForm';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
+type SummaryResponse = {
+  user?: { role?: 'provider' | 'customer' | 'admin' };
+  expert?: { id: string } | null;
+  provider?: { id: string } | null;
+};
+
 export default async function OnboardingPage() {
   const cookieStore = await cookies();
   const sessionCookie = cookieStore.get('session');
@@ -22,7 +28,15 @@ export default async function OnboardingPage() {
     throw new Error(`Failed to load onboarding gate (${res.status})`);
   }
 
-  const data = (await res.json()) as { expert?: { id: string } | null; provider?: { id: string } | null };
+  const data = (await res.json()) as SummaryResponse;
+
+  if (data.user?.role === 'customer') {
+    redirect('/dashboard/customer');
+  }
+
+  if (data.user?.role === 'admin') {
+    redirect('/dashboard/admin');
+  }
 
   if (data.expert || data.provider) {
     redirect('/dashboard/profile');

--- a/marketlink-frontend/src/app/dashboard/profile/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/profile/page.tsx
@@ -8,7 +8,7 @@ import { getStateDisplayName, normalizeStateCode } from '@/lib/usStates';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
-type Role = 'provider' | 'admin';
+type Role = 'provider' | 'customer' | 'admin';
 
 type ProviderStatus = 'active' | 'pending' | 'disabled';
 
@@ -166,6 +166,9 @@ export default function ProfileEditorPage() {
         const me = (await meRes.json()) as MeSummaryResponse;
         const meRole = (me?.user?.role || 'provider') as Role;
         setRole(meRole);
+
+        if (meRole === 'customer') return router.replace('/dashboard/customer');
+        if (meRole === 'admin') return router.replace('/dashboard/admin');
 
         const p = me.expert ?? me.provider;
         if (!p) return router.replace('/dashboard/onboarding');

--- a/marketlink-frontend/tests/customer-dashboard-guards.spec.ts
+++ b/marketlink-frontend/tests/customer-dashboard-guards.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect, type APIRequestContext, type BrowserContext, type Page } from '@playwright/test';
+
+const BASE_URL = process.env.ML_BASE_URL || 'http://localhost:3000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+async function createCustomerSession(request: APIRequestContext, context: BrowserContext) {
+  const email = `playwright-customer+${Date.now()}@example.com`;
+  const response = await request.post(`${API_BASE_URL}/auth/signup`, {
+    data: {
+      name: 'Jamie Rivera',
+      email,
+      password: 'password123',
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  const setCookie = response.headers()['set-cookie'];
+  expect(setCookie).toBeTruthy();
+
+  const match = /session=([^;]+)/.exec(setCookie || '');
+  expect(match).toBeTruthy();
+
+  await context.addCookies([
+    {
+      name: 'session',
+      value: match?.[1] || '',
+      domain: new URL(BASE_URL).hostname,
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function openCustomerArea(page: Page, request: APIRequestContext) {
+  await createCustomerSession(request, page.context());
+  await page.goto(`${BASE_URL}/dashboard/customer`);
+  await expect(page).toHaveURL(/\/dashboard\/customer/);
+}
+
+test('customer is kept out of provider onboarding route', async ({ page, request }) => {
+  await openCustomerArea(page, request);
+
+  await page.goto(`${BASE_URL}/dashboard/onboarding`);
+  await expect(page).toHaveURL(/\/dashboard\/customer/);
+});


### PR DESCRIPTION
## What changed
- keep customer accounts out of provider onboarding and profile routes
- add backend regression tests for provider/admin login and role-aware /me/summary behavior
- add a frontend Playwright regression for the customer onboarding guard

## Verification
- cd marketlink-backend && npx prisma generate
- cd marketlink-backend && node --test tests/auth.customer.test.js tests/account.customer.test.js tests/auth.roles.test.js tests/account.roles.test.js
- cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json
- cd marketlink-frontend && npm exec eslint src/app/dashboard/onboarding/page.tsx src/app/dashboard/profile/page.tsx tests/customer-dashboard-guards.spec.ts
- cd marketlink-frontend && npm run build
- cd marketlink-frontend && ML_BASE_URL=http://localhost:3001 npm exec playwright test tests/customer-dashboard-guards.spec.ts

## Notes
- the browser regression was run against a branch-local frontend on port 3001 while the existing backend stayed on 4000
- no schema or auth endpoint contract changes were made