### PR TITLE
MM-51 create customer request API routes and validation

### DIFF
--- a/marketlink-backend/prisma/migrations/20260525110000_add_customer_requests/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260525110000_add_customer_requests/migration.sql
@@ -1,0 +1,41 @@
+-- CreateEnum
+CREATE TYPE "CustomerRequestStatus" AS ENUM ('OPEN', 'CLOSED');
+
+-- CreateTable
+CREATE TABLE "CustomerRequest" (
+    "id" TEXT NOT NULL,
+    "customerUserId" TEXT NOT NULL,
+    "customerProfileId" TEXT,
+    "requesterName" TEXT NOT NULL,
+    "requesterBusinessName" TEXT,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "marketingSubjectId" TEXT NOT NULL,
+    "serviceTokens" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "zip" TEXT NOT NULL,
+    "budgetLabel" TEXT,
+    "timelineLabel" TEXT,
+    "status" "CustomerRequestStatus" NOT NULL DEFAULT 'OPEN',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CustomerRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CustomerRequest_customerUserId_createdAt_idx" ON "CustomerRequest"("customerUserId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CustomerRequest_status_createdAt_idx" ON "CustomerRequest"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "CustomerRequest_marketingSubjectId_status_idx" ON "CustomerRequest"("marketingSubjectId", "status");
+
+-- CreateIndex
+CREATE INDEX "CustomerRequest_zip_status_idx" ON "CustomerRequest"("zip", "status");
+
+-- AddForeignKey
+ALTER TABLE "CustomerRequest" ADD CONSTRAINT "CustomerRequest_customerUserId_fkey" FOREIGN KEY ("customerUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CustomerRequest" ADD CONSTRAINT "CustomerRequest_customerProfileId_fkey" FOREIGN KEY ("customerProfileId") REFERENCES "CustomerProfile"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   passwordHash       String?
   adminActions       AdminAction[]
   customerProfile    CustomerProfile?
+  customerRequests   CustomerRequest[]
   experts            Expert[]
   sessions           Session[]
 }
@@ -30,6 +31,7 @@ model CustomerProfile {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
   user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  requests     CustomerRequest[]
 }
 
 model Expert {
@@ -180,6 +182,36 @@ enum InquiryStatus {
   NEW
   READ
   ARCHIVED
+}
+
+enum CustomerRequestStatus {
+  OPEN
+  CLOSED
+}
+
+model CustomerRequest {
+  id                    String                @id @default(cuid())
+  customerUserId        String
+  customerProfileId     String?
+  requesterName         String
+  requesterBusinessName String?
+  title                 String
+  description           String
+  marketingSubjectId    String
+  serviceTokens         String[]              @default([])
+  zip                   String
+  budgetLabel           String?
+  timelineLabel         String?
+  status                CustomerRequestStatus @default(OPEN)
+  createdAt             DateTime              @default(now())
+  updatedAt             DateTime              @updatedAt
+  customerUser          User                  @relation(fields: [customerUserId], references: [id], onDelete: Cascade)
+  customerProfile       CustomerProfile?      @relation(fields: [customerProfileId], references: [id], onDelete: SetNull)
+
+  @@index([customerUserId, createdAt])
+  @@index([status, createdAt])
+  @@index([marketingSubjectId, status])
+  @@index([zip, status])
 }
 
 ///

--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -1,0 +1,173 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { CustomerRequestStatus } from '@prisma/client';
+import { prisma } from '../lib/prisma';
+import { getUserFromRequest } from '../lib/session';
+
+const ZIP_RE = /^\d{5}$/;
+
+function asCleanString(input: unknown) {
+  return String(input || '').trim();
+}
+
+function asServiceTokens(input: unknown) {
+  if (!Array.isArray(input)) return [];
+
+  return Array.from(
+    new Set(
+      input
+        .map((value) => String(value || '').trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
+const requestsRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post('/requests', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can create requests.' });
+
+    const body = (req.body || {}) as {
+      title?: unknown;
+      description?: unknown;
+      marketingSubjectId?: unknown;
+      serviceTokens?: unknown;
+      zip?: unknown;
+      budgetLabel?: unknown;
+      timelineLabel?: unknown;
+    };
+
+    const title = asCleanString(body.title);
+    const description = asCleanString(body.description);
+    const marketingSubjectId = asCleanString(body.marketingSubjectId);
+    const serviceTokens = asServiceTokens(body.serviceTokens);
+    const zip = asCleanString(body.zip);
+    const budgetLabel = asCleanString(body.budgetLabel) || null;
+    const timelineLabel = asCleanString(body.timelineLabel) || null;
+
+    if (!title) return reply.code(400).send({ ok: false, error: 'title is required' });
+    if (!description) return reply.code(400).send({ ok: false, error: 'description is required' });
+    if (!marketingSubjectId) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is required' });
+    if (serviceTokens.length === 0) return reply.code(400).send({ ok: false, error: 'serviceTokens must include at least one item' });
+    if (!zip || !ZIP_RE.test(zip)) return reply.code(400).send({ ok: false, error: 'zip must be a valid 5-digit ZIP code' });
+
+    if (title.length > 140) return reply.code(400).send({ ok: false, error: 'title is too long' });
+    if (description.length > 4000) return reply.code(400).send({ ok: false, error: 'description is too long' });
+    if (marketingSubjectId.length > 80) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is too long' });
+    if (serviceTokens.length > 12) return reply.code(400).send({ ok: false, error: 'serviceTokens cannot exceed 12 items' });
+    if (serviceTokens.some((token) => token.length > 80)) return reply.code(400).send({ ok: false, error: 'serviceTokens contains an item that is too long' });
+    if (budgetLabel && budgetLabel.length > 80) return reply.code(400).send({ ok: false, error: 'budgetLabel is too long' });
+    if (timelineLabel && timelineLabel.length > 80) return reply.code(400).send({ ok: false, error: 'timelineLabel is too long' });
+
+    const customerProfile = await prisma.customerProfile.findUnique({
+      where: { userId: user.id },
+      select: {
+        id: true,
+        name: true,
+        businessName: true,
+      },
+    });
+
+    if (!customerProfile?.name?.trim()) {
+      return reply.code(400).send({ ok: false, error: 'Complete your customer profile before creating a request.' });
+    }
+
+    const created = await prisma.customerRequest.create({
+      data: {
+        customerUserId: user.id,
+        customerProfileId: customerProfile.id,
+        requesterName: customerProfile.name.trim(),
+        requesterBusinessName: customerProfile.businessName?.trim() || null,
+        title,
+        description,
+        marketingSubjectId,
+        serviceTokens,
+        zip,
+        budgetLabel,
+        timelineLabel,
+        status: CustomerRequestStatus.OPEN,
+      },
+      select: {
+        id: true,
+        customerUserId: true,
+        customerProfileId: true,
+        requesterName: true,
+        requesterBusinessName: true,
+        title: true,
+        description: true,
+        marketingSubjectId: true,
+        serviceTokens: true,
+        zip: true,
+        budgetLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    req.log.info({ requestId: created.id, customerUserId: user.id }, 'customer-request.created');
+    return reply.code(201).send({ ok: true, request: created });
+  });
+
+  fastify.get('/requests', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can view requests.' });
+
+    const rows = await prisma.customerRequest.findMany({
+      where: { customerUserId: user.id },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        title: true,
+        marketingSubjectId: true,
+        serviceTokens: true,
+        zip: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      take: 100,
+    });
+
+    return reply.send({ ok: true, data: rows });
+  });
+
+  fastify.get('/requests/:id', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can view requests.' });
+
+    const { id } = (req.params || {}) as { id?: string };
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing request id' });
+
+    const request = await prisma.customerRequest.findFirst({
+      where: {
+        id,
+        customerUserId: user.id,
+      },
+      select: {
+        id: true,
+        requesterName: true,
+        requesterBusinessName: true,
+        title: true,
+        description: true,
+        marketingSubjectId: true,
+        serviceTokens: true,
+        zip: true,
+        budgetLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!request) return reply.code(404).send({ ok: false, error: 'Request not found' });
+
+    return reply.send({ ok: true, request });
+  });
+};
+
+export default requestsRoutes;

--- a/marketlink-backend/src/server.ts
+++ b/marketlink-backend/src/server.ts
@@ -9,6 +9,7 @@ import authRoutes from './routes/auth';
 import accountRoutes from './routes/account';
 import expertsRoutes from './routes/providers';
 import inquiriesRoutes from './routes/inquiries';
+import requestsRoutes from './routes/requests';
 
 function normalizeOrigin(raw: string) {
   return raw.trim().replace(/\/$/, '');
@@ -59,6 +60,7 @@ async function start() {
   await fastify.register(accountRoutes);
   await fastify.register(expertsRoutes);
   await fastify.register(inquiriesRoutes);
+  await fastify.register(requestsRoutes);
   await fastify.register(adminRoutes);
 
   const port = Number(process.env.PORT || 4000);

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -1,0 +1,259 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+
+const sessionModule = require('../src/lib/session');
+const prismaModule = require('../src/lib/prisma');
+const requestsRoutes = require('../src/routes/requests').default;
+
+function buildFastify() {
+  const fastify = Fastify();
+  return fastify.register(cookie, { secret: 'test-secret' }).then(() => fastify.register(requestsRoutes)).then(() => fastify);
+}
+
+test('POST /requests rejects non-customer users', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Need more local leads',
+        description: 'Looking for help with paid ads and landing pages.',
+        marketingSubjectId: 'paid-ads-lead-generation',
+        serviceTokens: ['paid-ads', 'google-ads'],
+        zip: '60559',
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(response.json().error, 'Only customers can create requests.');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    await fastify.close();
+  }
+});
+
+test('POST /requests validates required request fields', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_1',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    }),
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: '',
+        description: '',
+        marketingSubjectId: '',
+        serviceTokens: [],
+        zip: '6055',
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().error, 'title is required');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    await fastify.close();
+  }
+});
+
+test('POST /requests creates a customer request for the signed-in customer', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_2',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_2',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    }),
+  };
+
+  prismaModule.prisma.customerRequest = {
+    create: async ({ data }) => ({
+      id: 'request_1',
+      customerUserId: data.customerUserId,
+      customerProfileId: data.customerProfileId,
+      requesterName: data.requesterName,
+      requesterBusinessName: data.requesterBusinessName,
+      title: data.title,
+      description: data.description,
+      marketingSubjectId: data.marketingSubjectId,
+      serviceTokens: data.serviceTokens,
+      zip: data.zip,
+      budgetLabel: data.budgetLabel,
+      timelineLabel: data.timelineLabel,
+      status: data.status,
+      createdAt: new Date('2026-05-25T15:00:00.000Z'),
+      updatedAt: new Date('2026-05-25T15:00:00.000Z'),
+    }),
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Need help launching local Google Ads',
+        description: 'Need a local specialist to set up search campaigns for a dental office.',
+        marketingSubjectId: 'paid-ads-lead-generation',
+        serviceTokens: ['paid-ads', 'google-ads', 'lead-generation'],
+        zip: '60559',
+        budgetLabel: '$2k-$5k',
+        timelineLabel: 'This month',
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.request.id, 'request_1');
+    assert.equal(body.request.requesterName, 'Jamie Rivera');
+    assert.equal(body.request.requesterBusinessName, 'Westmont Dental');
+    assert.equal(body.request.status, 'OPEN');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    await fastify.close();
+  }
+});
+
+test('GET /requests lists only the signed-in customer requests', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_3',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerRequest = {
+    findMany: async ({ where }) => {
+      assert.equal(where.customerUserId, 'customer_user_3');
+      return [
+        {
+          id: 'request_2',
+          title: 'Need local SEO help',
+          marketingSubjectId: 'local-search-seo',
+          serviceTokens: ['seo', 'local-seo'],
+          zip: '60601',
+          status: 'OPEN',
+          createdAt: new Date('2026-05-24T15:00:00.000Z'),
+          updatedAt: new Date('2026-05-24T15:00:00.000Z'),
+        },
+      ];
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/requests',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].id, 'request_2');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    await fastify.close();
+  }
+});
+
+test('GET /requests/:id only returns a request owned by the signed-in customer', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_4',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerRequest = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'request_3');
+      assert.equal(where.customerUserId, 'customer_user_4');
+      return {
+        id: 'request_3',
+        title: 'Need creator support for a restaurant launch',
+        description: 'Looking for local creators who can visit and post.',
+        marketingSubjectId: 'creator-influencer-marketing',
+        serviceTokens: ['creator-marketing', 'local-influencer'],
+        zip: '60614',
+        budgetLabel: '$1k-$2k',
+        timelineLabel: 'Next 30 days',
+        status: 'OPEN',
+        requesterName: 'Jamie Rivera',
+        requesterBusinessName: 'Westmont Dental',
+        createdAt: new Date('2026-05-23T15:00:00.000Z'),
+        updatedAt: new Date('2026-05-23T15:00:00.000Z'),
+      };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/requests/request_3',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.request.id, 'request_3');
+    assert.equal(body.request.marketingSubjectId, 'creator-influencer-marketing');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    await fastify.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated customer request model and migration separate from expert inquiries
- add customer-only request create, list, and detail routes with server-side validation
- add backend regression tests for request auth, validation, create, list, and ownership checks

## Verify
- cd marketlink-backend && npx prisma generate
- cd marketlink-backend && node --test tests/requests.test.js
- cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json
- cd marketlink-backend && npm run build