### PR TITLE
MM-62: Wire proposal state into request dashboards

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -319,11 +319,26 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         status: true,
         createdAt: true,
         updatedAt: true,
+        proposals: {
+          select: {
+            status: true,
+          },
+        },
       },
       take: 100,
     });
 
-    return reply.send({ ok: true, data: rows });
+    const data = rows.map(({ proposals, ...request }) => ({
+      ...request,
+      proposalSummary: {
+        total: proposals.length,
+        pending: proposals.filter((proposal) => proposal.status === ProposalStatus.PENDING).length,
+        accepted: proposals.filter((proposal) => proposal.status === ProposalStatus.ACCEPTED).length,
+        declined: proposals.filter((proposal) => proposal.status === ProposalStatus.DECLINED).length,
+      },
+    }));
+
+    return reply.send({ ok: true, data });
   });
 
   fastify.get('/requests/:id', async (req, reply) => {
@@ -629,7 +644,29 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       });
     }
 
-    return reply.send({ ok: true, data: matches });
+    const proposals = matches.length
+      ? await prisma.proposal.findMany({
+          where: {
+            expertId: expert.id,
+            requestId: {
+              in: matches.map((request) => request.id),
+            },
+          },
+          select: {
+            requestId: true,
+            status: true,
+          },
+        })
+      : [];
+    const proposalStatusByRequestId = new Map(proposals.map((proposal) => [proposal.requestId, proposal.status]));
+
+    return reply.send({
+      ok: true,
+      data: matches.map((request) => ({
+        ...request,
+        proposalStatus: proposalStatusByRequestId.get(request.id) || null,
+      })),
+    });
   });
 
   fastify.get('/provider/requests/:id', async (req, reply) => {

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -228,9 +228,6 @@ test('GET /requests lists only the signed-in customer requests', async () => {
 
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
-  const originalExpert = prismaModule.prisma.expert;
-  const originalProposal = prismaModule.prisma.proposal;
-  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
     id: 'customer_user_3',
@@ -251,6 +248,10 @@ test('GET /requests lists only the signed-in customer requests', async () => {
           status: 'ACTIVE',
           createdAt: new Date('2026-05-24T15:00:00.000Z'),
           updatedAt: new Date('2026-05-24T15:00:00.000Z'),
+          proposals: [
+            { status: 'PENDING' },
+            { status: 'DECLINED' },
+          ],
         },
       ];
     },
@@ -267,6 +268,12 @@ test('GET /requests lists only the signed-in customer requests', async () => {
     assert.equal(body.ok, true);
     assert.equal(body.data.length, 1);
     assert.equal(body.data[0].id, 'request_2');
+    assert.deepEqual(body.data[0].proposalSummary, {
+      total: 2,
+      pending: 1,
+      accepted: 0,
+      declined: 1,
+    });
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
@@ -685,6 +692,7 @@ test('GET /provider/requests lists active matched requests for the signed-in pro
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalExpert = prismaModule.prisma.expert;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalProposal = prismaModule.prisma.proposal;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -752,6 +760,18 @@ test('GET /provider/requests lists active matched requests for the signed-in pro
       ];
     },
   };
+  prismaModule.prisma.proposal = {
+    findMany: async ({ where }) => {
+      assert.equal(where.expertId, 'expert_provider_1');
+      assert.deepEqual(where.requestId.in, ['request_provider_match_1']);
+      return [
+        {
+          requestId: 'request_provider_match_1',
+          status: 'PENDING',
+        },
+      ];
+    },
+  };
 
   geocodingModule.lookupZipLocation = async ({ zip }) => {
     if (zip === '60559') {
@@ -791,10 +811,12 @@ test('GET /provider/requests lists active matched requests for the signed-in pro
     assert.equal(body.data.length, 1);
     assert.equal(body.data[0].id, 'request_provider_match_1');
     assert.equal(body.data[0].primaryReason, 'same_zip');
+    assert.equal(body.data[0].proposalStatus, 'PENDING');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.expert = originalExpert;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.proposal = originalProposal;
     geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }
@@ -1375,6 +1397,7 @@ test('GET /provider/requests excludes closed and cancelled requests', async () =
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalExpert = prismaModule.prisma.expert;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalProposal = prismaModule.prisma.proposal;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -1424,6 +1447,9 @@ test('GET /provider/requests excludes closed and cancelled requests', async () =
       ];
     },
   };
+  prismaModule.prisma.proposal = {
+    findMany: async () => [],
+  };
 
   geocodingModule.lookupZipLocation = async () => ({
     ok: true,
@@ -1450,6 +1476,7 @@ test('GET /provider/requests excludes closed and cancelled requests', async () =
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.expert = originalExpert;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.proposal = originalProposal;
     geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }

--- a/marketlink-frontend/src/app/dashboard/customer/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/page.tsx
@@ -9,6 +9,14 @@ type SummaryResponse = {
   customer?: { name?: string | null; businessName?: string | null } | null;
 };
 
+type CustomerRequestSummary = {
+  status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+};
+
+type CustomerProposalSummary = {
+  status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+};
+
 function DashboardRailCard({
   eyebrow,
   title,
@@ -91,6 +99,24 @@ export default async function CustomerDashboardPage() {
     redirect('/dashboard/customer/onboarding');
   }
 
+  const [requestsRes, proposalsRes] = await Promise.all([
+    fetch(`${API_BASE}/requests`, {
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+      cache: 'no-store',
+    }),
+    fetch(`${API_BASE}/proposals`, {
+      headers: cookieHeader ? { cookie: cookieHeader } : {},
+      cache: 'no-store',
+    }),
+  ]);
+
+  const requestsData = requestsRes.ok ? ((await requestsRes.json()) as { data?: CustomerRequestSummary[] }) : {};
+  const proposalsData = proposalsRes.ok ? ((await proposalsRes.json()) as { data?: CustomerProposalSummary[] }) : {};
+  const requests = requestsData.data || [];
+  const proposals = proposalsData.data || [];
+  const activeRequestCount = requests.filter((request) => request.status === 'ACTIVE').length;
+  const pendingProposalCount = proposals.filter((proposal) => proposal.status === 'PENDING').length;
+
   return (
     <main className="ml-page-bg min-h-[calc(100vh-72px)]">
       <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
@@ -167,15 +193,23 @@ export default async function CustomerDashboardPage() {
         <section className="mt-5 grid gap-4 md:grid-cols-3">
           <FutureStateCard
             title="Requests"
-            body="Create requests privately, revisit your history, and review the matching preview from one place."
+            body={
+              activeRequestCount
+                ? `${activeRequestCount} active request${activeRequestCount === 1 ? '' : 's'}. Open history to review status and incoming proposals.`
+                : 'Create requests privately, revisit your history, and review the matching preview from one place.'
+            }
             href="/dashboard/customer/requests"
-            eyebrow="Live"
+            eyebrow={activeRequestCount ? `${activeRequestCount} active` : 'Live'}
           />
           <FutureStateCard
             title="Proposals"
-            body="Compare provider responses, review estimates, and accept or decline proposals."
+            body={
+              pendingProposalCount
+                ? `${pendingProposalCount} proposal${pendingProposalCount === 1 ? '' : 's'} waiting for your decision.`
+                : 'Compare provider responses, review estimates, and accept or decline proposals.'
+            }
             href="/dashboard/customer/proposals"
-            eyebrow="Live"
+            eyebrow={pendingProposalCount ? `${pendingProposalCount} needs action` : 'Live'}
           />
           <FutureStateCard
             title="Shortlist"

--- a/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
@@ -19,6 +19,12 @@ type RequestHistoryItem = {
   status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
   createdAt: string;
   updatedAt: string;
+  proposalSummary: {
+    total: number;
+    pending: number;
+    accepted: number;
+    declined: number;
+  };
 };
 
 type RequestsResponse = {
@@ -136,6 +142,19 @@ export default async function CustomerRequestsPage() {
                         <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
                           {subject?.label || request.marketingSubjectId}
                         </span>
+                        {request.proposalSummary.pending > 0 ? (
+                          <span className="inline-flex rounded-xl bg-amber-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700 ring-1 ring-amber-200">
+                            {request.proposalSummary.pending} needs decision
+                          </span>
+                        ) : request.proposalSummary.accepted > 0 ? (
+                          <span className="inline-flex rounded-xl bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 ring-1 ring-emerald-200">
+                            Proposal accepted
+                          </span>
+                        ) : request.proposalSummary.total > 0 ? (
+                          <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                            {request.proposalSummary.total} proposal{request.proposalSummary.total === 1 ? '' : 's'}
+                          </span>
+                        ) : null}
                       </div>
                       <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{request.title}</h2>
                       <p className="mt-2 text-sm text-slate-600">
@@ -143,7 +162,9 @@ export default async function CustomerRequestsPage() {
                       </p>
                     </div>
 
-                    <span className="text-sm font-semibold text-slate-900">Open</span>
+                    <span className="text-sm font-semibold text-slate-900">
+                      {request.proposalSummary.pending > 0 ? 'Review proposals' : 'Open'}
+                    </span>
                   </div>
 
                   <div className="mt-4 flex flex-wrap gap-2">

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -33,6 +33,7 @@ type ProviderRequestRow = {
   id: string;
   status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
   createdAt: string;
+  proposalStatus?: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN' | null;
 };
 
 function formatExpertTypeLabel(expertType: ExpertSummary['expertType']) {
@@ -69,6 +70,9 @@ const [user, setUser] = useState<User | null>(null);
   const [inquiryCount, setInquiryCount] = useState<number | null>(null);
   const [newInquiryCount, setNewInquiryCount] = useState<number | null>(null);
   const [matchedRequestCount, setMatchedRequestCount] = useState<number | null>(null);
+  const [needsProposalCount, setNeedsProposalCount] = useState<number | null>(null);
+  const [pendingProposalCount, setPendingProposalCount] = useState<number | null>(null);
+  const [acceptedProposalCount, setAcceptedProposalCount] = useState<number | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -136,6 +140,9 @@ const [user, setUser] = useState<User | null>(null);
           const body = (await requestsRes.json()) as { ok?: true; data?: ProviderRequestRow[] };
           const rows = Array.isArray(body?.data) ? body.data : [];
           setMatchedRequestCount(rows.filter((r) => r.status === 'ACTIVE').length);
+          setNeedsProposalCount(rows.filter((r) => !r.proposalStatus).length);
+          setPendingProposalCount(rows.filter((r) => r.proposalStatus === 'PENDING').length);
+          setAcceptedProposalCount(rows.filter((r) => r.proposalStatus === 'ACCEPTED').length);
         }
       } catch {
         // ignore dashboard sidebar count failures
@@ -239,9 +246,15 @@ const [user, setUser] = useState<User | null>(null);
                 <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Matched requests</div>
                 <div className="mt-2 text-base font-semibold text-slate-900">{matchedRequestCount === null ? '—' : matchedRequestCount}</div>
               </div>
+              <div className={mutedCardClass}>
+                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Needs proposal</div>
+                <div className="mt-2 text-base font-semibold text-slate-900">{needsProposalCount === null ? '—' : needsProposalCount}</div>
+              </div>
               <div className={`${mutedCardClass} col-span-2 sm:col-span-1`}>
-                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">New inquiries</div>
-                <div className="mt-2 text-base font-semibold text-slate-900">{newInquiryCount === null ? '—' : newInquiryCount}</div>
+                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Proposal decisions</div>
+                <div className="mt-2 text-sm font-semibold text-slate-900">
+                  {pendingProposalCount === null || acceptedProposalCount === null ? '—' : `${pendingProposalCount} pending • ${acceptedProposalCount} accepted`}
+                </div>
               </div>
             </div>
           </div>
@@ -300,7 +313,11 @@ const [user, setUser] = useState<User | null>(null);
                     </Link>
                     <Link href="/dashboard/requests" className={secondaryLinkClass}>
                       Matched requests
-                      {matchedRequestCount !== null && matchedRequestCount > 0 ? <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{matchedRequestCount} active</span> : null}
+                      {needsProposalCount !== null && needsProposalCount > 0 ? (
+                        <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{needsProposalCount} needs proposal</span>
+                      ) : matchedRequestCount !== null && matchedRequestCount > 0 ? (
+                        <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{matchedRequestCount} active</span>
+                      ) : null}
                     </Link>
                     <Link href="/dashboard/inquiries" className={secondaryLinkClass}>
                       Inquiries

--- a/marketlink-frontend/src/app/dashboard/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/page.tsx
@@ -9,6 +9,7 @@ import { useMarketLinkTheme } from '@/components/ThemeToggle';
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
 type ProviderRequestStatus = 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+type ProposalStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
 type MatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
 
 type ProviderRequestRow = {
@@ -24,6 +25,7 @@ type ProviderRequestRow = {
   primaryReason: MatchReason;
   reasons: MatchReason[];
   matchedServiceTokens: string[];
+  proposalStatus?: ProposalStatus | null;
 };
 
 type ProviderRequestsResponse = {
@@ -49,6 +51,13 @@ function formatStatus(status: ProviderRequestStatus) {
   if (status === 'ACTIVE') return 'Active';
   if (status === 'CLOSED') return 'Closed';
   return 'Cancelled';
+}
+
+function formatProposalStatus(status: ProposalStatus) {
+  if (status === 'PENDING') return 'Proposal pending';
+  if (status === 'ACCEPTED') return 'Proposal accepted';
+  if (status === 'DECLINED') return 'Proposal declined';
+  return 'Proposal withdrawn';
 }
 
 function formatShortDate(value: string) {
@@ -122,6 +131,9 @@ export default function ProviderRequestsPage() {
   }, [router]);
 
   const activeCount = useMemo(() => rows.filter((row) => row.status === 'ACTIVE').length, [rows]);
+  const needsProposalCount = useMemo(() => rows.filter((row) => !row.proposalStatus).length, [rows]);
+  const pendingProposalCount = useMemo(() => rows.filter((row) => row.proposalStatus === 'PENDING').length, [rows]);
+  const acceptedProposalCount = useMemo(() => rows.filter((row) => row.proposalStatus === 'ACCEPTED').length, [rows]);
 
   const shellClass =
     'rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(247,244,239,0.96))] p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] sm:p-6';
@@ -149,12 +161,20 @@ export default function ProviderRequestsPage() {
             <div className={mutedCardClass}>
               <div className="grid grid-cols-2 gap-3">
                 <div className="rounded-2xl bg-slate-900 px-4 py-3 text-white shadow-[0_18px_34px_rgba(15,23,42,0.18)]">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">Active</div>
-                  <div className="mt-2 text-lg font-semibold">{activeCount}</div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">Needs proposal</div>
+                  <div className="mt-2 text-lg font-semibold">{needsProposalCount}</div>
                 </div>
                 <div className="rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3">
-                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">Total</div>
-                  <div className="mt-2 text-lg font-semibold text-slate-950">{rows.length}</div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">Pending</div>
+                  <div className="mt-2 text-lg font-semibold text-slate-950">{pendingProposalCount}</div>
+                </div>
+                <div className="rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">Accepted</div>
+                  <div className="mt-2 text-lg font-semibold text-slate-950">{acceptedProposalCount}</div>
+                </div>
+                <div className="rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3">
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">Active matches</div>
+                  <div className="mt-2 text-lg font-semibold text-slate-950">{activeCount}</div>
                 </div>
               </div>
             </div>
@@ -205,6 +225,15 @@ export default function ProviderRequestsPage() {
                           <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-medium text-slate-700">
                             {formatReason(row.primaryReason)}
                           </span>
+                          {row.proposalStatus ? (
+                            <span className="rounded-full border border-slate-200/80 bg-white px-3 py-1 text-xs font-semibold text-slate-700">
+                              {formatProposalStatus(row.proposalStatus)}
+                            </span>
+                          ) : (
+                            <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700">
+                              Needs proposal
+                            </span>
+                          )}
                           <span className={`text-xs ${t.mutedText}`}>Created {formatShortDate(row.createdAt)}</span>
                         </div>
 
@@ -214,7 +243,7 @@ export default function ProviderRequestsPage() {
                         </p>
                       </div>
 
-                      <span className="text-sm font-semibold text-slate-900">Open</span>
+                      <span className="text-sm font-semibold text-slate-900">{row.proposalStatus ? 'View proposal' : 'Review and respond'}</span>
                     </div>
 
                     <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

- add proposal status summaries to customer request list responses
- add the signed-in provider's proposal status to matched request responses
- show requests and proposals needing action across customer and provider dashboards
- add proposal-state labels and actions to both request history views
- extend request route tests for customer proposal counts and provider proposal status

## Why

Customers and providers need to see which requests still require a proposal or proposal decision without opening every request individually.

## User impact

- customers can see active request and pending proposal-decision counts from their dashboard
- customer request history identifies requests with proposals awaiting review
- providers can distinguish requests needing a proposal from pending or accepted proposals
- provider dashboard counters summarize the current proposal workflow

## Validation

- `node --test tests/requests.test.js` (19 passed)
- backend TypeScript check
- backend production build
- targeted frontend ESLint
- frontend production build
- `git diff --check`
- live customer dashboard and request-history verification