### PR TITLE
MM-53 build customer request creation and history UI

### DIFF
--- a/marketlink-frontend/src/app/dashboard/customer/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/page.tsx
@@ -26,14 +26,31 @@ function DashboardRailCard({
 function FutureStateCard({
   title,
   body,
-}: Readonly<{ title: string; body: string }>) {
-  return (
-    <div className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+  href,
+  eyebrow = 'Reserved',
+}: Readonly<{ title: string; body: string; href?: string; eyebrow?: string }>) {
+  const content = (
+    <>
       <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-        Reserved
+        {eyebrow}
       </span>
       <h2 className="mt-4 text-xl font-semibold tracking-tight text-slate-950">{title}</h2>
       <p className="mt-2 text-sm leading-6 text-slate-600">{body}</p>
+      {href ? <span className="mt-4 inline-flex text-sm font-semibold text-slate-900">Open</span> : null}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(23,26,31,0.08)]">
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+      {content}
     </div>
   );
 }
@@ -104,6 +121,12 @@ export default async function CustomerDashboardPage() {
                   Edit profile
                 </Link>
                 <Link
+                  href="/dashboard/customer/requests/new"
+                  className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
+                >
+                  Create request
+                </Link>
+                <Link
                   href="/experts"
                   className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
                 >
@@ -144,7 +167,9 @@ export default async function CustomerDashboardPage() {
         <section className="mt-5 grid gap-4 md:grid-cols-3">
           <FutureStateCard
             title="Requests"
-            body="This space is reserved for the requests you send out once the customer request flow is added."
+            body="Create requests privately, revisit your history, and review the matching preview from one place."
+            href="/dashboard/customer/requests"
+            eyebrow="Live"
           />
           <FutureStateCard
             title="Messages"

--- a/marketlink-frontend/src/app/dashboard/customer/requests/CustomerRequestForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/CustomerRequestForm.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  formatServiceTokenLabel,
+  getMarketingSubjectById,
+  getServiceTokensForSubject,
+  getServiceTokensForSubcategory,
+  getSubcategoriesForSubject,
+  marketingSubjects,
+} from '@/lib/marketingTaxonomy';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+const budgetOptions = ['Under $1k', '$1k-$2k', '$2k-$5k', '$5k-$10k', '$10k+'] as const;
+const timelineOptions = ['ASAP', 'This month', 'Next 30 days', 'Next quarter', 'Just researching'] as const;
+
+type CustomerRequestFormProps = {
+  returnHref?: string;
+};
+
+function getRequestServiceTokens(subjectId: string, subcategoryId: string) {
+  return subcategoryId ? getServiceTokensForSubcategory(subjectId, subcategoryId) : getServiceTokensForSubject(subjectId);
+}
+
+export default function CustomerRequestForm({ returnHref = '/dashboard/customer/requests' }: CustomerRequestFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [subjectId, setSubjectId] = useState(marketingSubjects[0]?.id ?? '');
+  const [subcategoryId, setSubcategoryId] = useState('');
+  const [zip, setZip] = useState('');
+  const [budgetLabel, setBudgetLabel] = useState('');
+  const [timelineLabel, setTimelineLabel] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const subject = getMarketingSubjectById(subjectId);
+  const subcategories = getSubcategoriesForSubject(subjectId);
+  const selectedServiceTokens = useMemo(() => getRequestServiceTokens(subjectId, subcategoryId), [subjectId, subcategoryId]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    const cleanTitle = title.trim();
+    const cleanDescription = description.trim();
+    const cleanZip = zip.trim();
+
+    if (!cleanTitle) {
+      setError('Title is required.');
+      return;
+    }
+
+    if (!cleanDescription) {
+      setError('Description is required.');
+      return;
+    }
+
+    if (!subjectId) {
+      setError('Marketing area is required.');
+      return;
+    }
+
+    if (!/^\d{5}$/.test(cleanZip)) {
+      setError('ZIP must be 5 digits.');
+      return;
+    }
+
+    if (!selectedServiceTokens.length) {
+      setError('Choose a marketing area or specific help option.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch(`${API_BASE}/requests`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: cleanTitle,
+          description: cleanDescription,
+          marketingSubjectId: subjectId,
+          serviceTokens: selectedServiceTokens,
+          zip: cleanZip,
+          budgetLabel: budgetLabel || undefined,
+          timelineLabel: timelineLabel || undefined,
+        }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as { error?: string; request?: { id?: string } };
+      if (!response.ok || !body.request?.id) {
+        throw new Error(body.error || `Failed to create request (${response.status})`);
+      }
+
+      router.push(`/dashboard/customer/requests/view?id=${encodeURIComponent(body.request.id)}`);
+      router.refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-5">
+      <div className="grid gap-2">
+        <label htmlFor="request-title" className="text-sm font-medium text-slate-700">
+          Request title
+        </label>
+        <input
+          id="request-title"
+          className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          maxLength={140}
+        />
+      </div>
+
+      <div className="grid gap-2">
+        <label htmlFor="request-description" className="text-sm font-medium text-slate-700">
+          What do you need help with?
+        </label>
+        <textarea
+          id="request-description"
+          className="ml-input min-h-36 w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          maxLength={4000}
+        />
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <div className="grid gap-2">
+          <label htmlFor="request-subject" className="text-sm font-medium text-slate-700">
+            Marketing area
+          </label>
+          <select
+            id="request-subject"
+            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            value={subjectId}
+            onChange={(event) => {
+              setSubjectId(event.target.value);
+              setSubcategoryId('');
+            }}
+          >
+            {marketingSubjects.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+          {subject ? <p className="text-xs text-slate-500">{subject.shortDescription}</p> : null}
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="request-subcategory" className="text-sm font-medium text-slate-700">
+            Specific help
+          </label>
+          <select
+            id="request-subcategory"
+            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            value={subcategoryId}
+            onChange={(event) => setSubcategoryId(event.target.value)}
+          >
+            <option value="">Keep it broad</option>
+            {subcategories.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-slate-500">Optional. Choose this if you already know the exact kind of help you want.</p>
+        </div>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="grid gap-2">
+          <label htmlFor="request-zip" className="text-sm font-medium text-slate-700">
+            ZIP
+          </label>
+          <input
+            id="request-zip"
+            inputMode="numeric"
+            pattern="\d{5}"
+            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            value={zip}
+            onChange={(event) => setZip(event.target.value)}
+            maxLength={5}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="request-budget" className="text-sm font-medium text-slate-700">
+            Budget
+          </label>
+          <select
+            id="request-budget"
+            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            value={budgetLabel}
+            onChange={(event) => setBudgetLabel(event.target.value)}
+          >
+            <option value="">Optional</option>
+            {budgetOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="request-timeline" className="text-sm font-medium text-slate-700">
+            Timeline
+          </label>
+          <select
+            id="request-timeline"
+            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            value={timelineLabel}
+            onChange={(event) => setTimelineLabel(event.target.value)}
+          >
+            <option value="">Optional</option>
+            {timelineOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+        <div className="text-sm font-semibold text-slate-900">This request will be matched using</div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {selectedServiceTokens.map((token) => (
+            <span
+              key={token}
+              className="inline-flex rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+            >
+              {formatServiceTokenLabel(token)}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {error ? (
+        <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col gap-3 border-t border-slate-200/80 pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <Link href={returnHref} className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+          Back
+        </Link>
+        <button
+          type="submit"
+          disabled={saving}
+          className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          {saving ? 'Creating request...' : 'Create request'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/requests/new/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/new/page.tsx
@@ -1,0 +1,82 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import CustomerRequestForm from '../CustomerRequestForm';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+export default async function CustomerNewRequestPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const res = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (res.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer/requests/new');
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to load customer account (${res.status})`);
+  }
+
+  const data = (await res.json()) as SummaryResponse;
+
+  if (data.user?.role === 'admin') redirect('/dashboard/admin');
+  if (data.user?.role === 'provider') redirect('/dashboard');
+  if (!(data.customer?.name || '').trim()) redirect('/dashboard/customer/onboarding');
+
+  return (
+    <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+      <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_320px]">
+          <section className="ml-card overflow-hidden rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-6">
+            <div className="h-1.5 bg-[linear-gradient(90deg,#0f172a,#25324a,#b6bdc8)] -mx-5 -mt-5 mb-5 sm:-mx-6 sm:-mt-6 sm:mb-6" />
+            <div className="flex flex-col gap-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
+              <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Create a request</h1>
+              <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                Keep this simple. Tell us the problem, the marketing area, and where the business is located, then MarketLink will show the first plausible expert matches privately inside your dashboard.
+              </p>
+            </div>
+
+            <div className="mt-6">
+              <CustomerRequestForm />
+            </div>
+          </section>
+
+          <aside className="ml-card rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-6 lg:sticky lg:top-6 lg:self-start">
+            <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">How this works</div>
+            <div className="mt-4 grid gap-3">
+              <div className="ml-surface-muted rounded-2xl p-4">
+                <div className="text-sm font-semibold text-slate-900">Private by default</div>
+                <p className="mt-1 text-sm leading-6 text-slate-600">Requests stay inside your customer dashboard. Nothing here becomes a public marketplace page.</p>
+              </div>
+              <div className="ml-surface-muted rounded-2xl p-4">
+                <div className="text-sm font-semibold text-slate-900">Locality is MVP-simple</div>
+                <p className="mt-1 text-sm leading-6 text-slate-600">Matching currently uses service tags plus same ZIP, same city, nationwide coverage, or remote-friendly service area.</p>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3">
+              <Link href="/dashboard/customer/requests" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+                View request history
+              </Link>
+              <Link href="/experts" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+                Browse experts first
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
@@ -1,0 +1,167 @@
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+type RequestHistoryItem = {
+  id: string;
+  title: string;
+  marketingSubjectId: string;
+  serviceTokens: string[];
+  zip: string;
+  status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+  createdAt: string;
+  updatedAt: string;
+};
+
+type RequestsResponse = {
+  ok?: boolean;
+  data?: RequestHistoryItem[];
+};
+
+function formatRequestStatus(status: RequestHistoryItem['status']) {
+  if (status === 'ACTIVE') return 'Active';
+  if (status === 'CLOSED') return 'Closed';
+  return 'Cancelled';
+}
+
+function formatShortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default async function CustomerRequestsPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const summaryRes = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (summaryRes.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer/requests');
+  }
+
+  if (!summaryRes.ok) {
+    throw new Error(`Failed to load customer account (${summaryRes.status})`);
+  }
+
+  const summary = (await summaryRes.json()) as SummaryResponse;
+
+  if (summary.user?.role === 'admin') redirect('/dashboard/admin');
+  if (summary.user?.role === 'provider') redirect('/dashboard');
+  if (!(summary.customer?.name || '').trim()) redirect('/dashboard/customer/onboarding');
+
+  const requestsRes = await fetch(`${API_BASE}/requests`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (!requestsRes.ok) {
+    throw new Error(`Failed to load customer requests (${requestsRes.status})`);
+  }
+
+  const requestsData = (await requestsRes.json()) as RequestsResponse;
+  const requests = requestsData.data || [];
+
+  return (
+    <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Request history</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              Create requests privately, then revisit the matching preview and request details here.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/dashboard/customer" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+              Back to dashboard
+            </Link>
+            <Link href="/dashboard/customer/requests/new" className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white">
+              Create request
+            </Link>
+          </div>
+        </div>
+
+        {requests.length === 0 ? (
+          <section className="ml-card mt-5 rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">No requests yet</p>
+              <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">Start with your first request</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                Once you describe what you need, MarketLink will show a private matching preview based on service tags and the MVP locality rules.
+              </p>
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+              <Link href="/dashboard/customer/requests/new" className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white">
+                Create request
+              </Link>
+              <Link href="/experts" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+                Browse experts
+              </Link>
+            </div>
+          </section>
+        ) : (
+          <section className="mt-5 grid gap-4">
+            {requests.map((request) => {
+              const subject = getMarketingSubjectById(request.marketingSubjectId);
+              return (
+                <Link
+                  key={request.id}
+                  href={`/dashboard/customer/requests/view?id=${encodeURIComponent(request.id)}`}
+                  className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(23,26,31,0.08)]"
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {formatRequestStatus(request.status)}
+                        </span>
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {subject?.label || request.marketingSubjectId}
+                        </span>
+                      </div>
+                      <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{request.title}</h2>
+                      <p className="mt-2 text-sm text-slate-600">
+                        Created {formatShortDate(request.createdAt)} • ZIP {request.zip}
+                      </p>
+                    </div>
+
+                    <span className="text-sm font-semibold text-slate-900">Open</span>
+                  </div>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {request.serviceTokens.slice(0, 4).map((token) => (
+                      <span
+                        key={token}
+                        className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                      >
+                        {formatServiceTokenLabel(token)}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              );
+            })}
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
@@ -1,0 +1,292 @@
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+type DeliveryPreview = {
+  matchingModel: string;
+  requestLocation?: { zip?: string | null; city?: string | null; state?: string | null; source?: string | null } | null;
+  notes?: string[];
+  totalMatches: number;
+  matchedExperts: Array<{
+    id: string;
+    slug: string;
+    businessName: string;
+    city: string;
+    state: string;
+    zip?: string | null;
+    verified: boolean;
+    rating: number;
+    remoteFriendly: boolean;
+    servesNationwide: boolean;
+    matchedServiceTokens: string[];
+    primaryReason: 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
+    reasons: Array<'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly'>;
+  }>;
+};
+
+type RequestDetailResponse = {
+  ok?: boolean;
+  request?: {
+    id: string;
+    requesterName: string;
+    requesterBusinessName?: string | null;
+    title: string;
+    description: string;
+    marketingSubjectId: string;
+    serviceTokens: string[];
+    zip: string;
+    budgetLabel?: string | null;
+    timelineLabel?: string | null;
+    status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+    createdAt: string;
+    updatedAt: string;
+  };
+  deliveryPreview?: DeliveryPreview;
+};
+
+function formatShortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatReason(reason: DeliveryPreview['matchedExperts'][number]['primaryReason']) {
+  switch (reason) {
+    case 'same_zip':
+      return 'Same ZIP';
+    case 'same_city':
+      return 'Same city';
+    case 'serves_nationwide':
+      return 'Serves nationwide';
+    default:
+      return 'Remote-friendly';
+  }
+}
+
+function formatStatus(status: NonNullable<RequestDetailResponse['request']>['status']) {
+  if (status === 'ACTIVE') return 'Active';
+  if (status === 'CLOSED') return 'Closed';
+  return 'Cancelled';
+}
+
+export default async function CustomerRequestDetailPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ id?: string }>;
+}) {
+  const { id = '' } = await searchParams;
+  if (!id.trim()) {
+    redirect('/dashboard/customer/requests');
+  }
+
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const summaryRes = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (summaryRes.status === 401) {
+    redirect(`/login?returnTo=/dashboard/customer/requests/view?id=${encodeURIComponent(id)}`);
+  }
+
+  if (!summaryRes.ok) {
+    throw new Error(`Failed to load customer account (${summaryRes.status})`);
+  }
+
+  const summary = (await summaryRes.json()) as SummaryResponse;
+
+  if (summary.user?.role === 'admin') redirect('/dashboard/admin');
+  if (summary.user?.role === 'provider') redirect('/dashboard');
+  if (!(summary.customer?.name || '').trim()) redirect('/dashboard/customer/onboarding');
+
+  const requestRes = await fetch(`${API_BASE}/requests/${id}`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (requestRes.status === 404) {
+    redirect('/dashboard/customer/requests');
+  }
+
+  if (!requestRes.ok) {
+    throw new Error(`Failed to load customer request (${requestRes.status})`);
+  }
+
+  const data = (await requestRes.json()) as RequestDetailResponse;
+  const request = data.request;
+
+  if (!request) {
+    throw new Error('Customer request payload was missing.');
+  }
+
+  const subject = getMarketingSubjectById(request.marketingSubjectId);
+  const preview = data.deliveryPreview;
+
+  return (
+    <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">{request.title}</h1>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Created {formatShortDate(request.createdAt)} • {formatStatus(request.status)} • ZIP {request.zip}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/dashboard/customer/requests" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+              Back to history
+            </Link>
+            <Link href="/dashboard/customer/requests/new" className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white">
+              New request
+            </Link>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_340px]">
+          <section className="ml-card rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
+            <div className="flex flex-wrap gap-2">
+              <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                {formatStatus(request.status)}
+              </span>
+              <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                {subject?.label || request.marketingSubjectId}
+              </span>
+            </div>
+
+            <div className="mt-5 grid gap-5 md:grid-cols-2">
+              <div>
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Description</div>
+                <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{request.description}</p>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Business location</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">ZIP {request.zip}</div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Budget</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">{request.budgetLabel || 'Not specified'}</div>
+                </div>
+                <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Timeline</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">{request.timelineLabel || 'Not specified'}</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Matching tags</div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {request.serviceTokens.map((token) => (
+                  <span
+                    key={token}
+                    className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                  >
+                    {formatServiceTokenLabel(token)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <aside className="ml-card rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
+            <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Matching preview</div>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+              {preview?.totalMatches ?? 0} plausible match{preview?.totalMatches === 1 ? '' : 'es'}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              This preview is private and based on the current MVP model: service tags plus ZIP, city, nationwide coverage, or remote-friendly service area.
+            </p>
+
+            {preview?.requestLocation ? (
+              <div className="mt-4 rounded-2xl bg-slate-50 px-4 py-4">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request location</div>
+                <div className="mt-2 text-sm font-medium text-slate-900">
+                  {[preview.requestLocation.city, preview.requestLocation.state].filter(Boolean).join(', ') || `ZIP ${request.zip}`}
+                </div>
+              </div>
+            ) : null}
+
+            {preview?.notes?.length ? (
+              <ul className="mt-4 space-y-2 text-sm leading-6 text-slate-600">
+                {preview.notes.map((note) => (
+                  <li key={note}>• {note}</li>
+                ))}
+              </ul>
+            ) : null}
+          </aside>
+        </div>
+
+        <section className="mt-5">
+          <div className="flex items-end justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Likely experts</p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">Who this request may reach</h2>
+            </div>
+          </div>
+
+          {preview?.matchedExperts?.length ? (
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {preview.matchedExperts.map((expert) => (
+                <Link
+                  key={expert.id}
+                  href={`/experts/${expert.slug}`}
+                  className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(23,26,31,0.08)]"
+                >
+                  <div className="flex flex-wrap gap-2">
+                    <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                      {formatReason(expert.primaryReason)}
+                    </span>
+                    {expert.verified ? (
+                      <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                        Verified
+                      </span>
+                    ) : null}
+                  </div>
+
+                  <h3 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{expert.businessName}</h3>
+                  <p className="mt-1 text-sm text-slate-600">
+                    {expert.city}, {expert.state}
+                  </p>
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    {expert.matchedServiceTokens.map((token) => (
+                      <span
+                        key={token}
+                        className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                      >
+                        {formatServiceTokenLabel(token)}
+                      </span>
+                    ))}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <div className="ml-card mt-4 rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+              <p className="text-sm leading-6 text-slate-600">
+                No plausible matches showed up yet. Try broadening the marketing area, adjusting the ZIP, or browsing experts directly.
+              </p>
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What changed
- added private customer request history under /dashboard/customer/requests
- added a private request creation flow under /dashboard/customer/requests/new
- added a private request detail page under /dashboard/customer/requests/view
- added a shared customer request form wired to the existing /requests API
- updated the customer dashboard requests card to point into the live request flow

## Verification
- 
pm exec eslint src/app/dashboard/customer/page.tsx src/app/dashboard/customer/requests/CustomerRequestForm.tsx src/app/dashboard/customer/requests/page.tsx src/app/dashboard/customer/requests/new/page.tsx src/app/dashboard/customer/requests/view/page.tsx
- 
pm run build
- browser flow on http://localhost:3000: sign up -> create request -> request detail -> matching preview -> request history
