### PR TITLE
Add customer proposal review UI

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -360,7 +360,35 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       zip: request.zip,
     });
 
-    return reply.send({ ok: true, request, deliveryPreview });
+    const proposals = await prisma.proposal.findMany({
+      where: { requestId: request.id },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        requestId: true,
+        expertId: true,
+        message: true,
+        priceLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        expert: {
+          select: {
+            id: true,
+            slug: true,
+            businessName: true,
+            expertType: true,
+            city: true,
+            state: true,
+            verified: true,
+            rating: true,
+          },
+        },
+      },
+    });
+
+    return reply.send({ ok: true, request, deliveryPreview, proposals });
   });
 
   fastify.patch('/requests/:id', async (req, reply) => {

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -229,6 +229,7 @@ test('GET /requests lists only the signed-in customer requests', async () => {
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
   const originalExpert = prismaModule.prisma.expert;
+  const originalProposal = prismaModule.prisma.proposal;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -279,6 +280,7 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
   const originalExpert = prismaModule.prisma.expert;
+  const originalProposal = prismaModule.prisma.proposal;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -338,6 +340,12 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
       },
     ],
   };
+  prismaModule.prisma.proposal = {
+    findMany: async ({ where }) => {
+      assert.equal(where.requestId, 'request_3');
+      return [];
+    },
+  };
   geocodingModule.lookupZipLocation = async () => ({
     ok: true,
     city: 'Chicago',
@@ -367,6 +375,129 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
     prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.proposal = originalProposal;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});
+
+test('GET /requests/:id returns proposals with expert summaries for the signed-in customer request', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalProposal = prismaModule.prisma.proposal;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_proposal_review',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerRequest = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'request_customer_proposals_1');
+      assert.equal(where.customerUserId, 'customer_user_proposal_review');
+      return {
+        id: 'request_customer_proposals_1',
+        title: 'Need Google Ads support for a local dental office',
+        description: 'Looking for an expert to audit and relaunch paid search campaigns.',
+        marketingSubjectId: 'paid-ads-lead-generation',
+        serviceTokens: ['google-ads', 'paid-search'],
+        zip: '60601',
+        budgetLabel: '$5k-$10k',
+        timelineLabel: 'This month',
+        status: 'ACTIVE',
+        requesterName: 'Jamie Rivera',
+        requesterBusinessName: 'Westmont Dental',
+        createdAt: new Date('2026-06-05T15:00:00.000Z'),
+        updatedAt: new Date('2026-06-05T15:00:00.000Z'),
+      };
+    },
+  };
+
+  prismaModule.prisma.expert = {
+    findMany: async () => [
+      {
+        id: 'expert_customer_proposal_1',
+        slug: 'windy-city-growth',
+        businessName: 'Windy City Growth',
+        city: 'Chicago',
+        state: 'IL',
+        zip: '60601',
+        remoteFriendly: true,
+        servesNationwide: false,
+        services: ['google-ads', 'paid-search'],
+        verified: true,
+        rating: 4.7,
+      },
+    ],
+  };
+
+  prismaModule.prisma.proposal = {
+    findMany: async ({ where, orderBy }) => {
+      assert.equal(where.requestId, 'request_customer_proposals_1');
+      assert.deepEqual(orderBy, { createdAt: 'desc' });
+      return [
+        {
+          id: 'proposal_customer_review_1',
+          requestId: 'request_customer_proposals_1',
+          expertId: 'expert_customer_proposal_1',
+          message: 'We can audit your account and rebuild the campaign around local search intent.',
+          priceLabel: '$5k-$10k',
+          timelineLabel: 'This month',
+          status: 'PENDING',
+          createdAt: new Date('2026-06-05T18:00:00.000Z'),
+          updatedAt: new Date('2026-06-05T18:00:00.000Z'),
+          expert: {
+            id: 'expert_customer_proposal_1',
+            slug: 'windy-city-growth',
+            businessName: 'Windy City Growth',
+            expertType: 'agency',
+            city: 'Chicago',
+            state: 'IL',
+            verified: true,
+            rating: 4.7,
+          },
+        },
+      ];
+    },
+  };
+
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Chicago',
+    state: 'IL',
+    zip: '60601',
+    latitude: 41.88,
+    longitude: -87.62,
+    geocodedAt: new Date('2026-06-05T15:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/requests/request_customer_proposals_1',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.request.id, 'request_customer_proposals_1');
+    assert.equal(body.proposals.length, 1);
+    assert.equal(body.proposals[0].id, 'proposal_customer_review_1');
+    assert.equal(body.proposals[0].status, 'PENDING');
+    assert.equal(body.proposals[0].expert.businessName, 'Windy City Growth');
+    assert.equal(body.proposals[0].expert.slug, 'windy-city-growth');
+    assert.equal(body.proposals[0].expert.verified, true);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.proposal = originalProposal;
     geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }

--- a/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
@@ -51,6 +51,27 @@ type RequestDetailResponse = {
     updatedAt: string;
   };
   deliveryPreview?: DeliveryPreview;
+  proposals?: Array<{
+    id: string;
+    requestId: string;
+    expertId: string;
+    message: string;
+    priceLabel?: string | null;
+    timelineLabel?: string | null;
+    status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+    createdAt: string;
+    updatedAt: string;
+    expert: {
+      id: string;
+      slug: string;
+      businessName: string;
+      expertType?: string | null;
+      city: string;
+      state: string;
+      verified: boolean;
+      rating: number;
+    };
+  }>;
 };
 
 function formatShortDate(value: string) {
@@ -78,6 +99,23 @@ function formatStatus(status: NonNullable<RequestDetailResponse['request']>['sta
   if (status === 'ACTIVE') return 'Active';
   if (status === 'CLOSED') return 'Closed';
   return 'Cancelled';
+}
+
+function formatProposalStatus(status: NonNullable<RequestDetailResponse['proposals']>[number]['status']) {
+  if (status === 'PENDING') return 'New proposal';
+  if (status === 'ACCEPTED') return 'Accepted';
+  if (status === 'DECLINED') return 'Declined';
+  return 'Withdrawn';
+}
+
+function formatExpertType(value?: string | null) {
+  const cleanValue = (value || 'expert').trim();
+
+  return cleanValue
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
 }
 
 export default async function CustomerRequestDetailPage({
@@ -135,6 +173,7 @@ export default async function CustomerRequestDetailPage({
 
   const subject = getMarketingSubjectById(request.marketingSubjectId);
   const preview = data.deliveryPreview;
+  const proposals = data.proposals || [];
 
   return (
     <main className="ml-page-bg min-h-[calc(100vh-72px)]">
@@ -235,6 +274,86 @@ export default async function CustomerRequestDetailPage({
             <RequestLifecycleActions requestId={request.id} status={request.status} />
           </aside>
         </div>
+
+        <section className="mt-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Provider proposals</p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                {proposals.length ? `${proposals.length} proposal${proposals.length === 1 ? '' : 's'} to review` : 'No proposals yet'}
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                Review who responded, their note, estimated budget, and timing. Messaging and accept/decline actions will come in the next workflow step.
+              </p>
+            </div>
+          </div>
+
+          {proposals.length ? (
+            <div className="mt-4 grid gap-4">
+              {proposals.map((proposal) => (
+                <article key={proposal.id} className="ml-card rounded-[28px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {formatProposalStatus(proposal.status)}
+                        </span>
+                        {proposal.expert.verified ? (
+                          <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                            Verified
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <h3 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{proposal.expert.businessName}</h3>
+                      <p className="mt-1 text-sm leading-6 text-slate-600">
+                        {formatExpertType(proposal.expert.expertType)} in {proposal.expert.city}, {proposal.expert.state}
+                      </p>
+                    </div>
+
+                    <Link
+                      href={`/experts/${proposal.expert.slug}`}
+                      className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
+                    >
+                      View expert profile
+                    </Link>
+                  </div>
+
+                  <div className="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_260px]">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Provider note</div>
+                      <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{proposal.message}</p>
+                    </div>
+
+                    <div className="rounded-2xl bg-slate-50 p-4">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Estimate</div>
+                      <dl className="mt-3 space-y-3 text-sm">
+                        <div>
+                          <dt className="text-slate-500">Budget</dt>
+                          <dd className="mt-1 font-semibold text-slate-950">{proposal.priceLabel || 'Not specified'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Timing</dt>
+                          <dd className="mt-1 font-semibold text-slate-950">{proposal.timelineLabel || 'Not specified'}</dd>
+                        </div>
+                        <div>
+                          <dt className="text-slate-500">Received</dt>
+                          <dd className="mt-1 font-semibold text-slate-950">{formatShortDate(proposal.createdAt)}</dd>
+                        </div>
+                      </dl>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="ml-card mt-4 rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+              <p className="text-sm leading-6 text-slate-600">
+                Providers have not sent proposals yet. This page will update once matched experts respond to the request.
+              </p>
+            </div>
+          )}
+        </section>
 
         <section className="mt-5">
           <div className="flex items-end justify-between">


### PR DESCRIPTION
﻿## Summary
- Add proposals to the customer-owned request detail API response with expert summary data.
- Add a customer request detail section for reviewing provider proposals, including status, provider note, budget, timeline, received date, and expert profile link.
- Cover the customer proposal response with backend route tests.

## Validation
- `node --test tests/requests.test.js`
- `node_modules\.bin\tsc.cmd --noEmit -p tsconfig.json`
- `npm exec eslint src/app/dashboard/customer/requests/view/page.tsx`
- `npm run build` in `marketlink-backend`
- `npm run build` in `marketlink-frontend`
- Browser verified locally at `/dashboard/customer/requests/view?id=mm60_customer_request_1`
