### PR TITLE
MM-52 implement request matching preview

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -1,9 +1,18 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { CustomerRequestStatus } from '@prisma/client';
+import { CustomerRequestStatus, ExpertStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
+import { lookupZipLocation } from '../lib/geocoding';
 
 const ZIP_RE = /^\d{5}$/;
+
+type RequestMatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
+
+type DeliveryPreviewInput = {
+  id: string;
+  serviceTokens: string[];
+  zip: string;
+};
 
 function asCleanString(input: unknown) {
   return String(input || '').trim();
@@ -19,6 +28,106 @@ function asServiceTokens(input: unknown) {
         .filter(Boolean),
     ),
   );
+}
+
+function normalizeCity(value: string | null | undefined) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeState(value: string | null | undefined) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function getReasonWeight(reason: RequestMatchReason) {
+  if (reason === 'same_zip') return 400;
+  if (reason === 'same_city') return 300;
+  if (reason === 'serves_nationwide') return 200;
+  return 100;
+}
+
+async function buildDeliveryPreview(input: DeliveryPreviewInput) {
+  const locationLookup = await lookupZipLocation({ zip: input.zip });
+  const requestCity = locationLookup.ok ? locationLookup.city : null;
+  const requestState = locationLookup.ok ? locationLookup.state : null;
+  const requestZip = locationLookup.ok ? locationLookup.zip : input.zip;
+
+  const experts = await prisma.expert.findMany({
+    where: {
+      status: ExpertStatus.active,
+      services: { hasSome: input.serviceTokens },
+    },
+    select: {
+      id: true,
+      slug: true,
+      businessName: true,
+      city: true,
+      state: true,
+      zip: true,
+      remoteFriendly: true,
+      servesNationwide: true,
+      services: true,
+      verified: true,
+      rating: true,
+    },
+    take: 200,
+  });
+
+  const matches = experts
+    .map((expert) => {
+      const matchedServiceTokens = expert.services.filter((token) => input.serviceTokens.includes(token));
+      if (!matchedServiceTokens.length) return null;
+
+      const sameZip = Boolean(expert.zip && expert.zip.trim() === requestZip);
+      const sameCity =
+        Boolean(requestCity && requestState) &&
+        normalizeCity(expert.city) === normalizeCity(requestCity) &&
+        normalizeState(expert.state) === normalizeState(requestState);
+
+      const reasons: RequestMatchReason[] = [];
+      if (sameZip) reasons.push('same_zip');
+      else if (sameCity) reasons.push('same_city');
+      else if (expert.servesNationwide) reasons.push('serves_nationwide');
+      else if (expert.remoteFriendly) reasons.push('remote_friendly');
+
+      if (!reasons.length) return null;
+
+      const primaryReason = reasons[0];
+      return {
+        id: expert.id,
+        slug: expert.slug,
+        businessName: expert.businessName,
+        city: expert.city,
+        state: expert.state,
+        zip: expert.zip,
+        verified: expert.verified,
+        rating: expert.rating,
+        remoteFriendly: expert.remoteFriendly,
+        servesNationwide: expert.servesNationwide,
+        matchedServiceTokens,
+        primaryReason,
+        reasons,
+        score: getReasonWeight(primaryReason) + matchedServiceTokens.length,
+      };
+    })
+    .filter((match): match is NonNullable<typeof match> => Boolean(match))
+    .sort((a, b) => b.score - a.score || b.rating - a.rating || a.businessName.localeCompare(b.businessName));
+
+  return {
+    requestId: input.id,
+    matchingModel: 'city-zip-service-v1',
+    requestLocation: {
+      zip: requestZip,
+      city: requestCity,
+      state: requestState,
+      source: locationLookup.ok ? 'zip_lookup' : 'zip_only',
+    },
+    notes: [
+      'MVP matching uses service tags plus same ZIP, same city, nationwide coverage, or remote-friendly service area.',
+      ...(locationLookup.ok ? [] : ['ZIP lookup was unavailable, so locality matching fell back to ZIP-only checks.']),
+    ],
+    totalMatches: matches.length,
+    matchedExperts: matches.map(({ score, ...match }) => match),
+  };
 }
 
 const requestsRoutes: FastifyPluginAsync = async (fastify) => {
@@ -107,7 +216,13 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     req.log.info({ requestId: created.id, customerUserId: user.id }, 'customer-request.created');
-    return reply.code(201).send({ ok: true, request: created });
+    const deliveryPreview = await buildDeliveryPreview({
+      id: created.id,
+      serviceTokens: created.serviceTokens,
+      zip: created.zip,
+    });
+
+    return reply.code(201).send({ ok: true, request: created, deliveryPreview });
   });
 
   fastify.get('/requests', async (req, reply) => {
@@ -166,7 +281,13 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
 
     if (!request) return reply.code(404).send({ ok: false, error: 'Request not found' });
 
-    return reply.send({ ok: true, request });
+    const deliveryPreview = await buildDeliveryPreview({
+      id: request.id,
+      serviceTokens: request.serviceTokens,
+      zip: request.zip,
+    });
+
+    return reply.send({ ok: true, request, deliveryPreview });
   });
 };
 

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -7,6 +7,7 @@ const cookie = require('@fastify/cookie');
 
 const sessionModule = require('../src/lib/session');
 const prismaModule = require('../src/lib/prisma');
+const geocodingModule = require('../src/lib/geocoding');
 const requestsRoutes = require('../src/routes/requests').default;
 
 function buildFastify() {
@@ -93,6 +94,8 @@ test('POST /requests creates a customer request for the signed-in customer', asy
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerProfile = prismaModule.prisma.customerProfile;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
     id: 'customer_user_2',
@@ -127,6 +130,59 @@ test('POST /requests creates a customer request for the signed-in customer', asy
       updatedAt: new Date('2026-05-25T15:00:00.000Z'),
     }),
   };
+  prismaModule.prisma.expert = {
+    findMany: async () => [
+      {
+        id: 'expert_same_zip',
+        slug: 'westmont-growth',
+        businessName: 'Westmont Growth',
+        city: 'Westmont',
+        state: 'IL',
+        zip: '60559',
+        remoteFriendly: false,
+        servesNationwide: false,
+        services: ['paid-ads', 'google-ads'],
+        verified: true,
+        rating: 4.9,
+      },
+      {
+        id: 'expert_remote',
+        slug: 'remote-ppc-team',
+        businessName: 'Remote PPC Team',
+        city: 'Austin',
+        state: 'TX',
+        zip: '73301',
+        remoteFriendly: true,
+        servesNationwide: false,
+        services: ['google-ads'],
+        verified: false,
+        rating: 4.4,
+      },
+      {
+        id: 'expert_wrong_area',
+        slug: 'miami-social-house',
+        businessName: 'Miami Social House',
+        city: 'Miami',
+        state: 'FL',
+        zip: '33101',
+        remoteFriendly: false,
+        servesNationwide: false,
+        services: ['google-ads'],
+        verified: true,
+        rating: 4.7,
+      },
+    ],
+  };
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Westmont',
+    state: 'IL',
+    zip: '60559',
+    latitude: 41.79,
+    longitude: -87.98,
+    geocodedAt: new Date('2026-05-25T15:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
 
   try {
     const response = await fastify.inject({
@@ -150,10 +206,19 @@ test('POST /requests creates a customer request for the signed-in customer', asy
     assert.equal(body.request.requesterName, 'Jamie Rivera');
     assert.equal(body.request.requesterBusinessName, 'Westmont Dental');
     assert.equal(body.request.status, 'ACTIVE');
+    assert.equal(body.deliveryPreview.matchingModel, 'city-zip-service-v1');
+    assert.equal(body.deliveryPreview.totalMatches, 2);
+    assert.deepEqual(
+      body.deliveryPreview.matchedExperts.map((expert) => expert.id),
+      ['expert_same_zip', 'expert_remote'],
+    );
+    assert.equal(body.deliveryPreview.matchedExperts[0].primaryReason, 'same_zip');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerProfile = originalCustomerProfile;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.expert = originalExpert;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }
 });
@@ -163,6 +228,8 @@ test('GET /requests lists only the signed-in customer requests', async () => {
 
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
     id: 'customer_user_3',
@@ -211,6 +278,8 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
 
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
     id: 'customer_user_4',
@@ -239,6 +308,46 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
       };
     },
   };
+  prismaModule.prisma.expert = {
+    findMany: async () => [
+      {
+        id: 'expert_same_city',
+        slug: 'lincoln-park-creators',
+        businessName: 'Lincoln Park Creators',
+        city: 'Chicago',
+        state: 'IL',
+        zip: '60639',
+        remoteFriendly: false,
+        servesNationwide: false,
+        services: ['creator-marketing', 'local-influencer'],
+        verified: true,
+        rating: 4.8,
+      },
+      {
+        id: 'expert_nationwide',
+        slug: 'nationwide-creator-team',
+        businessName: 'Nationwide Creator Team',
+        city: 'Los Angeles',
+        state: 'CA',
+        zip: '90001',
+        remoteFriendly: false,
+        servesNationwide: true,
+        services: ['creator-marketing'],
+        verified: false,
+        rating: 4.5,
+      },
+    ],
+  };
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60614',
+    latitude: 41.92,
+    longitude: -87.65,
+    geocodedAt: new Date('2026-05-25T15:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
 
   try {
     const response = await fastify.inject({
@@ -251,9 +360,14 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
     assert.equal(body.ok, true);
     assert.equal(body.request.id, 'request_3');
     assert.equal(body.request.marketingSubjectId, 'creator-influencer-marketing');
+    assert.equal(body.deliveryPreview.totalMatches, 2);
+    assert.equal(body.deliveryPreview.matchedExperts[0].primaryReason, 'same_city');
+    assert.equal(body.deliveryPreview.matchedExperts[1].primaryReason, 'serves_nationwide');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.expert = originalExpert;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }
 });


### PR DESCRIPTION
## Summary
- add v1 request matching using service tokens plus ZIP, city/state, nationwide, and remote-friendly expert coverage
- return an explicit delivery preview on request create and request detail responses
- add backend tests covering ZIP, city, and nationwide matching behavior

## Verify
- cd marketlink-backend && node --test tests/requests.test.js
- cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json
- cd marketlink-backend && npx prisma generate
- cd marketlink-backend && npm run build