### PR TITLE
MM-66 Add live chat messaging APIs

### DIFF
--- a/marketlink-backend/package-lock.json
+++ b/marketlink-backend/package-lock.json
@@ -12,12 +12,16 @@
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^11.1.0",
         "@fastify/rate-limit": "^10.3.0",
+        "@fastify/websocket": "^11.2.0",
         "@prisma/client": "^6.17.0",
+        "bcryptjs": "^3.0.3",
         "fastify": "^5.0.0",
         "prisma": "^6.17.0"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^22.0.0",
+        "@types/ws": "^8.18.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.0"
@@ -208,6 +212,27 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/@fastify/websocket": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.2.0.tgz",
+      "integrity": "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^5.0.0",
+        "ws": "^8.16.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -358,6 +383,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.18.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
@@ -381,6 +413,16 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -493,6 +535,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -718,6 +769,18 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
@@ -745,6 +808,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/exsolve": {
@@ -1034,7 +1106,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1276,7 +1347,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1445,6 +1515,20 @@
         "destr": "^2.0.3"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1535,6 +1619,26 @@
       "bin": {
         "rimraf": "bin.js"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-regex2": {
       "version": "5.0.0",
@@ -1641,6 +1745,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-bom": {
@@ -1836,6 +1955,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -1847,8 +1972,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/marketlink-backend/package.json
+++ b/marketlink-backend/package.json
@@ -14,6 +14,7 @@
     "@fastify/cookie": "^11.0.2",
     "@fastify/cors": "^11.1.0",
     "@fastify/rate-limit": "^10.3.0",
+    "@fastify/websocket": "^11.2.0",
     "@prisma/client": "^6.17.0",
     "bcryptjs": "^3.0.3",
     "fastify": "^5.0.0",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^22.0.0",
+    "@types/ws": "^8.18.1",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.0"

--- a/marketlink-backend/src/lib/chatRealtime.ts
+++ b/marketlink-backend/src/lib/chatRealtime.ts
@@ -1,0 +1,39 @@
+type ConversationEvent = {
+  type: string;
+  conversationId: string;
+  [key: string]: unknown;
+};
+
+type ConversationSubscriber = {
+  send: (event: ConversationEvent) => void;
+};
+
+const subscriptions = new Map<string, Set<ConversationSubscriber>>();
+
+export function subscribeConversation(conversationId: string, subscriber: ConversationSubscriber) {
+  const current = subscriptions.get(conversationId) ?? new Set<ConversationSubscriber>();
+  current.add(subscriber);
+  subscriptions.set(conversationId, current);
+
+  return () => {
+    const active = subscriptions.get(conversationId);
+    if (!active) return;
+    active.delete(subscriber);
+    if (active.size === 0) subscriptions.delete(conversationId);
+  };
+}
+
+export function publishConversationEvent(conversationId: string, event: ConversationEvent) {
+  const active = subscriptions.get(conversationId);
+  if (!active) return;
+
+  for (const subscriber of active) {
+    try {
+      subscriber.send(event);
+    } catch {
+      active.delete(subscriber);
+    }
+  }
+
+  if (active.size === 0) subscriptions.delete(conversationId);
+}

--- a/marketlink-backend/src/routes/messaging.ts
+++ b/marketlink-backend/src/routes/messaging.ts
@@ -1,0 +1,296 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { User } from '@prisma/client';
+import type { WebSocket } from 'ws';
+import { prisma } from '../lib/prisma';
+import { publishConversationEvent, subscribeConversation } from '../lib/chatRealtime';
+import { getUserFromRequest } from '../lib/session';
+
+async function getExpertAccess(user: User) {
+  const expert = await prisma.expert.findFirst({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+
+  return expert ? { expertId: expert.id } : null;
+}
+
+async function getConversationAccess(user: User) {
+  if (user.role === 'customer') return { customerUserId: user.id };
+  if (user.role === 'provider') return getExpertAccess(user);
+  return null;
+}
+
+function asMessageBody(input: unknown) {
+  return String(input || '').trim();
+}
+
+function serializeMessage(message: {
+  id: string;
+  conversationId: string;
+  senderUserId: string;
+  body: string;
+  createdAt: Date;
+}) {
+  return {
+    ...message,
+    createdAt: message.createdAt.toISOString(),
+  };
+}
+
+const messagingRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get('/conversations', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer' && user.role !== 'provider') {
+      return reply.code(403).send({ error: 'Only customers and providers can view conversations.' });
+    }
+
+    const access = await getConversationAccess(user);
+    if (!access) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const rows = await prisma.conversation.findMany({
+      where: access,
+      orderBy: [{ lastMessageAt: 'desc' }, { updatedAt: 'desc' }],
+      select: {
+        id: true,
+        proposalId: true,
+        requestId: true,
+        customerUserId: true,
+        expertId: true,
+        lastMessageAt: true,
+        updatedAt: true,
+        request: {
+          select: {
+            id: true,
+            title: true,
+            marketingSubjectId: true,
+            customerProfile: {
+              select: {
+                name: true,
+                businessName: true,
+              },
+            },
+          },
+        },
+        proposal: {
+          select: {
+            id: true,
+            priceLabel: true,
+            timelineLabel: true,
+            status: true,
+          },
+        },
+        expert: {
+          select: {
+            id: true,
+            businessName: true,
+            slug: true,
+            logo: true,
+          },
+        },
+        messages: {
+          take: 1,
+          orderBy: { createdAt: 'desc' },
+          select: {
+            id: true,
+            body: true,
+            senderUserId: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    const data = rows.map(({ messages, ...conversation }) => ({
+      ...conversation,
+      latestMessage: messages[0] ?? null,
+    }));
+
+    return reply.send({ ok: true, data });
+  });
+
+  fastify.get('/conversations/:id', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer' && user.role !== 'provider') {
+      return reply.code(403).send({ error: 'Only customers and providers can view conversations.' });
+    }
+
+    const access = await getConversationAccess(user);
+    if (!access) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const { id } = (req.params || {}) as { id?: string };
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing conversation id' });
+
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id,
+        ...access,
+      },
+      select: {
+        id: true,
+        proposalId: true,
+        requestId: true,
+        customerUserId: true,
+        expertId: true,
+        lastMessageAt: true,
+        customerLastReadAt: true,
+        expertLastReadAt: true,
+        createdAt: true,
+        updatedAt: true,
+        request: {
+          select: {
+            id: true,
+            title: true,
+            marketingSubjectId: true,
+            customerProfile: {
+              select: {
+                name: true,
+                businessName: true,
+              },
+            },
+          },
+        },
+        proposal: {
+          select: {
+            id: true,
+            priceLabel: true,
+            timelineLabel: true,
+            status: true,
+          },
+        },
+        expert: {
+          select: {
+            id: true,
+            businessName: true,
+            slug: true,
+            logo: true,
+          },
+        },
+        messages: {
+          orderBy: { createdAt: 'asc' },
+          select: {
+            id: true,
+            conversationId: true,
+            senderUserId: true,
+            body: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!conversation) return reply.code(404).send({ error: 'Conversation not found' });
+    return reply.send({ ok: true, conversation });
+  });
+
+  fastify.post('/conversations/:id/messages', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer' && user.role !== 'provider') {
+      return reply.code(403).send({ error: 'Only customers and providers can send messages.' });
+    }
+
+    const access = await getConversationAccess(user);
+    if (!access) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const { id } = (req.params || {}) as { id?: string };
+    const body = req.body as { body?: string } | undefined;
+    const messageBody = asMessageBody(body?.body);
+
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing conversation id' });
+    if (!messageBody) return reply.code(400).send({ ok: false, error: 'body is required' });
+
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id,
+        ...access,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!conversation) return reply.code(404).send({ error: 'Conversation not found' });
+
+    const message = await prisma.message.create({
+      data: {
+        conversationId: conversation.id,
+        senderUserId: user.id,
+        body: messageBody,
+      },
+      select: {
+        id: true,
+        conversationId: true,
+        senderUserId: true,
+        body: true,
+        createdAt: true,
+      },
+    });
+
+    await prisma.conversation.update({
+      where: { id: conversation.id },
+      data: {
+        lastMessageAt: message.createdAt,
+      },
+    });
+
+    const responseMessage = serializeMessage(message);
+
+    const event = {
+      type: 'message.created',
+      conversationId: conversation.id,
+      message: responseMessage,
+    };
+
+    publishConversationEvent(conversation.id, event);
+    return reply.code(201).send({ ok: true, message: responseMessage });
+  });
+
+  fastify.get('/conversations/:id/live', { websocket: true }, async (socket: WebSocket, req) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user || (user.role !== 'customer' && user.role !== 'provider')) {
+      socket.close(4401, 'Not authenticated');
+      return;
+    }
+
+    const access = await getConversationAccess(user);
+    if (!access) {
+      socket.close(4403, 'Forbidden');
+      return;
+    }
+
+    const { id } = (req.params || {}) as { id?: string };
+    if (!id) {
+      socket.close(4400, 'Missing conversation id');
+      return;
+    }
+
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id,
+        ...access,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    if (!conversation) {
+      socket.close(4404, 'Conversation not found');
+      return;
+    }
+
+    const unsubscribe = subscribeConversation(conversation.id, {
+      send(event) {
+        socket.send(JSON.stringify(event));
+      },
+    });
+
+    socket.send(JSON.stringify({ type: 'connected', conversationId: conversation.id }));
+    socket.on('close', unsubscribe);
+    socket.on('error', unsubscribe);
+  });
+};
+
+export default messagingRoutes;

--- a/marketlink-backend/src/server.ts
+++ b/marketlink-backend/src/server.ts
@@ -4,11 +4,13 @@ import Fastify from 'fastify';
 import cors from '@fastify/cors';
 import cookie from '@fastify/cookie';
 import rateLimit from '@fastify/rate-limit';
+import websocket from '@fastify/websocket';
 import adminRoutes from './routes/admin';
 import authRoutes from './routes/auth';
 import accountRoutes from './routes/account';
 import expertsRoutes from './routes/providers';
 import inquiriesRoutes from './routes/inquiries';
+import messagingRoutes from './routes/messaging';
 import requestsRoutes from './routes/requests';
 
 function normalizeOrigin(raw: string) {
@@ -49,6 +51,7 @@ async function start() {
 
   // 👇 register rate-limit plugin, but don't enable globally
   await fastify.register(rateLimit, { global: false });
+  await fastify.register(websocket);
 
   fastify.get('/health', async () => ({
     ok: true,
@@ -60,6 +63,7 @@ async function start() {
   await fastify.register(accountRoutes);
   await fastify.register(expertsRoutes);
   await fastify.register(inquiriesRoutes);
+  await fastify.register(messagingRoutes);
   await fastify.register(requestsRoutes);
   await fastify.register(adminRoutes);
 

--- a/marketlink-backend/tests/messaging.test.js
+++ b/marketlink-backend/tests/messaging.test.js
@@ -1,0 +1,334 @@
+require('ts-node/register/transpile-only');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Fastify = require('fastify');
+const cookie = require('@fastify/cookie');
+const websocket = require('@fastify/websocket');
+
+const sessionModule = require('../src/lib/session');
+const prismaModule = require('../src/lib/prisma');
+const realtimeModule = require('../src/lib/chatRealtime');
+const messagingRoutes = require('../src/routes/messaging').default;
+
+function buildFastify() {
+  const fastify = Fastify();
+  return fastify
+    .register(cookie, { secret: 'test-secret' })
+    .then(() => fastify.register(websocket))
+    .then(() => fastify.register(messagingRoutes))
+    .then(() => fastify);
+}
+
+test('GET /conversations lists only the signed-in customer conversations', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.conversation = {
+    findMany: async ({ where }) => {
+      assert.equal(where.customerUserId, 'customer_user_1');
+      return [
+        {
+          id: 'conversation_1',
+          proposalId: 'proposal_1',
+          requestId: 'request_1',
+          customerUserId: 'customer_user_1',
+          expertId: 'expert_1',
+          lastMessageAt: new Date('2026-06-18T01:00:00.000Z'),
+          updatedAt: new Date('2026-06-18T01:00:00.000Z'),
+          request: {
+            id: 'request_1',
+            title: 'Need Google Ads help',
+            marketingSubjectId: 'paid-ads',
+          },
+          proposal: {
+            id: 'proposal_1',
+            priceLabel: '$3k-$5k',
+            timelineLabel: 'This month',
+            status: 'ACCEPTED',
+          },
+          customerProfile: {
+            name: 'Jamie Rivera',
+            businessName: 'Westmont Dental',
+          },
+          expert: {
+            id: 'expert_1',
+            businessName: 'Windy City Growth',
+            slug: 'windy-city-growth',
+            logo: null,
+          },
+          messages: [
+            {
+              id: 'message_1',
+              body: 'Happy to help.',
+              senderUserId: 'provider_user_1',
+              createdAt: new Date('2026-06-18T01:00:00.000Z'),
+            },
+          ],
+        },
+      ];
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/conversations',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.data.length, 1);
+    assert.equal(body.data[0].id, 'conversation_1');
+    assert.equal(body.data[0].request.title, 'Need Google Ads help');
+    assert.equal(body.data[0].expert.businessName, 'Windy City Growth');
+    assert.equal(body.data[0].latestMessage.id, 'message_1');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    await fastify.close();
+  }
+});
+
+test('GET /conversations lists only the signed-in expert conversations', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+  const originalExpert = prismaModule.prisma.expert;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.userId, 'provider_user_1');
+      return { id: 'expert_1' };
+    },
+  };
+
+  prismaModule.prisma.conversation = {
+    findMany: async ({ where }) => {
+      assert.equal(where.expertId, 'expert_1');
+      return [];
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/conversations',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.deepEqual(body.data, []);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    prismaModule.prisma.expert = originalExpert;
+    await fastify.close();
+  }
+});
+
+test('GET /conversations/:id rejects non-participants', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.conversation = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'conversation_missing');
+      assert.equal(where.customerUserId, 'customer_user_1');
+      return null;
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/conversations/conversation_missing',
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.equal(response.json().error, 'Conversation not found');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    await fastify.close();
+  }
+});
+
+test('POST /conversations/:id/messages creates a message and broadcasts it to the live thread', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+  const originalMessage = prismaModule.prisma.message;
+  const originalPublishConversationEvent = realtimeModule.publishConversationEvent;
+  let publishedEvent = null;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.conversation = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.equal(where.customerUserId, 'customer_user_1');
+      return {
+        id: 'conversation_1',
+        proposalId: 'proposal_1',
+        requestId: 'request_1',
+        customerUserId: 'customer_user_1',
+        expertId: 'expert_1',
+      };
+    },
+    update: async ({ where, data }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.ok(data.lastMessageAt instanceof Date);
+      return { id: 'conversation_1' };
+    },
+  };
+
+  prismaModule.prisma.message = {
+    create: async ({ data, select }) => {
+      assert.equal(data.conversationId, 'conversation_1');
+      assert.equal(data.senderUserId, 'customer_user_1');
+      assert.equal(data.body, 'Can we start next week?');
+      assert.deepEqual(select, {
+        id: true,
+        conversationId: true,
+        senderUserId: true,
+        body: true,
+        createdAt: true,
+      });
+      return {
+        id: 'message_1',
+        conversationId: 'conversation_1',
+        senderUserId: 'customer_user_1',
+        body: 'Can we start next week?',
+        createdAt: new Date('2026-06-18T02:00:00.000Z'),
+      };
+    },
+  };
+
+  realtimeModule.publishConversationEvent = (conversationId, event) => {
+    publishedEvent = { conversationId, event };
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/conversations/conversation_1/messages',
+      payload: {
+        body: 'Can we start next week?',
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.message.id, 'message_1');
+    assert.equal(body.message.body, 'Can we start next week?');
+    assert.deepEqual(publishedEvent, {
+      conversationId: 'conversation_1',
+      event: {
+        type: 'message.created',
+        conversationId: 'conversation_1',
+        message: body.message,
+      },
+    });
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    prismaModule.prisma.message = originalMessage;
+    realtimeModule.publishConversationEvent = originalPublishConversationEvent;
+    await fastify.close();
+  }
+});
+
+test('GET /conversations/:id/live streams conversation events to signed-in participants', async () => {
+  const fastify = await buildFastify();
+  await fastify.ready();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.conversation = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.equal(where.customerUserId, 'customer_user_1');
+      return { id: 'conversation_1' };
+    },
+  };
+
+  try {
+    const messages = [];
+    let socket;
+    const streamedEvent = {
+      type: 'message.created',
+      conversationId: 'conversation_1',
+      message: {
+        id: 'message_2',
+        conversationId: 'conversation_1',
+        senderUserId: 'provider_user_1',
+        body: 'Yes, that works for me.',
+        createdAt: '2026-06-18T03:00:00.000Z',
+      },
+    };
+
+    const received = new Promise((resolve) => {
+      const handleMessage = (payload) => {
+        messages.push(JSON.parse(payload.toString()));
+        if (messages.length === 2) resolve(messages);
+      };
+
+      fastify
+        .injectWS('/conversations/conversation_1/live', {}, { onInit: (socket) => socket.on('message', handleMessage) })
+        .then((connectedSocket) => {
+          socket = connectedSocket;
+          realtimeModule.publishConversationEvent('conversation_1', streamedEvent);
+        });
+    });
+
+    assert.deepEqual(await received, [
+      { type: 'connected', conversationId: 'conversation_1' },
+      streamedEvent,
+    ]);
+
+    socket.terminate();
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    await fastify.close();
+  }
+});


### PR DESCRIPTION
## What changed
- added backend messaging routes for conversation list, detail, and sending messages
- added a live websocket endpoint for conversation updates
- added in-memory conversation event fanout for realtime delivery
- registered websocket support and messaging routes in the backend server
- added backend coverage for REST messaging flows and websocket streaming

## Why this changed
MM-66 needed the backend foundation for live customer-provider chat on top of the existing accepted-proposal conversation model.

## Impact
- customers and providers can load only their own conversations
- participants can send messages through the backend API
- connected clients can receive live conversation events over websocket
- no frontend UI changes are included in this PR

## Validation
- `node --test tests\\auth.customer.test.js tests\\auth.roles.test.js tests\\account.customer.test.js tests\\account.roles.test.js tests\\requests.test.js tests\\messaging.schema.test.js tests\\messaging.test.js`
- `npm run build`
- `git diff --check`