### PR TITLE
MM-55 add request lifecycle controls and status surfaces

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -75,6 +75,13 @@ function getReasonWeight(reason: RequestMatchReason) {
   return 100;
 }
 
+function canTransitionRequestStatus(current: CustomerRequestStatus, next: CustomerRequestStatus) {
+  if (current === next) return true;
+  if (current === CustomerRequestStatus.ACTIVE && (next === CustomerRequestStatus.CLOSED || next === CustomerRequestStatus.CANCELLED)) return true;
+  if (current === CustomerRequestStatus.CLOSED && next === CustomerRequestStatus.ACTIVE) return true;
+  return false;
+}
+
 async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, request: RequestForProviderMatching) {
   const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
   if (!matchedServiceTokens.length) return null;
@@ -354,6 +361,56 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     return reply.send({ ok: true, request, deliveryPreview });
+  });
+
+  fastify.patch('/requests/:id', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can update requests.' });
+
+    const { id } = (req.params || {}) as { id?: string };
+    const body = (req.body || {}) as { status?: CustomerRequestStatus | string };
+    const nextStatus = String(body.status || '')
+      .trim()
+      .toUpperCase() as CustomerRequestStatus;
+
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing request id' });
+    if (!Object.values(CustomerRequestStatus).includes(nextStatus)) {
+      return reply.code(400).send({ ok: false, error: 'status must be ACTIVE, CLOSED, or CANCELLED' });
+    }
+
+    const existing = await prisma.customerRequest.findFirst({
+      where: {
+        id,
+        customerUserId: user.id,
+      },
+      select: {
+        id: true,
+        status: true,
+      },
+    });
+
+    if (!existing) return reply.code(404).send({ ok: false, error: 'Request not found' });
+
+    if (!canTransitionRequestStatus(existing.status, nextStatus)) {
+      return reply.code(409).send({
+        ok: false,
+        error: `This request cannot move from ${existing.status} to ${nextStatus}.`,
+      });
+    }
+
+    const updated = await prisma.customerRequest.update({
+      where: { id },
+      data: { status: nextStatus },
+      select: {
+        id: true,
+        status: true,
+        updatedAt: true,
+      },
+    });
+
+    req.log.info({ requestId: updated.id, status: updated.status, customerUserId: user.id }, 'customer-request.updated');
+    return reply.send({ ok: true, request: updated });
   });
 
   fastify.get('/provider/requests', async (req, reply) => {

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -581,3 +581,183 @@ test('GET /provider/requests/:id only returns a matched active request for the s
     await fastify.close();
   }
 });
+
+test('PATCH /requests/:id lets a customer close their active request', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_close_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerRequest = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'request_close_1');
+      assert.equal(where.customerUserId, 'customer_user_close_1');
+      return {
+        id: 'request_close_1',
+        status: 'ACTIVE',
+      };
+    },
+    update: async ({ where, data }) => {
+      assert.equal(where.id, 'request_close_1');
+      assert.equal(data.status, 'CLOSED');
+      return {
+        id: 'request_close_1',
+        status: 'CLOSED',
+        updatedAt: new Date('2026-05-30T01:00:00.000Z'),
+      };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'PATCH',
+      url: '/requests/request_close_1',
+      payload: {
+        status: 'CLOSED',
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.request.id, 'request_close_1');
+    assert.equal(body.request.status, 'CLOSED');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    await fastify.close();
+  }
+});
+
+test('PATCH /requests/:id rejects invalid lifecycle transitions', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_cancelled_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerRequest = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'request_cancelled_1');
+      assert.equal(where.customerUserId, 'customer_user_cancelled_1');
+      return {
+        id: 'request_cancelled_1',
+        status: 'CANCELLED',
+      };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'PATCH',
+      url: '/requests/request_cancelled_1',
+      payload: {
+        status: 'ACTIVE',
+      },
+    });
+
+    assert.equal(response.statusCode, 409);
+    assert.equal(response.json().error, 'This request cannot move from CANCELLED to ACTIVE.');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    await fastify.close();
+  }
+});
+
+test('GET /provider/requests excludes closed and cancelled requests', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_filter_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.userId, 'provider_user_filter_1');
+      return {
+        id: 'expert_provider_filter_1',
+        slug: 'windy-city-growth',
+        businessName: 'Windy City Growth',
+        city: 'Chicago',
+        state: 'IL',
+        zip: '60601',
+        remoteFriendly: true,
+        servesNationwide: true,
+        services: ['google-ads', 'paid-search', 'ads'],
+        verified: true,
+        rating: 4.7,
+      };
+    },
+  };
+
+  prismaModule.prisma.customerRequest = {
+    findMany: async ({ where }) => {
+      assert.equal(where.status, 'ACTIVE');
+      return [
+        {
+          id: 'request_active_1',
+          title: 'Active request',
+          description: 'Looking for Google Ads help.',
+          marketingSubjectId: 'paid-ads-lead-generation',
+          serviceTokens: ['google-ads'],
+          zip: '60601',
+          budgetLabel: null,
+          timelineLabel: null,
+          status: 'ACTIVE',
+          requesterName: 'Jamie Rivera',
+          requesterBusinessName: null,
+          createdAt: new Date('2026-05-30T01:00:00.000Z'),
+          updatedAt: new Date('2026-05-30T01:00:00.000Z'),
+        },
+      ];
+    },
+  };
+
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60601',
+    latitude: 41.88,
+    longitude: -87.62,
+    geocodedAt: new Date('2026-05-30T01:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/provider/requests',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.deepEqual(body.data.map((row) => row.id), ['request_active_1']);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});

--- a/marketlink-frontend/src/app/dashboard/customer/requests/RequestLifecycleActions.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/RequestLifecycleActions.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type RequestStatus = 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+
+type RequestLifecycleActionsProps = {
+  requestId: string;
+  status: RequestStatus;
+};
+
+export default function RequestLifecycleActions({ requestId, status }: RequestLifecycleActionsProps) {
+  const router = useRouter();
+  const [busyStatus, setBusyStatus] = useState<RequestStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function updateStatus(nextStatus: RequestStatus) {
+    setBusyStatus(nextStatus);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/requests/${requestId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) {
+        throw new Error(body.error || `Failed to update request (${response.status})`);
+      }
+
+      router.refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setBusyStatus(null);
+    }
+  }
+
+  return (
+    <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request controls</div>
+      <p className="mt-2 text-sm leading-6 text-slate-600">
+        Active requests can keep matching. Closed requests can be reopened later. Cancelled requests stay in your history but stop here permanently.
+      </p>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+        {status === 'ACTIVE' ? (
+          <>
+            <button
+              type="button"
+              disabled={Boolean(busyStatus)}
+              onClick={() => updateStatus('CLOSED')}
+              className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900 disabled:opacity-60"
+            >
+              {busyStatus === 'CLOSED' ? 'Closing...' : 'Close request'}
+            </button>
+            <button
+              type="button"
+              disabled={Boolean(busyStatus)}
+              onClick={() => updateStatus('CANCELLED')}
+              className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:opacity-60"
+            >
+              {busyStatus === 'CANCELLED' ? 'Cancelling...' : 'Cancel request'}
+            </button>
+          </>
+        ) : null}
+
+        {status === 'CLOSED' ? (
+          <button
+            type="button"
+            disabled={Boolean(busyStatus)}
+            onClick={() => updateStatus('ACTIVE')}
+            className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white disabled:opacity-60"
+          >
+            {busyStatus === 'ACTIVE' ? 'Reopening...' : 'Reopen request'}
+          </button>
+        ) : null}
+      </div>
+
+      {status === 'CANCELLED' ? <p className="mt-4 text-sm font-medium text-slate-700">This request is cancelled and cannot be reopened.</p> : null}
+
+      {error ? (
+        <div role="alert" className="mt-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
@@ -84,7 +84,7 @@ export default async function CustomerRequestsPage() {
             <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
             <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Request history</h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-              Create requests privately, then revisit the matching preview and request details here.
+              Create requests privately, then revisit the matching preview and request details here. Active requests can keep matching, while closed and cancelled requests stay visible in your history.
             </p>
           </div>
 

--- a/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+import RequestLifecycleActions from '../RequestLifecycleActions';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
@@ -230,6 +231,8 @@ export default async function CustomerRequestDetailPage({
                 ))}
               </ul>
             ) : null}
+
+            <RequestLifecycleActions requestId={request.id} status={request.status} />
           </aside>
         </div>
 


### PR DESCRIPTION
## What changed
- added customer request lifecycle updates through `PATCH /requests/:id`
- enforced valid transitions for active, closed, and cancelled requests
- added customer-side request controls for close, cancel, and reopen
- clarified customer request status surfaces
- ensured provider matched-request visibility drops closed/cancelled requests and returns on reopen

## Verification
- `cd marketlink-backend && node --test tests/requests.test.js`
- `cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json`
- `cd marketlink-backend && npm run build`
- `cd marketlink-frontend && npm exec eslint src/app/dashboard/customer/requests/page.tsx src/app/dashboard/customer/requests/view/page.tsx src/app/dashboard/customer/requests/RequestLifecycleActions.tsx src/app/dashboard/requests/page.tsx src/app/dashboard/requests/view/page.tsx`
- `cd marketlink-frontend && npm run build`
- browser verification on `http://localhost:3000`: customer close/reopen flow plus provider visibility through `/provider/requests`