### PR TITLE
MM-54 build provider-side incoming request inbox

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -14,6 +14,36 @@ type DeliveryPreviewInput = {
   zip: string;
 };
 
+type ProviderExpertForMatching = {
+  id: string;
+  slug: string;
+  businessName: string;
+  city: string;
+  state: string;
+  zip: string | null;
+  remoteFriendly: boolean;
+  servesNationwide: boolean;
+  services: string[];
+  verified: boolean;
+  rating: number;
+};
+
+type RequestForProviderMatching = {
+  id: string;
+  title: string;
+  description: string;
+  marketingSubjectId: string;
+  serviceTokens: string[];
+  zip: string;
+  budgetLabel: string | null;
+  timelineLabel: string | null;
+  status: CustomerRequestStatus;
+  requesterName: string;
+  requesterBusinessName: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
 function asCleanString(input: unknown) {
   return String(input || '').trim();
 }
@@ -43,6 +73,42 @@ function getReasonWeight(reason: RequestMatchReason) {
   if (reason === 'same_city') return 300;
   if (reason === 'serves_nationwide') return 200;
   return 100;
+}
+
+async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, request: RequestForProviderMatching) {
+  const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
+  if (!matchedServiceTokens.length) return null;
+
+  const locationLookup = await lookupZipLocation({ zip: request.zip });
+  const requestCity = locationLookup.ok ? locationLookup.city : null;
+  const requestState = locationLookup.ok ? locationLookup.state : null;
+  const requestZip = locationLookup.ok ? locationLookup.zip : request.zip;
+
+  const sameZip = Boolean(expert.zip && expert.zip.trim() === requestZip);
+  const sameCity =
+    Boolean(requestCity && requestState) &&
+    normalizeCity(expert.city) === normalizeCity(requestCity) &&
+    normalizeState(expert.state) === normalizeState(requestState);
+
+  const reasons: RequestMatchReason[] = [];
+  if (sameZip) reasons.push('same_zip');
+  else if (sameCity) reasons.push('same_city');
+  else if (expert.servesNationwide) reasons.push('serves_nationwide');
+  else if (expert.remoteFriendly) reasons.push('remote_friendly');
+
+  if (!reasons.length) return null;
+
+  return {
+    primaryReason: reasons[0],
+    reasons,
+    matchedServiceTokens,
+    requestLocation: {
+      zip: requestZip,
+      city: requestCity,
+      state: requestState,
+      source: locationLookup.ok ? 'zip_lookup' : 'zip_only',
+    },
+  };
 }
 
 async function buildDeliveryPreview(input: DeliveryPreviewInput) {
@@ -288,6 +354,141 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     return reply.send({ ok: true, request, deliveryPreview });
+  });
+
+  fastify.get('/provider/requests', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'provider') return reply.code(403).send({ error: 'Only providers can view matched requests.' });
+
+    const expert = await prisma.expert.findFirst({
+      where: { userId: user.id },
+      select: {
+        id: true,
+        slug: true,
+        businessName: true,
+        city: true,
+        state: true,
+        zip: true,
+        remoteFriendly: true,
+        servesNationwide: true,
+        services: true,
+        verified: true,
+        rating: true,
+      },
+    });
+
+    if (!expert) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const requests = await prisma.customerRequest.findMany({
+      where: { status: CustomerRequestStatus.ACTIVE },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        marketingSubjectId: true,
+        serviceTokens: true,
+        zip: true,
+        budgetLabel: true,
+        timelineLabel: true,
+        status: true,
+        requesterName: true,
+        requesterBusinessName: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+      take: 100,
+    });
+
+    const matches = [];
+    for (const request of requests) {
+      const match = await buildProviderMatchForRequest(expert, request);
+      if (!match) continue;
+
+      matches.push({
+        id: request.id,
+        title: request.title,
+        marketingSubjectId: request.marketingSubjectId,
+        zip: request.zip,
+        budgetLabel: request.budgetLabel,
+        timelineLabel: request.timelineLabel,
+        status: request.status,
+        createdAt: request.createdAt,
+        updatedAt: request.updatedAt,
+        primaryReason: match.primaryReason,
+        reasons: match.reasons,
+        matchedServiceTokens: match.matchedServiceTokens,
+      });
+    }
+
+    return reply.send({ ok: true, data: matches });
+  });
+
+  fastify.get('/provider/requests/:id', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'provider') return reply.code(403).send({ error: 'Only providers can view matched requests.' });
+
+    const expert = await prisma.expert.findFirst({
+      where: { userId: user.id },
+      select: {
+        id: true,
+        slug: true,
+        businessName: true,
+        city: true,
+        state: true,
+        zip: true,
+        remoteFriendly: true,
+        servesNationwide: true,
+        services: true,
+        verified: true,
+        rating: true,
+      },
+    });
+
+    if (!expert) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const { id } = (req.params || {}) as { id?: string };
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing request id' });
+
+    const request = await prisma.customerRequest.findFirst({
+      where: {
+        id,
+        status: CustomerRequestStatus.ACTIVE,
+      },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        marketingSubjectId: true,
+        serviceTokens: true,
+        zip: true,
+        budgetLabel: true,
+        timelineLabel: true,
+        status: true,
+        requesterName: true,
+        requesterBusinessName: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!request) return reply.code(404).send({ ok: false, error: 'Request not found' });
+
+    const match = await buildProviderMatchForRequest(expert, request);
+    if (!match) return reply.code(404).send({ ok: false, error: 'Request not found' });
+
+    return reply.send({
+      ok: true,
+      request,
+      match: {
+        primaryReason: match.primaryReason,
+        reasons: match.reasons,
+        matchedServiceTokens: match.matchedServiceTokens,
+        requestLocation: match.requestLocation,
+      },
+    });
   });
 };
 

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -371,3 +371,213 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
     await fastify.close();
   }
 });
+
+test('GET /provider/requests lists active matched requests for the signed-in provider expert', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where, select }) => {
+      if (where?.userId === 'provider_user_1') {
+        return {
+          id: 'expert_provider_1',
+          slug: 'westmont-growth',
+          businessName: 'Westmont Growth',
+          city: 'Westmont',
+          state: 'IL',
+          zip: '60559',
+          remoteFriendly: true,
+          servesNationwide: false,
+          services: ['paid-ads', 'google-ads', 'lead-generation'],
+          verified: true,
+          rating: 4.9,
+        };
+      }
+
+      throw new Error(`Unexpected expert.findFirst call: ${JSON.stringify({ where, select })}`);
+    },
+  };
+
+  prismaModule.prisma.customerRequest = {
+    findMany: async ({ where }) => {
+      assert.equal(where.status, 'ACTIVE');
+      return [
+        {
+          id: 'request_provider_match_1',
+          title: 'Need more local leads',
+          description: 'Looking for help with Google Ads and lead generation.',
+          marketingSubjectId: 'paid-ads-lead-generation',
+          serviceTokens: ['google-ads', 'lead-generation'],
+          zip: '60559',
+          budgetLabel: '$2k-$5k',
+          timelineLabel: 'ASAP',
+          status: 'ACTIVE',
+          requesterName: 'Jamie Rivera',
+          requesterBusinessName: 'Westmont Dental',
+          createdAt: new Date('2026-05-29T15:00:00.000Z'),
+          updatedAt: new Date('2026-05-29T15:00:00.000Z'),
+        },
+        {
+          id: 'request_provider_miss_1',
+          title: 'Need creator help',
+          description: 'Looking for local influencer support.',
+          marketingSubjectId: 'creator-influencer-marketing',
+          serviceTokens: ['creator-marketing', 'ugc'],
+          zip: '60614',
+          budgetLabel: '$1k-$2k',
+          timelineLabel: 'Next 30 days',
+          status: 'ACTIVE',
+          requesterName: 'Alex Kim',
+          requesterBusinessName: 'Lakeview Cafe',
+          createdAt: new Date('2026-05-29T16:00:00.000Z'),
+          updatedAt: new Date('2026-05-29T16:00:00.000Z'),
+        },
+      ];
+    },
+  };
+
+  geocodingModule.lookupZipLocation = async ({ zip }) => {
+    if (zip === '60559') {
+      return {
+        ok: true,
+        city: 'Westmont',
+        state: 'IL',
+        zip: '60559',
+        latitude: 41.79,
+        longitude: -87.98,
+        geocodedAt: new Date('2026-05-29T15:00:00.000Z'),
+        geocodeProvider: 'geoapify',
+      };
+    }
+
+    return {
+      ok: true,
+      city: 'Chicago',
+      state: 'IL',
+      zip: '60614',
+      latitude: 41.92,
+      longitude: -87.65,
+      geocodedAt: new Date('2026-05-29T16:00:00.000Z'),
+      geocodeProvider: 'geoapify',
+    };
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/provider/requests',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].id, 'request_provider_match_1');
+    assert.equal(body.data[0].primaryReason, 'same_zip');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});
+
+test('GET /provider/requests/:id only returns a matched active request for the signed-in provider expert', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_2',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where, select }) => {
+      if (where?.userId === 'provider_user_2') {
+        return {
+          id: 'expert_provider_2',
+          slug: 'windy-city-growth',
+          businessName: 'Windy City Growth',
+          city: 'Westmont',
+          state: 'IL',
+          zip: '60559',
+          remoteFriendly: false,
+          servesNationwide: true,
+          services: ['ads', 'google-ads', 'paid-search'],
+          verified: true,
+          rating: 4.7,
+        };
+      }
+
+      throw new Error(`Unexpected expert.findFirst call: ${JSON.stringify({ where, select })}`);
+    },
+  };
+
+  prismaModule.prisma.customerRequest = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'request_provider_detail_1');
+      assert.equal(where.status, 'ACTIVE');
+      return {
+        id: 'request_provider_detail_1',
+        title: 'Need Google Ads support for a local dental office',
+        description: 'Looking for an expert to audit and relaunch paid search campaigns.',
+        marketingSubjectId: 'paid-ads-lead-generation',
+        serviceTokens: ['google-ads', 'paid-search'],
+        zip: '60601',
+        budgetLabel: '$5k-$10k',
+        timelineLabel: 'This month',
+        status: 'ACTIVE',
+        requesterName: 'Jamie Rivera',
+        requesterBusinessName: 'Westmont Dental',
+        createdAt: new Date('2026-05-29T17:00:00.000Z'),
+        updatedAt: new Date('2026-05-29T17:00:00.000Z'),
+      };
+    },
+  };
+
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60601',
+    latitude: 41.88,
+    longitude: -87.62,
+    geocodedAt: new Date('2026-05-29T17:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/provider/requests/request_provider_detail_1',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.request.id, 'request_provider_detail_1');
+    assert.equal(body.match.primaryReason, 'serves_nationwide');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -29,6 +29,12 @@ type InquiryRow = {
   createdAt: string;
 };
 
+type ProviderRequestRow = {
+  id: string;
+  status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+  createdAt: string;
+};
+
 function formatExpertTypeLabel(expertType: ExpertSummary['expertType']) {
   switch (expertType) {
     case 'agency':
@@ -62,6 +68,7 @@ const [user, setUser] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [inquiryCount, setInquiryCount] = useState<number | null>(null);
   const [newInquiryCount, setNewInquiryCount] = useState<number | null>(null);
+  const [matchedRequestCount, setMatchedRequestCount] = useState<number | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -107,19 +114,31 @@ const [user, setUser] = useState<User | null>(null);
 
     (async () => {
       try {
-        const res = await fetch(`${API_BASE}/inquiries`, {
-          credentials: 'include',
-          cache: 'no-store',
-        });
+        const [inquiriesRes, requestsRes] = await Promise.all([
+          fetch(`${API_BASE}/inquiries`, {
+            credentials: 'include',
+            cache: 'no-store',
+          }),
+          fetch(`${API_BASE}/provider/requests`, {
+            credentials: 'include',
+            cache: 'no-store',
+          }),
+        ]);
 
-        if (!res.ok) return;
+        if (inquiriesRes.ok) {
+          const body = (await inquiriesRes.json()) as { ok?: true; data?: InquiryRow[] };
+          const rows = Array.isArray(body?.data) ? body.data : [];
+          setInquiryCount(rows.length);
+          setNewInquiryCount(rows.filter((r) => r.status === 'NEW').length);
+        }
 
-        const body = (await res.json()) as { ok?: true; data?: InquiryRow[] };
-        const rows = Array.isArray(body?.data) ? body.data : [];
-        setInquiryCount(rows.length);
-        setNewInquiryCount(rows.filter((r) => r.status === 'NEW').length);
+        if (requestsRes.ok) {
+          const body = (await requestsRes.json()) as { ok?: true; data?: ProviderRequestRow[] };
+          const rows = Array.isArray(body?.data) ? body.data : [];
+          setMatchedRequestCount(rows.filter((r) => r.status === 'ACTIVE').length);
+        }
       } catch {
-        // ignore inquiry count failures on dashboard
+        // ignore dashboard sidebar count failures
       }
     })();
   }, [expert]);
@@ -216,6 +235,10 @@ const [user, setUser] = useState<User | null>(null);
                 <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Buyer inquiries</div>
                 <div className="mt-2 text-base font-semibold text-slate-900">{inquiryCount === null ? '—' : inquiryCount}</div>
               </div>
+              <div className={mutedCardClass}>
+                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Matched requests</div>
+                <div className="mt-2 text-base font-semibold text-slate-900">{matchedRequestCount === null ? '—' : matchedRequestCount}</div>
+              </div>
               <div className={`${mutedCardClass} col-span-2 sm:col-span-1`}>
                 <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">New inquiries</div>
                 <div className="mt-2 text-base font-semibold text-slate-900">{newInquiryCount === null ? '—' : newInquiryCount}</div>
@@ -275,6 +298,10 @@ const [user, setUser] = useState<User | null>(null);
                     <Link href="/dashboard/profile" className={primaryLinkClass}>
                       Edit profile
                     </Link>
+                    <Link href="/dashboard/requests" className={secondaryLinkClass}>
+                      Matched requests
+                      {matchedRequestCount !== null && matchedRequestCount > 0 ? <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{matchedRequestCount} active</span> : null}
+                    </Link>
                     <Link href="/dashboard/inquiries" className={secondaryLinkClass}>
                       Inquiries
                       {newInquiryCount !== null && newInquiryCount > 0 ? <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{newInquiryCount} new</span> : null}
@@ -303,6 +330,11 @@ const [user, setUser] = useState<User | null>(null);
                 <Link href={expert ? '/dashboard/inquiries' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!expert}>
                   <div className="text-sm font-semibold text-slate-900">Buyer inquiries</div>
                   <p className={`mt-1 text-sm ${t.mutedText}`}>{expert ? 'Review new messages, triage active buyers, and keep response times tight.' : 'Create your expert profile first to receive inquiries.'}</p>
+                </Link>
+
+                <Link href={expert ? '/dashboard/requests' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!expert}>
+                  <div className="text-sm font-semibold text-slate-900">Matched requests</div>
+                  <p className={`mt-1 text-sm ${t.mutedText}`}>{expert ? 'Review active customer requests that currently match your services and delivery footprint.' : 'Create your expert profile first to start receiving matched request opportunities.'}</p>
                 </Link>
 
                 <div className={mutedCardClass}>

--- a/marketlink-frontend/src/app/dashboard/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+import { useMarketLinkTheme } from '@/components/ThemeToggle';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type ProviderRequestStatus = 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+type MatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
+
+type ProviderRequestRow = {
+  id: string;
+  title: string;
+  marketingSubjectId: string;
+  zip: string;
+  budgetLabel?: string | null;
+  timelineLabel?: string | null;
+  status: ProviderRequestStatus;
+  createdAt: string;
+  updatedAt: string;
+  primaryReason: MatchReason;
+  reasons: MatchReason[];
+  matchedServiceTokens: string[];
+};
+
+type ProviderRequestsResponse = {
+  ok?: boolean;
+  data?: ProviderRequestRow[];
+  error?: string;
+};
+
+function formatReason(reason: MatchReason) {
+  switch (reason) {
+    case 'same_zip':
+      return 'Same ZIP';
+    case 'same_city':
+      return 'Same city';
+    case 'serves_nationwide':
+      return 'Serves nationwide';
+    default:
+      return 'Remote-friendly';
+  }
+}
+
+function formatStatus(status: ProviderRequestStatus) {
+  if (status === 'ACTIVE') return 'Active';
+  if (status === 'CLOSED') return 'Closed';
+  return 'Cancelled';
+}
+
+function formatShortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export default function ProviderRequestsPage() {
+  const router = useRouter();
+  const { t } = useMarketLinkTheme();
+  const [rows, setRows] = useState<ProviderRequestRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setPageError(null);
+
+      try {
+        const summaryRes = await fetch(`${API_BASE}/me/summary`, {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+
+        if (summaryRes.status === 401) {
+          router.replace('/login?returnTo=/dashboard/requests');
+          return;
+        }
+
+        if (!summaryRes.ok) {
+          const body = (await summaryRes.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error || `Failed (${summaryRes.status})`);
+        }
+
+        const summary = (await summaryRes.json()) as {
+          user?: { role?: 'provider' | 'customer' | 'admin' };
+        };
+
+        if (summary.user?.role === 'admin') {
+          router.replace('/dashboard/admin');
+          return;
+        }
+
+        if (summary.user?.role === 'customer') {
+          router.replace('/dashboard/customer');
+          return;
+        }
+
+        const res = await fetch(`${API_BASE}/provider/requests`, {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error || `Failed (${res.status})`);
+        }
+
+        const body = (await res.json()) as ProviderRequestsResponse;
+        setRows(Array.isArray(body.data) ? body.data : []);
+      } catch (error: unknown) {
+        setPageError(error instanceof Error ? error.message : 'Something went wrong');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [router]);
+
+  const activeCount = useMemo(() => rows.filter((row) => row.status === 'ACTIVE').length, [rows]);
+
+  const shellClass =
+    'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(247,244,239,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
+  const mutedCardClass =
+    'rounded-[24px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(251,250,248,0.98),rgba(243,239,234,0.72))] p-4 shadow-[0_10px_30px_rgba(15,23,42,0.04)]';
+
+  return (
+    <main className={`${t.pageBg} min-h-[calc(100vh-72px)]`}>
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        <section className={`${shellClass} overflow-hidden`}>
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1.45fr)_320px] lg:items-stretch">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Matched requests</p>
+              <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Incoming opportunities</h1>
+              <p className={`mt-3 text-sm ${t.mutedText}`}>
+                Review active customer requests that currently match your expert profile based on services and the current locality rules.
+              </p>
+              <div className="mt-5 flex flex-wrap gap-2">
+                <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-600 shadow-sm">Private provider view</span>
+                <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-600 shadow-sm">Active requests only</span>
+                <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-600 shadow-sm">Service + locality match</span>
+              </div>
+            </div>
+
+            <div className={mutedCardClass}>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-2xl bg-slate-900 px-4 py-3 text-white shadow-[0_18px_34px_rgba(15,23,42,0.18)]">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">Active</div>
+                  <div className="mt-2 text-lg font-semibold">{activeCount}</div>
+                </div>
+                <div className="rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">Total</div>
+                  <div className="mt-2 text-lg font-semibold text-slate-950">{rows.length}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${shellClass} mt-5`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">Request inbox</h2>
+              <p className={`mt-1 text-sm ${t.mutedText}`}>Open a request to see the full brief and why your profile matched it.</p>
+            </div>
+
+            <Link href="/dashboard" className="rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50">
+              Back to dashboard
+            </Link>
+          </div>
+        </section>
+
+        {pageError ? <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{pageError}</div> : null}
+
+        {loading ? (
+          <section className={`${shellClass} mt-5`}>
+            <p className={`text-sm ${t.mutedText}`}>Loading matched requests...</p>
+          </section>
+        ) : rows.length === 0 ? (
+          <section className={`${shellClass} mt-5`}>
+            <p className={`text-sm ${t.mutedText}`}>No matched requests are available right now.</p>
+          </section>
+        ) : (
+          <div className="mt-5 space-y-4">
+            {rows.map((row) => {
+              const subject = getMarketingSubjectById(row.marketingSubjectId);
+
+              return (
+                <Link
+                  key={row.id}
+                  href={`/dashboard/requests/view?id=${encodeURIComponent(row.id)}`}
+                  className={`${shellClass} block transition ${t.cardHover}`}
+                >
+                  <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
+                            {formatStatus(row.status)}
+                          </span>
+                          <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
+                            {formatReason(row.primaryReason)}
+                          </span>
+                          <span className={`text-xs ${t.mutedText}`}>Created {formatShortDate(row.createdAt)}</span>
+                        </div>
+
+                        <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{row.title}</h2>
+                        <p className={`mt-2 text-sm ${t.mutedText}`}>
+                          {subject?.label || row.marketingSubjectId} • ZIP {row.zip}
+                        </p>
+                      </div>
+
+                      <span className="text-sm font-semibold text-slate-900">Open</span>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      {row.matchedServiceTokens.slice(0, 4).map((token) => (
+                        <span
+                          key={token}
+                          className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                        >
+                          {formatServiceTokenLabel(token)}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+import { useMarketLinkTheme } from '@/components/ThemeToggle';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type MatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
+type ProviderRequestStatus = 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+
+type ProviderRequestDetailResponse = {
+  ok?: boolean;
+  request?: {
+    id: string;
+    requesterName: string;
+    requesterBusinessName?: string | null;
+    title: string;
+    description: string;
+    marketingSubjectId: string;
+    serviceTokens: string[];
+    zip: string;
+    budgetLabel?: string | null;
+    timelineLabel?: string | null;
+    status: ProviderRequestStatus;
+    createdAt: string;
+    updatedAt: string;
+  };
+  match?: {
+    primaryReason: MatchReason;
+    reasons: MatchReason[];
+    matchedServiceTokens: string[];
+    requestLocation?: { zip?: string | null; city?: string | null; state?: string | null; source?: string | null } | null;
+  };
+  error?: string;
+};
+
+function formatReason(reason: MatchReason) {
+  switch (reason) {
+    case 'same_zip':
+      return 'Same ZIP';
+    case 'same_city':
+      return 'Same city';
+    case 'serves_nationwide':
+      return 'Serves nationwide';
+    default:
+      return 'Remote-friendly';
+  }
+}
+
+function formatStatus(status: ProviderRequestStatus) {
+  if (status === 'ACTIVE') return 'Active';
+  if (status === 'CLOSED') return 'Closed';
+  return 'Cancelled';
+}
+
+function formatShortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function ProviderRequestDetailPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { t } = useMarketLinkTheme();
+  const [data, setData] = useState<ProviderRequestDetailResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState<string | null>(null);
+
+  const requestId = (searchParams.get('id') || '').trim();
+
+  useEffect(() => {
+    if (!requestId) {
+      router.replace('/dashboard/requests');
+      return;
+    }
+
+    (async () => {
+      setLoading(true);
+      setPageError(null);
+
+      try {
+        const summaryRes = await fetch(`${API_BASE}/me/summary`, {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+
+        if (summaryRes.status === 401) {
+          router.replace(`/login?returnTo=/dashboard/requests/view?id=${encodeURIComponent(requestId)}`);
+          return;
+        }
+
+        if (!summaryRes.ok) {
+          const body = (await summaryRes.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error || `Failed (${summaryRes.status})`);
+        }
+
+        const summary = (await summaryRes.json()) as {
+          user?: { role?: 'provider' | 'customer' | 'admin' };
+        };
+
+        if (summary.user?.role === 'admin') {
+          router.replace('/dashboard/admin');
+          return;
+        }
+
+        if (summary.user?.role === 'customer') {
+          router.replace('/dashboard/customer');
+          return;
+        }
+
+        const res = await fetch(`${API_BASE}/provider/requests/${requestId}`, {
+          credentials: 'include',
+          cache: 'no-store',
+        });
+
+        if (res.status === 404) {
+          router.replace('/dashboard/requests');
+          return;
+        }
+
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string };
+          throw new Error(body.error || `Failed (${res.status})`);
+        }
+
+        const body = (await res.json()) as ProviderRequestDetailResponse;
+        setData(body);
+      } catch (error: unknown) {
+        setPageError(error instanceof Error ? error.message : 'Something went wrong');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [requestId, router]);
+
+  const shellClass =
+    'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(247,244,239,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
+
+  const request = data?.request;
+  const match = data?.match;
+  const subject = request ? getMarketingSubjectById(request.marketingSubjectId) : null;
+
+  return (
+    <main className={`${t.pageBg} min-h-[calc(100vh-72px)]`}>
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        {loading ? (
+          <section className={shellClass}>
+            <p className={`text-sm ${t.mutedText}`}>Loading request...</p>
+          </section>
+        ) : pageError ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{pageError}</div>
+        ) : !request || !match ? (
+          <section className={shellClass}>
+            <p className={`text-sm ${t.mutedText}`}>Request not found.</p>
+          </section>
+        ) : (
+          <>
+            <section className={`${shellClass} overflow-hidden`}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Matched request</p>
+                  <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">{request.title}</h1>
+                  <p className={`mt-3 text-sm ${t.mutedText}`}>
+                    Created {formatShortDate(request.createdAt)} • {formatStatus(request.status)} • ZIP {request.zip}
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-3 sm:flex-row">
+                  <Link href="/dashboard/requests" className="rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50">
+                    Back to inbox
+                  </Link>
+                  <Link href="/dashboard" className="rounded-full bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800">
+                    Dashboard
+                  </Link>
+                </div>
+              </div>
+            </section>
+
+            <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1.05fr)_340px]">
+              <section className={shellClass}>
+                <div className="flex flex-wrap gap-2">
+                  <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
+                    {formatStatus(request.status)}
+                  </span>
+                  <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
+                    {subject?.label || request.marketingSubjectId}
+                  </span>
+                  <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
+                    {formatReason(match.primaryReason)}
+                  </span>
+                </div>
+
+                <div className="mt-5 grid gap-5 md:grid-cols-2">
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Description</div>
+                    <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{request.description}</p>
+                  </div>
+
+                  <div className="space-y-4">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Business</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">{request.requesterBusinessName || request.requesterName}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Budget</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">{request.budgetLabel || 'Not specified'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Timeline</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">{request.timelineLabel || 'Not specified'}</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-5">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request tags</div>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {request.serviceTokens.map((token) => (
+                      <span
+                        key={token}
+                        className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                      >
+                        {formatServiceTokenLabel(token)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </section>
+
+              <aside className={shellClass}>
+                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Why you matched</div>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{formatReason(match.primaryReason)}</h2>
+                <p className={`mt-2 text-sm ${t.mutedText}`}>
+                  This request is shown to you because your current expert profile overlaps on services and location rules.
+                </p>
+
+                <div className="mt-5 space-y-4">
+                  <div>
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Matched tags</div>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {match.matchedServiceTokens.map((token) => (
+                        <span
+                          key={token}
+                          className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                        >
+                          {formatServiceTokenLabel(token)}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                  {match.requestLocation ? (
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request location</div>
+                      <div className="mt-1 text-sm font-medium text-slate-900">
+                        {[match.requestLocation.city, match.requestLocation.state].filter(Boolean).join(', ') || `ZIP ${request.zip}`}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </aside>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default function ProviderRequestDetailPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+          <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+            <section className="rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(247,244,239,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6">
+              <p className="text-sm text-slate-600">Loading request...</p>
+            </section>
+          </div>
+        </main>
+      }
+    >
+      <ProviderRequestDetailPageContent />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## What changed
- added provider-only matched request endpoints under /provider/requests
- reused the existing request matching rules to compute provider-visible opportunities from active customer requests
- added a provider inbox list at /dashboard/requests
- added a provider request detail page at /dashboard/requests/view
- updated the provider dashboard to show matched request counts and links

## Verification
- 
ode --test tests/requests.test.js
- 
ode_modules/.bin/tsc.cmd --noEmit -p tsconfig.json
- 
pm run build in marketlink-backend
- 
pm exec eslint src/app/dashboard/page.tsx src/app/dashboard/requests/page.tsx src/app/dashboard/requests/view/page.tsx
- 
pm run build in marketlink-frontend
- browser flow on http://localhost:3000: create matching customer request -> sign in as provider -> open /dashboard/requests -> open matched request detail

## Local verification note
- used local provider login for verification: contact@windycitygrowth.com / TempProvider123!
