### PR TITLE
MM-64: Add messaging schema foundation

### DIFF
--- a/marketlink-backend/prisma/migrations/20260618010741_add_messaging_models/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260618010741_add_messaging_models/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" TEXT NOT NULL,
+    "proposalId" TEXT NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "customerUserId" TEXT NOT NULL,
+    "expertId" TEXT NOT NULL,
+    "lastMessageAt" TIMESTAMP(3),
+    "customerLastReadAt" TIMESTAMP(3),
+    "expertLastReadAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderUserId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Conversation_proposalId_key" ON "Conversation"("proposalId");
+
+-- CreateIndex
+CREATE INDEX "Conversation_customerUserId_updatedAt_idx" ON "Conversation"("customerUserId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Conversation_expertId_updatedAt_idx" ON "Conversation"("expertId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Conversation_requestId_updatedAt_idx" ON "Conversation"("requestId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Message_conversationId_createdAt_idx" ON "Message"("conversationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Message_senderUserId_createdAt_idx" ON "Message"("senderUserId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_proposalId_fkey" FOREIGN KEY ("proposalId") REFERENCES "Proposal"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_requestId_fkey" FOREIGN KEY ("requestId") REFERENCES "CustomerRequest"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_customerUserId_fkey" FOREIGN KEY ("customerUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Conversation" ADD CONSTRAINT "Conversation_expertId_fkey" FOREIGN KEY ("expertId") REFERENCES "Expert"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderUserId_fkey" FOREIGN KEY ("senderUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -19,7 +19,9 @@ model User {
   adminActions       AdminAction[]
   customerProfile    CustomerProfile?
   customerRequests   CustomerRequest[]
+  customerConversations Conversation[]     @relation("CustomerConversations")
   experts            Expert[]
+  sentMessages       Message[]             @relation("MessageSender")
   sessions           Session[]
 }
 
@@ -87,6 +89,7 @@ model Expert {
   status              ExpertStatus          @default(active)
   adminActions        AdminAction[]
   owner               User?                 @relation(fields: [userId], references: [id])
+  conversations       Conversation[]
   proposals           Proposal[]
   projects            ExpertProject[]
   clients             ExpertClient[]
@@ -216,6 +219,7 @@ model CustomerRequest {
   updatedAt             DateTime              @updatedAt
   customerUser          User                  @relation(fields: [customerUserId], references: [id], onDelete: Cascade)
   customerProfile       CustomerProfile?      @relation(fields: [customerProfileId], references: [id], onDelete: SetNull)
+  conversations         Conversation[]
   proposals             Proposal[]
 
   @@index([customerUserId, createdAt])
@@ -236,10 +240,46 @@ model Proposal {
   updatedAt     DateTime        @updatedAt
   request       CustomerRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
   expert        Expert          @relation(fields: [expertId], references: [id], onDelete: Cascade)
+  conversation  Conversation?
 
   @@unique([requestId, expertId])
   @@index([requestId, status, createdAt])
   @@index([expertId, status, createdAt])
+}
+
+model Conversation {
+  id                 String          @id @default(cuid())
+  proposalId         String          @unique
+  requestId          String
+  customerUserId     String
+  expertId           String
+  lastMessageAt      DateTime?
+  customerLastReadAt DateTime?
+  expertLastReadAt   DateTime?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  proposal           Proposal        @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+  request            CustomerRequest @relation(fields: [requestId], references: [id], onDelete: Cascade)
+  customerUser       User            @relation("CustomerConversations", fields: [customerUserId], references: [id], onDelete: Cascade)
+  expert             Expert          @relation(fields: [expertId], references: [id], onDelete: Cascade)
+  messages           Message[]
+
+  @@index([customerUserId, updatedAt])
+  @@index([expertId, updatedAt])
+  @@index([requestId, updatedAt])
+}
+
+model Message {
+  id             String       @id @default(cuid())
+  conversationId String
+  senderUserId   String
+  body           String
+  createdAt      DateTime     @default(now())
+  conversation   Conversation @relation(fields: [conversationId], references: [id], onDelete: Cascade)
+  senderUser     User         @relation("MessageSender", fields: [senderUserId], references: [id], onDelete: Cascade)
+
+  @@index([conversationId, createdAt])
+  @@index([senderUserId, createdAt])
 }
 
 ///

--- a/marketlink-backend/tests/messaging.schema.test.js
+++ b/marketlink-backend/tests/messaging.schema.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const schemaPath = path.join(__dirname, '..', 'prisma', 'schema.prisma');
+
+function readSchema() {
+  return fs.readFileSync(schemaPath, 'utf8');
+}
+
+test('messaging schema models accepted-proposal conversations and message history', () => {
+  const schema = readSchema();
+
+  assert.match(schema, /model Conversation \{/);
+  assert.match(schema, /proposalId\s+String\s+@unique/);
+  assert.match(schema, /requestId\s+String/);
+  assert.match(schema, /customerUserId\s+String/);
+  assert.match(schema, /expertId\s+String/);
+  assert.match(schema, /customerLastReadAt\s+DateTime\?/);
+  assert.match(schema, /expertLastReadAt\s+DateTime\?/);
+  assert.match(schema, /messages\s+Message\[\]/);
+  assert.match(schema, /@@index\(\[customerUserId, updatedAt\]\)/);
+  assert.match(schema, /@@index\(\[expertId, updatedAt\]\)/);
+
+  assert.match(schema, /model Message \{/);
+  assert.match(schema, /conversationId\s+String/);
+  assert.match(schema, /senderUserId\s+String/);
+  assert.match(schema, /body\s+String/);
+  assert.match(schema, /@@index\(\[conversationId, createdAt\]\)/);
+  assert.match(schema, /@@index\(\[senderUserId, createdAt\]\)/);
+});


### PR DESCRIPTION
## Summary

- add `Conversation` and `Message` Prisma models for private messaging
- tie each conversation one-to-one to a proposal, plus its request, customer user, and expert
- add message history with sender ownership
- add read-state placeholders for later unread behavior
- add the Prisma migration and a schema contract test

## Why

MM-64 is the database foundation for the Private Messaging epic. The later tickets can now create a conversation when a proposal is accepted, expose message APIs, and build customer/expert inboxes without changing the core data model again.

## Migration note

Migration `20260618010741_add_messaging_models` was generated and applied to the Neon dev database with `npx prisma migrate dev`. No API routes or frontend UI are included in this PR.

## Validation

- `node --test tests/messaging.schema.test.js tests/requests.test.js` (20 passed)
- `npx prisma validate`
- `npx prisma migrate status` (database schema is up to date)
- backend TypeScript check
- `npm run build`
- `git diff --check`