### PR TITLE
MM-57 add proposal schema foundation

### DIFF
--- a/marketlink-backend/prisma/migrations/20260602004045_add_proposals/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260602004045_add_proposals/migration.sql
@@ -1,0 +1,32 @@
+-- CreateEnum
+CREATE TYPE "ProposalStatus" AS ENUM ('PENDING', 'ACCEPTED', 'DECLINED', 'WITHDRAWN');
+
+-- CreateTable
+CREATE TABLE "Proposal" (
+    "id" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "expertId" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "priceLabel" TEXT,
+    "timelineLabel" TEXT,
+    "status" "ProposalStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Proposal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Proposal_requestId_status_createdAt_idx" ON "Proposal"("requestId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Proposal_expertId_status_createdAt_idx" ON "Proposal"("expertId", "status", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Proposal_requestId_expertId_key" ON "Proposal"("requestId", "expertId");
+
+-- AddForeignKey
+ALTER TABLE "Proposal" ADD CONSTRAINT "Proposal_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "CustomerRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Proposal" ADD CONSTRAINT "Proposal_expertId_fkey" FOREIGN KEY ("expertId") REFERENCES "Expert"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -8,13 +8,13 @@ datasource db {
 }
 
 model User {
-  id                 String        @id @default(cuid())
-  email              String        @unique
-  role               UserRole      @default(provider)
-  createdAt          DateTime      @default(now())
-  updatedAt          DateTime      @updatedAt
-  isDisabled         Boolean       @default(false)
-  mustChangePassword Boolean       @default(true)
+  id                 String            @id @default(cuid())
+  email              String            @unique
+  role               UserRole          @default(provider)
+  createdAt          DateTime          @default(now())
+  updatedAt          DateTime          @updatedAt
+  isDisabled         Boolean           @default(false)
+  mustChangePassword Boolean           @default(true)
   passwordHash       String?
   adminActions       AdminAction[]
   customerProfile    CustomerProfile?
@@ -24,13 +24,13 @@ model User {
 }
 
 model CustomerProfile {
-  id           String   @id @default(cuid())
-  userId       String   @unique
+  id           String            @id @default(cuid())
+  userId       String            @unique
   name         String
   businessName String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime          @default(now())
+  updatedAt    DateTime          @updatedAt
+  user         User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   requests     CustomerRequest[]
 }
 
@@ -87,6 +87,7 @@ model Expert {
   status              ExpertStatus          @default(active)
   adminActions        AdminAction[]
   owner               User?                 @relation(fields: [userId], references: [id])
+  proposals           Proposal[]
   projects            ExpertProject[]
   clients             ExpertClient[]
   media               ExpertMedia[]
@@ -190,6 +191,13 @@ enum CustomerRequestStatus {
   CANCELLED
 }
 
+enum ProposalStatus {
+  PENDING
+  ACCEPTED
+  DECLINED
+  WITHDRAWN
+}
+
 model CustomerRequest {
   id                    String                @id @default(cuid())
   customerUserId        String
@@ -208,11 +216,30 @@ model CustomerRequest {
   updatedAt             DateTime              @updatedAt
   customerUser          User                  @relation(fields: [customerUserId], references: [id], onDelete: Cascade)
   customerProfile       CustomerProfile?      @relation(fields: [customerProfileId], references: [id], onDelete: SetNull)
+  proposals             Proposal[]
 
   @@index([customerUserId, createdAt])
   @@index([status, createdAt])
   @@index([marketingSubjectId, status])
   @@index([zip, status])
+}
+
+model Proposal {
+  id            String          @id @default(cuid())
+  requestId     String
+  expertId      String
+  message       String
+  priceLabel    String?
+  timelineLabel String?
+  status        ProposalStatus  @default(PENDING)
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  request       CustomerRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  expert        Expert          @relation(fields: [expertId], references: [id], onDelete: Cascade)
+
+  @@unique([requestId, expertId])
+  @@index([requestId, status, createdAt])
+  @@index([expertId, status, createdAt])
 }
 
 ///


### PR DESCRIPTION
## What changed
- added the proposal foundation schema for the request-to-provider workflow
- added `ProposalStatus` with `PENDING`, `ACCEPTED`, `DECLINED`, and `WITHDRAWN`
- added `Proposal` linked to `CustomerRequest` and `Expert`
- added uniqueness and lookup indexes for request/expert proposal access
- added the Prisma migration for the new proposal tables and enum

## Verification
- `cd marketlink-backend && npx prisma migrate dev --name add_proposals`
- `cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json`
- `cd marketlink-backend && npm run build`
- `cd marketlink-backend && node --test tests/requests.test.js`