### PR TITLE
Add customer proposal inbox and decisions

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -82,6 +82,10 @@ function canTransitionRequestStatus(current: CustomerRequestStatus, next: Custom
   return false;
 }
 
+function isCustomerProposalDecision(status: ProposalStatus) {
+  return status === ProposalStatus.ACCEPTED || status === ProposalStatus.DECLINED;
+}
+
 async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, request: RequestForProviderMatching) {
   const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
   if (!matchedServiceTokens.length) return null;
@@ -389,6 +393,124 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     return reply.send({ ok: true, request, deliveryPreview, proposals });
+  });
+
+  fastify.get('/proposals', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can view proposals.' });
+
+    const proposals = await prisma.proposal.findMany({
+      where: {
+        request: {
+          customerUserId: user.id,
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        requestId: true,
+        expertId: true,
+        message: true,
+        priceLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+        request: {
+          select: {
+            id: true,
+            title: true,
+            marketingSubjectId: true,
+            status: true,
+          },
+        },
+        expert: {
+          select: {
+            id: true,
+            slug: true,
+            businessName: true,
+            expertType: true,
+            city: true,
+            state: true,
+            verified: true,
+            rating: true,
+          },
+        },
+      },
+      take: 100,
+    });
+
+    return reply.send({ ok: true, data: proposals });
+  });
+
+  fastify.patch('/proposals/:id', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer') return reply.code(403).send({ error: 'Only customers can update proposals.' });
+
+    const { id } = (req.params || {}) as { id?: string };
+    const body = (req.body || {}) as { status?: ProposalStatus | string };
+    const nextStatus = String(body.status || '')
+      .trim()
+      .toUpperCase() as ProposalStatus;
+
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing proposal id' });
+    if (!Object.values(ProposalStatus).includes(nextStatus) || !isCustomerProposalDecision(nextStatus)) {
+      return reply.code(400).send({ ok: false, error: 'status must be ACCEPTED or DECLINED' });
+    }
+
+    const existing = await prisma.proposal.findFirst({
+      where: {
+        id,
+        request: {
+          customerUserId: user.id,
+        },
+      },
+      select: {
+        id: true,
+        requestId: true,
+        status: true,
+      },
+    });
+
+    if (!existing) return reply.code(404).send({ ok: false, error: 'Proposal not found' });
+
+    if (existing.status !== ProposalStatus.PENDING) {
+      return reply.code(409).send({ ok: false, error: `This proposal cannot move from ${existing.status} to ${nextStatus}.` });
+    }
+
+    const updated = await prisma.proposal.update({
+      where: { id },
+      data: { status: nextStatus },
+      select: {
+        id: true,
+        requestId: true,
+        expertId: true,
+        message: true,
+        priceLabel: true,
+        timelineLabel: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (nextStatus === ProposalStatus.ACCEPTED) {
+      await prisma.proposal.updateMany({
+        where: {
+          requestId: existing.requestId,
+          id: { not: updated.id },
+          status: ProposalStatus.PENDING,
+        },
+        data: {
+          status: ProposalStatus.DECLINED,
+        },
+      });
+    }
+
+    req.log.info({ proposalId: updated.id, requestId: updated.requestId, status: updated.status, customerUserId: user.id }, 'proposal.updated');
+    return reply.send({ ok: true, proposal: updated });
   });
 
   fastify.patch('/requests/:id', async (req, reply) => {

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -503,6 +503,182 @@ test('GET /requests/:id returns proposals with expert summaries for the signed-i
   }
 });
 
+test('GET /proposals lists incoming proposals for the signed-in customer requests', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalProposal = prismaModule.prisma.proposal;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_proposal_inbox',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.proposal = {
+    findMany: async ({ where, orderBy }) => {
+      assert.equal(where.request.customerUserId, 'customer_user_proposal_inbox');
+      assert.deepEqual(orderBy, { createdAt: 'desc' });
+      return [
+        {
+          id: 'proposal_inbox_1',
+          requestId: 'request_inbox_1',
+          expertId: 'expert_inbox_1',
+          message: 'We can launch your local search campaign this month.',
+          priceLabel: '$5k-$10k',
+          timelineLabel: 'This month',
+          status: 'PENDING',
+          createdAt: new Date('2026-06-06T15:00:00.000Z'),
+          updatedAt: new Date('2026-06-06T15:00:00.000Z'),
+          request: {
+            id: 'request_inbox_1',
+            title: 'Need Google Ads support',
+            marketingSubjectId: 'paid-ads-lead-generation',
+            status: 'ACTIVE',
+          },
+          expert: {
+            id: 'expert_inbox_1',
+            slug: 'windy-city-growth',
+            businessName: 'Windy City Growth',
+            expertType: 'agency',
+            city: 'Chicago',
+            state: 'IL',
+            verified: true,
+            rating: 4.7,
+          },
+        },
+      ];
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/proposals',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].id, 'proposal_inbox_1');
+    assert.equal(body.data[0].request.title, 'Need Google Ads support');
+    assert.equal(body.data[0].expert.businessName, 'Windy City Growth');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.proposal = originalProposal;
+    await fastify.close();
+  }
+});
+
+test('PATCH /proposals/:id lets a customer accept their pending proposal', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalProposal = prismaModule.prisma.proposal;
+  let declinedOtherPendingProposals = false;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_proposal_accept',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.proposal = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'proposal_accept_1');
+      assert.equal(where.request.customerUserId, 'customer_user_proposal_accept');
+      return {
+        id: 'proposal_accept_1',
+        requestId: 'request_accept_1',
+        status: 'PENDING',
+      };
+    },
+    update: async ({ where, data }) => {
+      assert.equal(where.id, 'proposal_accept_1');
+      assert.equal(data.status, 'ACCEPTED');
+      return {
+        id: 'proposal_accept_1',
+        requestId: 'request_accept_1',
+        expertId: 'expert_accept_1',
+        message: 'We can help.',
+        priceLabel: '$5k-$10k',
+        timelineLabel: 'This month',
+        status: 'ACCEPTED',
+        createdAt: new Date('2026-06-06T15:00:00.000Z'),
+        updatedAt: new Date('2026-06-06T15:05:00.000Z'),
+      };
+    },
+    updateMany: async ({ where, data }) => {
+      declinedOtherPendingProposals = true;
+      assert.equal(where.requestId, 'request_accept_1');
+      assert.deepEqual(where.id, { not: 'proposal_accept_1' });
+      assert.equal(where.status, 'PENDING');
+      assert.equal(data.status, 'DECLINED');
+      return { count: 1 };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'PATCH',
+      url: '/proposals/proposal_accept_1',
+      payload: {
+        status: 'ACCEPTED',
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.proposal.id, 'proposal_accept_1');
+    assert.equal(body.proposal.status, 'ACCEPTED');
+    assert.equal(declinedOtherPendingProposals, true);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.proposal = originalProposal;
+    await fastify.close();
+  }
+});
+
+test('PATCH /proposals/:id rejects proposal decisions for non-owned requests', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalProposal = prismaModule.prisma.proposal;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_proposal_other',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.proposal = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'proposal_other_1');
+      assert.equal(where.request.customerUserId, 'customer_user_proposal_other');
+      return null;
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'PATCH',
+      url: '/proposals/proposal_other_1',
+      payload: {
+        status: 'DECLINED',
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.json().error, 'Proposal not found');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.proposal = originalProposal;
+    await fastify.close();
+  }
+});
+
 test('GET /provider/requests lists active matched requests for the signed-in provider expert', async () => {
   const fastify = await buildFastify();
 

--- a/marketlink-frontend/src/app/dashboard/customer/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/page.tsx
@@ -102,7 +102,7 @@ export default async function CustomerDashboardPage() {
                 <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer dashboard</p>
                 <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Good to see you, {name}.</h1>
                 <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
-                  This is your lightweight home base. Keep the basics current, browse experts, and use this space later to track requests, replies, and your shortlist as those tools come online.
+                  This is your lightweight home base. Keep the basics current, browse experts, track requests, and review provider proposals from one place.
                 </p>
               </div>
 
@@ -158,7 +158,7 @@ export default async function CustomerDashboardPage() {
               <DashboardRailCard
                 eyebrow="Next"
                 title="Use this as your base"
-                body="Later request, proposal, and messaging flows will plug into this dashboard instead of sending you through scattered screens."
+                body="Requests and proposals now stay connected here. Messaging can plug into the same workflow later."
               />
             </div>
           </aside>
@@ -172,8 +172,10 @@ export default async function CustomerDashboardPage() {
             eyebrow="Live"
           />
           <FutureStateCard
-            title="Messages"
-            body="When expert conversations go live, your replies and updates will show here in one place."
+            title="Proposals"
+            body="Compare provider responses, review estimates, and accept or decline proposals."
+            href="/dashboard/customer/proposals"
+            eyebrow="Live"
           />
           <FutureStateCard
             title="Shortlist"

--- a/marketlink-frontend/src/app/dashboard/customer/proposals/ProposalDecisionActions.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/proposals/ProposalDecisionActions.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type ProposalStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+type ProposalDecisionStatus = 'ACCEPTED' | 'DECLINED';
+
+type ProposalDecisionActionsProps = {
+  proposalId: string;
+  status: ProposalStatus;
+};
+
+function formatProposalStatus(status: ProposalStatus) {
+  if (status === 'PENDING') return 'Awaiting your decision';
+  if (status === 'ACCEPTED') return 'Accepted';
+  if (status === 'DECLINED') return 'Declined';
+  return 'Withdrawn';
+}
+
+export default function ProposalDecisionActions({ proposalId, status }: ProposalDecisionActionsProps) {
+  const router = useRouter();
+  const [busyStatus, setBusyStatus] = useState<ProposalDecisionStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function updateProposal(nextStatus: ProposalDecisionStatus) {
+    setBusyStatus(nextStatus);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/proposals/${proposalId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: nextStatus }),
+      });
+
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      if (!response.ok) {
+        throw new Error(body.error || `Failed to update proposal (${response.status})`);
+      }
+
+      router.refresh();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong.');
+    } finally {
+      setBusyStatus(null);
+    }
+  }
+
+  if (status !== 'PENDING') {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Decision</div>
+        <p className="mt-1 text-sm font-semibold text-slate-900">{formatProposalStatus(status)}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Decision</div>
+      <p className="mt-2 text-sm leading-6 text-slate-600">Accept the proposal when you want to move forward, or decline it to keep your list clear.</p>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <button
+          type="button"
+          disabled={Boolean(busyStatus)}
+          onClick={() => updateProposal('ACCEPTED')}
+          className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          {busyStatus === 'ACCEPTED' ? 'Accepting...' : 'Accept'}
+        </button>
+        <button
+          type="button"
+          disabled={Boolean(busyStatus)}
+          onClick={() => updateProposal('DECLINED')}
+          className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 disabled:opacity-60"
+        >
+          {busyStatus === 'DECLINED' ? 'Declining...' : 'Decline'}
+        </button>
+      </div>
+
+      {error ? (
+        <div role="alert" className="mt-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/proposals/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/proposals/page.tsx
@@ -1,0 +1,240 @@
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+import ProposalDecisionActions from './ProposalDecisionActions';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+
+type SummaryResponse = {
+  user?: { email?: string; role?: 'provider' | 'customer' | 'admin' };
+  customer?: { name?: string | null; businessName?: string | null } | null;
+};
+
+type ProposalInboxItem = {
+  id: string;
+  requestId: string;
+  expertId: string;
+  message: string;
+  priceLabel?: string | null;
+  timelineLabel?: string | null;
+  status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+  createdAt: string;
+  updatedAt: string;
+  request: {
+    id: string;
+    title: string;
+    marketingSubjectId: string;
+    status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+  };
+  expert: {
+    id: string;
+    slug: string;
+    businessName: string;
+    expertType?: string | null;
+    city: string;
+    state: string;
+    verified: boolean;
+    rating: number;
+  };
+};
+
+type ProposalInboxResponse = {
+  ok?: boolean;
+  data?: ProposalInboxItem[];
+};
+
+function formatShortDate(value: string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatProposalStatus(status: ProposalInboxItem['status']) {
+  if (status === 'PENDING') return 'Needs decision';
+  if (status === 'ACCEPTED') return 'Accepted';
+  if (status === 'DECLINED') return 'Declined';
+  return 'Withdrawn';
+}
+
+function formatExpertType(value?: string | null) {
+  const cleanValue = (value || 'expert').trim();
+
+  return cleanValue
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(' ');
+}
+
+export default async function CustomerProposalsPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('session');
+  const cookieHeader = sessionCookie ? `${sessionCookie.name}=${sessionCookie.value}` : '';
+
+  const summaryRes = await fetch(`${API_BASE}/me/summary`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (summaryRes.status === 401) {
+    redirect('/login?returnTo=/dashboard/customer/proposals');
+  }
+
+  if (!summaryRes.ok) {
+    throw new Error(`Failed to load customer account (${summaryRes.status})`);
+  }
+
+  const summary = (await summaryRes.json()) as SummaryResponse;
+
+  if (summary.user?.role === 'admin') redirect('/dashboard/admin');
+  if (summary.user?.role === 'provider') redirect('/dashboard');
+  if (!(summary.customer?.name || '').trim()) redirect('/dashboard/customer/onboarding');
+
+  const proposalsRes = await fetch(`${API_BASE}/proposals`, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+    cache: 'no-store',
+  });
+
+  if (!proposalsRes.ok) {
+    throw new Error(`Failed to load customer proposals (${proposalsRes.status})`);
+  }
+
+  const proposalsData = (await proposalsRes.json()) as ProposalInboxResponse;
+  const proposals = proposalsData.data || [];
+  const pendingCount = proposals.filter((proposal) => proposal.status === 'PENDING').length;
+
+  return (
+    <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer proposals</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Proposal inbox</h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+              Compare incoming proposals across your requests. Accept the provider you want to move forward with or decline proposals that are not a fit.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link href="/dashboard/customer" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+              Back to dashboard
+            </Link>
+            <Link href="/dashboard/customer/requests" className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white">
+              Request history
+            </Link>
+          </div>
+        </div>
+
+        <section className="ml-card mt-5 rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Total proposals</div>
+              <div className="mt-2 text-2xl font-semibold text-slate-950">{proposals.length}</div>
+            </div>
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Needs decision</div>
+              <div className="mt-2 text-2xl font-semibold text-slate-950">{pendingCount}</div>
+            </div>
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Flow</div>
+              <div className="mt-2 text-sm font-semibold text-slate-950">Review, accept, or decline</div>
+            </div>
+          </div>
+        </section>
+
+        {proposals.length ? (
+          <section className="mt-5 grid gap-4">
+            {proposals.map((proposal) => {
+              const subject = getMarketingSubjectById(proposal.request.marketingSubjectId);
+              return (
+                <article key={proposal.id} className="ml-card rounded-[28px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <div className="flex flex-wrap gap-2">
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {formatProposalStatus(proposal.status)}
+                        </span>
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {subject?.label || proposal.request.marketingSubjectId}
+                        </span>
+                        {proposal.expert.verified ? (
+                          <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                            Verified
+                          </span>
+                        ) : null}
+                      </div>
+
+                      <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{proposal.expert.businessName}</h2>
+                      <p className="mt-1 text-sm leading-6 text-slate-600">
+                        {formatExpertType(proposal.expert.expertType)} in {proposal.expert.city}, {proposal.expert.state}
+                      </p>
+                      <p className="mt-2 text-sm font-medium text-slate-900">{proposal.request.title}</p>
+                    </div>
+
+                    <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
+                      <Link
+                        href={`/dashboard/customer/requests/view?id=${encodeURIComponent(proposal.request.id)}`}
+                        className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
+                      >
+                        Open request
+                      </Link>
+                      <Link
+                        href={`/experts/${proposal.expert.slug}`}
+                        className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                      >
+                        Expert profile
+                      </Link>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 grid gap-4 md:grid-cols-[minmax(0,1fr)_280px]">
+                    <div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Provider note</div>
+                      <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{proposal.message}</p>
+                    </div>
+
+                    <div className="grid gap-4">
+                      <div className="rounded-2xl bg-slate-50 p-4">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Estimate</div>
+                        <dl className="mt-3 space-y-3 text-sm">
+                          <div>
+                            <dt className="text-slate-500">Budget</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{proposal.priceLabel || 'Not specified'}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-slate-500">Timing</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{proposal.timelineLabel || 'Not specified'}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-slate-500">Received</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{formatShortDate(proposal.createdAt)}</dd>
+                          </div>
+                        </dl>
+                      </div>
+
+                      <ProposalDecisionActions proposalId={proposal.id} status={proposal.status} />
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </section>
+        ) : (
+          <section className="ml-card mt-5 rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">No proposals yet</p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">Your inbox will fill in once providers respond.</h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Create or keep an active request open so matched providers can send proposals.
+            </p>
+            <Link href="/dashboard/customer/requests/new" className="ml-btn-primary mt-5 inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white">
+              Create request
+            </Link>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { formatServiceTokenLabel, getMarketingSubjectById } from '@/lib/marketingTaxonomy';
+import ProposalDecisionActions from '../../proposals/ProposalDecisionActions';
 import RequestLifecycleActions from '../RequestLifecycleActions';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
@@ -174,6 +175,7 @@ export default async function CustomerRequestDetailPage({
   const subject = getMarketingSubjectById(request.marketingSubjectId);
   const preview = data.deliveryPreview;
   const proposals = data.proposals || [];
+  const pendingProposalCount = proposals.filter((proposal) => proposal.status === 'PENDING').length;
 
   return (
     <main className="ml-page-bg min-h-[calc(100vh-72px)]">
@@ -280,12 +282,19 @@ export default async function CustomerRequestDetailPage({
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Provider proposals</p>
               <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
-                {proposals.length ? `${proposals.length} proposal${proposals.length === 1 ? '' : 's'} to review` : 'No proposals yet'}
+                {proposals.length
+                  ? pendingProposalCount
+                    ? `${pendingProposalCount} proposal${pendingProposalCount === 1 ? '' : 's'} needs your decision`
+                    : `${proposals.length} proposal${proposals.length === 1 ? '' : 's'} received`
+                  : 'No proposals yet'}
               </h2>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-                Review who responded, their note, estimated budget, and timing. Messaging and accept/decline actions will come in the next workflow step.
+                Review who responded, their note, estimated budget, and timing. Accept the proposal you want to move forward with, or decline ones that are not a fit.
               </p>
             </div>
+            <Link href="/dashboard/customer/proposals" className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900">
+              Proposal inbox
+            </Link>
           </div>
 
           {proposals.length ? (
@@ -325,22 +334,26 @@ export default async function CustomerRequestDetailPage({
                       <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{proposal.message}</p>
                     </div>
 
-                    <div className="rounded-2xl bg-slate-50 p-4">
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Estimate</div>
-                      <dl className="mt-3 space-y-3 text-sm">
-                        <div>
-                          <dt className="text-slate-500">Budget</dt>
-                          <dd className="mt-1 font-semibold text-slate-950">{proposal.priceLabel || 'Not specified'}</dd>
-                        </div>
-                        <div>
-                          <dt className="text-slate-500">Timing</dt>
-                          <dd className="mt-1 font-semibold text-slate-950">{proposal.timelineLabel || 'Not specified'}</dd>
-                        </div>
-                        <div>
-                          <dt className="text-slate-500">Received</dt>
-                          <dd className="mt-1 font-semibold text-slate-950">{formatShortDate(proposal.createdAt)}</dd>
-                        </div>
-                      </dl>
+                    <div className="grid gap-4">
+                      <div className="rounded-2xl bg-slate-50 p-4">
+                        <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Estimate</div>
+                        <dl className="mt-3 space-y-3 text-sm">
+                          <div>
+                            <dt className="text-slate-500">Budget</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{proposal.priceLabel || 'Not specified'}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-slate-500">Timing</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{proposal.timelineLabel || 'Not specified'}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-slate-500">Received</dt>
+                            <dd className="mt-1 font-semibold text-slate-950">{formatShortDate(proposal.createdAt)}</dd>
+                          </div>
+                        </dl>
+                      </div>
+
+                      <ProposalDecisionActions proposalId={proposal.id} status={proposal.status} />
                     </div>
                   </div>
                 </article>


### PR DESCRIPTION
﻿## Summary
- Add a customer proposal inbox across all owned requests.
- Add customer-only proposal accept and decline endpoints with server-side ownership checks.
- Add accept/decline controls to the inbox and existing request detail proposal cards.
- When a proposal is accepted, automatically decline other pending proposals for the same request.
- Link the live proposal workflow from the customer dashboard.

## User impact
Customers can compare incoming provider proposals, open the related request or expert profile, and make a clear proposal decision without leaving their private dashboard.

## Validation
- `node --test tests/requests.test.js` (19 passing)
- `node_modules\.bin\tsc.cmd --noEmit -p tsconfig.json`
- `npm exec eslint src/app/dashboard/customer/proposals/page.tsx src/app/dashboard/customer/proposals/ProposalDecisionActions.tsx src/app/dashboard/customer/requests/view/page.tsx src/app/dashboard/customer/page.tsx`
- `npm run build` in `marketlink-backend`
- `npm run build` in `marketlink-frontend`
- Browser verified the proposal inbox, accept action, pending count update, and accepted state on the request detail page
