### PR TITLE
MM-65: Create conversations on proposal acceptance

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -485,6 +485,11 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       select: {
         id: true,
         requestId: true,
+        request: {
+          select: {
+            customerUserId: true,
+          },
+        },
         status: true,
       },
     });
@@ -495,37 +500,61 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       return reply.code(409).send({ ok: false, error: `This proposal cannot move from ${existing.status} to ${nextStatus}.` });
     }
 
-    const updated = await prisma.proposal.update({
-      where: { id },
-      data: { status: nextStatus },
-      select: {
-        id: true,
-        requestId: true,
-        expertId: true,
-        message: true,
-        priceLabel: true,
-        timelineLabel: true,
-        status: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+    const { updated, conversation } = await prisma.$transaction(async (tx) => {
+      const updated = await tx.proposal.update({
+        where: { id },
+        data: { status: nextStatus },
+        select: {
+          id: true,
+          requestId: true,
+          expertId: true,
+          message: true,
+          priceLabel: true,
+          timelineLabel: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
 
-    if (nextStatus === ProposalStatus.ACCEPTED) {
-      await prisma.proposal.updateMany({
+      if (nextStatus !== ProposalStatus.ACCEPTED) {
+        return { updated, conversation: null };
+      }
+
+      await tx.proposal.updateMany({
         where: {
           requestId: existing.requestId,
           id: { not: updated.id },
           status: ProposalStatus.PENDING,
         },
-        data: {
-          status: ProposalStatus.DECLINED,
+        data: { status: ProposalStatus.DECLINED },
+      });
+
+      const conversation = await tx.conversation.upsert({
+        where: { proposalId: updated.id },
+        update: {},
+        create: {
+          proposalId: updated.id,
+          requestId: updated.requestId,
+          customerUserId: existing.request.customerUserId,
+          expertId: updated.expertId,
+        },
+        select: {
+          id: true,
+          proposalId: true,
+          requestId: true,
+          customerUserId: true,
+          expertId: true,
+          createdAt: true,
+          updatedAt: true,
         },
       });
-    }
+
+      return { updated, conversation };
+    });
 
     req.log.info({ proposalId: updated.id, requestId: updated.requestId, status: updated.status, customerUserId: user.id }, 'proposal.updated');
-    return reply.send({ ok: true, proposal: updated });
+    return reply.send({ ok: true, proposal: updated, conversation });
   });
 
   fastify.patch('/requests/:id', async (req, reply) => {

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -583,7 +583,10 @@ test('PATCH /proposals/:id lets a customer accept their pending proposal', async
 
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalProposal = prismaModule.prisma.proposal;
+  const originalConversation = prismaModule.prisma.conversation;
+  const originalTransaction = prismaModule.prisma.$transaction;
   let declinedOtherPendingProposals = false;
+  let createdConversation = false;
 
   sessionModule.getUserFromRequest = async () => ({
     id: 'customer_user_proposal_accept',
@@ -598,6 +601,9 @@ test('PATCH /proposals/:id lets a customer accept their pending proposal', async
       return {
         id: 'proposal_accept_1',
         requestId: 'request_accept_1',
+        request: {
+          customerUserId: 'customer_user_proposal_accept',
+        },
         status: 'PENDING',
       };
     },
@@ -626,6 +632,38 @@ test('PATCH /proposals/:id lets a customer accept their pending proposal', async
     },
   };
 
+  prismaModule.prisma.conversation = {
+    upsert: async ({ where, create, update, select }) => {
+      createdConversation = true;
+      assert.deepEqual(where, { proposalId: 'proposal_accept_1' });
+      assert.deepEqual(update, {});
+      assert.equal(create.proposalId, 'proposal_accept_1');
+      assert.equal(create.requestId, 'request_accept_1');
+      assert.equal(create.customerUserId, 'customer_user_proposal_accept');
+      assert.equal(create.expertId, 'expert_accept_1');
+      assert.deepEqual(select, {
+        id: true,
+        proposalId: true,
+        requestId: true,
+        customerUserId: true,
+        expertId: true,
+        createdAt: true,
+        updatedAt: true,
+      });
+      return {
+        id: 'conversation_accept_1',
+        proposalId: 'proposal_accept_1',
+        requestId: 'request_accept_1',
+        customerUserId: 'customer_user_proposal_accept',
+        expertId: 'expert_accept_1',
+        createdAt: new Date('2026-06-06T15:05:00.000Z'),
+        updatedAt: new Date('2026-06-06T15:05:00.000Z'),
+      };
+    },
+  };
+
+  prismaModule.prisma.$transaction = async (callback) => callback(prismaModule.prisma);
+
   try {
     const response = await fastify.inject({
       method: 'PATCH',
@@ -640,10 +678,15 @@ test('PATCH /proposals/:id lets a customer accept their pending proposal', async
     assert.equal(body.ok, true);
     assert.equal(body.proposal.id, 'proposal_accept_1');
     assert.equal(body.proposal.status, 'ACCEPTED');
+    assert.equal(body.conversation.id, 'conversation_accept_1');
+    assert.equal(body.conversation.proposalId, 'proposal_accept_1');
+    assert.equal(createdConversation, true);
     assert.equal(declinedOtherPendingProposals, true);
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.proposal = originalProposal;
+    prismaModule.prisma.conversation = originalConversation;
+    prismaModule.prisma.$transaction = originalTransaction;
     await fastify.close();
   }
 });


### PR DESCRIPTION
## Summary

- create the accepted-proposal handoff inside the customer proposal decision route
- update proposal acceptance to run in a transaction
- decline competing pending proposals for the same request in the same transaction
- upsert exactly one conversation by `proposalId` for the accepted buyer and expert
- return the created or existing conversation in the acceptance response
- extend request route tests to cover the conversation handoff

## Why

MM-65 needs proposal acceptance to open private messaging in a safe, idempotent way. This PR connects the proposal decision flow to the messaging schema foundation without exposing message APIs yet.

## User impact

When a customer accepts a proposal, the backend now guarantees one conversation exists for that accepted proposal. Later messaging tickets can rely on this conversation instead of recreating the handoff logic.

## Validation

- `node --test tests/messaging.schema.test.js tests/requests.test.js` (20 passed)
- backend TypeScript check
- `npx prisma validate`
- `npx prisma migrate status` (database schema is up to date)
- `npm run build`
- `git diff --check`