### PR TITLE
MM-59 add provider proposal submission UI

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -536,6 +536,26 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     const match = await buildProviderMatchForRequest(expert, request);
     if (!match) return reply.code(404).send({ ok: false, error: 'Request not found' });
 
+    const proposal = await prisma.proposal.findUnique({
+      where: {
+        requestId_expertId: {
+          requestId: request.id,
+          expertId: expert.id,
+        },
+      },
+      select: {
+        id: true,
+        requestId: true,
+        expertId: true,
+        message: true,
+        priceLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
     return reply.send({
       ok: true,
       request,
@@ -545,6 +565,7 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         matchedServiceTokens: match.matchedServiceTokens,
         requestLocation: match.requestLocation,
       },
+      proposal,
     });
   });
 

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -499,6 +499,7 @@ test('GET /provider/requests/:id only returns a matched active request for the s
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalExpert = prismaModule.prisma.expert;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalProposal = prismaModule.prisma.proposal;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -551,6 +552,26 @@ test('GET /provider/requests/:id only returns a matched active request for the s
     },
   };
 
+  prismaModule.prisma.proposal = {
+    findUnique: async ({ where }) => {
+      assert.deepEqual(where.requestId_expertId, {
+        requestId: 'request_provider_detail_1',
+        expertId: 'expert_provider_2',
+      });
+      return {
+        id: 'proposal_provider_detail_1',
+        requestId: 'request_provider_detail_1',
+        expertId: 'expert_provider_2',
+        message: 'We can audit and relaunch your paid search campaigns.',
+        priceLabel: '$5k-$10k',
+        timelineLabel: 'This month',
+        status: 'PENDING',
+        createdAt: new Date('2026-06-05T18:00:00.000Z'),
+        updatedAt: new Date('2026-06-05T18:00:00.000Z'),
+      };
+    },
+  };
+
   geocodingModule.lookupZipLocation = async () => ({
     ok: true,
     city: 'Chicago',
@@ -573,10 +594,13 @@ test('GET /provider/requests/:id only returns a matched active request for the s
     assert.equal(body.ok, true);
     assert.equal(body.request.id, 'request_provider_detail_1');
     assert.equal(body.match.primaryReason, 'serves_nationwide');
+    assert.equal(body.proposal.id, 'proposal_provider_detail_1');
+    assert.equal(body.proposal.status, 'PENDING');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.expert = originalExpert;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.proposal = originalProposal;
     geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }

--- a/marketlink-frontend/src/app/dashboard/requests/ProposalForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/ProposalForm.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type ProposalStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+
+type ProposalSummary = {
+  id: string;
+  message: string;
+  priceLabel?: string | null;
+  timelineLabel?: string | null;
+  status: ProposalStatus;
+  createdAt: string;
+};
+
+type ProposalFormProps = {
+  requestId: string;
+  initialProposal?: ProposalSummary | null;
+};
+
+function formatProposalStatus(status: ProposalStatus) {
+  if (status === 'PENDING') return 'Pending';
+  if (status === 'ACCEPTED') return 'Accepted';
+  if (status === 'DECLINED') return 'Declined';
+  return 'Withdrawn';
+}
+
+export default function ProposalForm({ requestId, initialProposal = null }: ProposalFormProps) {
+  const [proposal, setProposal] = useState<ProposalSummary | null>(initialProposal);
+  const [message, setMessage] = useState('');
+  const [priceLabel, setPriceLabel] = useState('');
+  const [timelineLabel, setTimelineLabel] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submitProposal(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    const cleanMessage = message.trim();
+    if (!cleanMessage) {
+      setError('Proposal message is required.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const response = await fetch(`${API_BASE}/provider/requests/${requestId}/proposals`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: cleanMessage,
+          priceLabel: priceLabel.trim() || undefined,
+          timelineLabel: timelineLabel.trim() || undefined,
+        }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as { error?: string; proposal?: ProposalSummary };
+      if (!response.ok || !body.proposal) {
+        throw new Error(body.error || `Failed to submit proposal (${response.status})`);
+      }
+
+      setProposal(body.proposal);
+      setMessage('');
+      setPriceLabel('');
+      setTimelineLabel('');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (proposal) {
+    return (
+      <section className="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-700">Proposal submitted</div>
+          <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200">
+            {formatProposalStatus(proposal.status)}
+          </span>
+        </div>
+        <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-slate-700">{proposal.message}</p>
+        <div className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Price</div>
+            <div className="mt-1 font-medium text-slate-900">{proposal.priceLabel || 'Not specified'}</div>
+          </div>
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-700">Timeline</div>
+            <div className="mt-1 font-medium text-slate-900">{proposal.timelineLabel || 'Not specified'}</div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <form onSubmit={submitProposal} className="mt-5 rounded-2xl border border-slate-200 bg-white/80 px-4 py-4">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Send proposal</div>
+      <div className="mt-4 grid gap-4">
+        <div className="grid gap-2">
+          <label htmlFor="proposal-message" className="text-sm font-medium text-slate-700">
+            Message
+          </label>
+          <textarea
+            id="proposal-message"
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            maxLength={4000}
+            className="ml-input min-h-32 w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-2">
+            <label htmlFor="proposal-price" className="text-sm font-medium text-slate-700">
+              Price
+            </label>
+            <input
+              id="proposal-price"
+              value={priceLabel}
+              onChange={(event) => setPriceLabel(event.target.value)}
+              maxLength={80}
+              className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label htmlFor="proposal-timeline" className="text-sm font-medium text-slate-700">
+              Timeline
+            </label>
+            <input
+              id="proposal-timeline"
+              value={timelineLabel}
+              onChange={(event) => setTimelineLabel(event.target.value)}
+              maxLength={80}
+              className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            />
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div role="alert" className="mt-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={saving}
+        className="ml-btn-primary mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-xl px-6 text-sm font-semibold text-white disabled:opacity-60"
+      >
+        {saving ? 'Submitting proposal...' : 'Submit proposal'}
+      </button>
+    </form>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
 import { useMarketLinkTheme } from '@/components/ThemeToggle';
+import ProposalForm from '../ProposalForm';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
@@ -34,6 +35,17 @@ type ProviderRequestDetailResponse = {
     matchedServiceTokens: string[];
     requestLocation?: { zip?: string | null; city?: string | null; state?: string | null; source?: string | null } | null;
   };
+  proposal?: {
+    id: string;
+    requestId: string;
+    expertId: string;
+    message: string;
+    priceLabel?: string | null;
+    timelineLabel?: string | null;
+    status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+    createdAt: string;
+    updatedAt: string;
+  } | null;
   error?: string;
 };
 
@@ -144,6 +156,7 @@ function ProviderRequestDetailPageContent() {
 
   const request = data?.request;
   const match = data?.match;
+  const proposal = data?.proposal;
   const subject = request ? getMarketingSubjectById(request.marketingSubjectId) : null;
 
   return (
@@ -264,6 +277,8 @@ function ProviderRequestDetailPageContent() {
                     </div>
                   ) : null}
                 </div>
+
+                <ProposalForm requestId={request.id} initialProposal={proposal} />
               </aside>
             </div>
           </>


### PR DESCRIPTION
## What changed
- added a provider proposal form to the matched request detail page
- providers can submit message, optional price, and optional timeline
- submitted proposals render as a persisted submitted state after reload
- extended `GET /provider/requests/:id` to return the provider's existing proposal
- added backend coverage for the existing proposal response

## Verification
- `cd marketlink-backend && node --test tests/requests.test.js`
- `cd marketlink-backend && node_modules/.bin/tsc.cmd --noEmit -p tsconfig.json`
- `cd marketlink-backend && npm run build`
- `cd marketlink-frontend && npm exec eslint src/app/dashboard/requests/view/page.tsx src/app/dashboard/requests/ProposalForm.tsx`
- `cd marketlink-frontend && npm run build`
- browser flow on `http://localhost:3000`: provider signs in, opens matched request, submits proposal, reload confirms submitted state persists