### PR TITLE
MM-50 add customer request lifecycle states

### DIFF
--- a/marketlink-backend/prisma/migrations/20260525143000_update_customer_request_status_lifecycle/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260525143000_update_customer_request_status_lifecycle/migration.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "CustomerRequestStatus" RENAME VALUE 'OPEN' TO 'ACTIVE';
+
+ALTER TYPE "CustomerRequestStatus" ADD VALUE 'CANCELLED';

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -185,8 +185,9 @@ enum InquiryStatus {
 }
 
 enum CustomerRequestStatus {
-  OPEN
+  ACTIVE
   CLOSED
+  CANCELLED
 }
 
 model CustomerRequest {
@@ -202,7 +203,7 @@ model CustomerRequest {
   zip                   String
   budgetLabel           String?
   timelineLabel         String?
-  status                CustomerRequestStatus @default(OPEN)
+  status                CustomerRequestStatus @default(ACTIVE)
   createdAt             DateTime              @default(now())
   updatedAt             DateTime              @updatedAt
   customerUser          User                  @relation(fields: [customerUserId], references: [id], onDelete: Cascade)

--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -85,7 +85,7 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         zip,
         budgetLabel,
         timelineLabel,
-        status: CustomerRequestStatus.OPEN,
+        status: CustomerRequestStatus.ACTIVE,
       },
       select: {
         id: true,

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -149,7 +149,7 @@ test('POST /requests creates a customer request for the signed-in customer', asy
     assert.equal(body.request.id, 'request_1');
     assert.equal(body.request.requesterName, 'Jamie Rivera');
     assert.equal(body.request.requesterBusinessName, 'Westmont Dental');
-    assert.equal(body.request.status, 'OPEN');
+    assert.equal(body.request.status, 'ACTIVE');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerProfile = originalCustomerProfile;
@@ -180,7 +180,7 @@ test('GET /requests lists only the signed-in customer requests', async () => {
           marketingSubjectId: 'local-search-seo',
           serviceTokens: ['seo', 'local-seo'],
           zip: '60601',
-          status: 'OPEN',
+          status: 'ACTIVE',
           createdAt: new Date('2026-05-24T15:00:00.000Z'),
           updatedAt: new Date('2026-05-24T15:00:00.000Z'),
         },
@@ -231,7 +231,7 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
         zip: '60614',
         budgetLabel: '$1k-$2k',
         timelineLabel: 'Next 30 days',
-        status: 'OPEN',
+        status: 'ACTIVE',
         requesterName: 'Jamie Rivera',
         requesterBusinessName: 'Westmont Dental',
         createdAt: new Date('2026-05-23T15:00:00.000Z'),


### PR DESCRIPTION
## Summary
- update customer request lifecycle states to match the request-flow schema ticket
- rename the default active state from OPEN to ACTIVE and add CANCELLED
- add the enum migration and align the existing request route/tests with the updated lifecycle values

## Verify
- cd marketlink-backend && npx prisma generate
- cd marketlink-backend && node --test tests/requests.test.js
- cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json
- cd marketlink-backend && npm run build