### PR TITLE
MM-68: build provider chat inbox UI

### DIFF
--- a/marketlink-frontend/src/app/dashboard/messages/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/messages/page.tsx
@@ -1,0 +1,102 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import ConversationWorkspace, { type ConversationSummary } from '@/components/chat/ConversationWorkspace';
+import { apiJSON } from '@/lib/serverApi';
+
+type SummaryResponse = {
+  user?: { id: string; email?: string; role?: 'provider' | 'customer' | 'admin' };
+  expert?: { id: string; businessName?: string | null } | null;
+  provider?: { id: string; businessName?: string | null } | null;
+};
+
+type ConversationsResponse = {
+  ok?: boolean;
+  data?: ConversationSummary[];
+};
+
+export default async function ProviderMessagesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ id?: string; proposalId?: string; requestId?: string }>;
+}) {
+  const { id, proposalId, requestId } = await searchParams;
+  const summary = await apiJSON<SummaryResponse>('/me/summary').catch((error: Error) => {
+    if (error.message === 'Not authenticated') {
+      redirect('/login?returnTo=/dashboard/messages');
+    }
+
+    throw error;
+  });
+
+  if (summary.user?.role === 'admin') redirect('/dashboard/admin');
+  if (summary.user?.role === 'customer') redirect('/dashboard/customer');
+  if (!(summary.expert?.id || summary.provider?.id)) redirect('/dashboard/onboarding');
+
+  const conversationsData = await apiJSON<ConversationsResponse>('/conversations').catch((error: Error) => {
+    if (error.message === "You don't have an expert profile yet.") {
+      redirect('/dashboard/onboarding');
+    }
+
+    throw error;
+  });
+  const conversations = conversationsData.data || [];
+
+  return (
+    <main className="ml-page-bg min-h-[calc(100vh-72px)]">
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 sm:py-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Provider messages</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Provider chat inbox</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">
+              Accepted proposals turn into private customer threads here. Keep the request context visible, reply in real time, and move the work forward without leaving your dashboard.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Link
+              href="/dashboard/requests"
+              className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
+            >
+              Matched requests
+            </Link>
+            <Link
+              href="/dashboard"
+              className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white"
+            >
+              Back to dashboard
+            </Link>
+          </div>
+        </div>
+
+        <section className="ml-card mt-5 rounded-[28px] p-5 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-6">
+          <div className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Conversations</div>
+              <div className="mt-2 text-2xl font-semibold text-slate-950">{conversations.length}</div>
+            </div>
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Flow</div>
+              <div className="mt-2 text-sm font-semibold text-slate-950">Accepted proposal only</div>
+            </div>
+            <div className="rounded-2xl bg-slate-50 p-4">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Realtime</div>
+              <div className="mt-2 text-sm font-semibold text-slate-950">Live replies without refresh</div>
+            </div>
+          </div>
+        </section>
+
+        <div className="mt-5">
+          <ConversationWorkspace
+            initialConversations={conversations}
+            currentUserId={summary.user?.id || ''}
+            preferredConversationId={id || null}
+            preferredProposalId={proposalId || null}
+            preferredRequestId={requestId || null}
+            mode="provider"
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/marketlink-frontend/src/app/dashboard/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/page.tsx
@@ -73,6 +73,7 @@ const [user, setUser] = useState<User | null>(null);
   const [needsProposalCount, setNeedsProposalCount] = useState<number | null>(null);
   const [pendingProposalCount, setPendingProposalCount] = useState<number | null>(null);
   const [acceptedProposalCount, setAcceptedProposalCount] = useState<number | null>(null);
+  const [conversationCount, setConversationCount] = useState<number | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -118,12 +119,16 @@ const [user, setUser] = useState<User | null>(null);
 
     (async () => {
       try {
-        const [inquiriesRes, requestsRes] = await Promise.all([
+        const [inquiriesRes, requestsRes, conversationsRes] = await Promise.all([
           fetch(`${API_BASE}/inquiries`, {
             credentials: 'include',
             cache: 'no-store',
           }),
           fetch(`${API_BASE}/provider/requests`, {
+            credentials: 'include',
+            cache: 'no-store',
+          }),
+          fetch(`${API_BASE}/conversations`, {
             credentials: 'include',
             cache: 'no-store',
           }),
@@ -143,6 +148,12 @@ const [user, setUser] = useState<User | null>(null);
           setNeedsProposalCount(rows.filter((r) => !r.proposalStatus).length);
           setPendingProposalCount(rows.filter((r) => r.proposalStatus === 'PENDING').length);
           setAcceptedProposalCount(rows.filter((r) => r.proposalStatus === 'ACCEPTED').length);
+        }
+
+        if (conversationsRes?.ok) {
+          const body = (await conversationsRes.json()) as { ok?: true; data?: Array<{ id: string }> };
+          const rows = Array.isArray(body?.data) ? body.data : [];
+          setConversationCount(rows.length);
         }
       } catch {
         // ignore dashboard sidebar count failures
@@ -256,6 +267,10 @@ const [user, setUser] = useState<User | null>(null);
                   {pendingProposalCount === null || acceptedProposalCount === null ? '—' : `${pendingProposalCount} pending • ${acceptedProposalCount} accepted`}
                 </div>
               </div>
+              <div className={`${mutedCardClass} col-span-2 sm:col-span-1`}>
+                <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Messages</div>
+                <div className="mt-2 text-sm font-semibold text-slate-900">{conversationCount === null ? '—' : `${conversationCount} live chats`}</div>
+              </div>
             </div>
           </div>
         </section>
@@ -323,6 +338,12 @@ const [user, setUser] = useState<User | null>(null);
                       Inquiries
                       {newInquiryCount !== null && newInquiryCount > 0 ? <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{newInquiryCount} new</span> : null}
                     </Link>
+                    <Link href="/dashboard/messages" className={secondaryLinkClass}>
+                      Messages
+                      {conversationCount !== null && conversationCount > 0 ? (
+                        <span className="ml-pill ml-2 rounded-xl px-2 py-0.5 text-xs normal-case tracking-normal">{conversationCount} live</span>
+                      ) : null}
+                    </Link>
                   </div>
 
                   <div className="grid gap-3 sm:grid-cols-3">
@@ -352,6 +373,11 @@ const [user, setUser] = useState<User | null>(null);
                 <Link href={expert ? '/dashboard/requests' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!expert}>
                   <div className="text-sm font-semibold text-slate-900">Matched requests</div>
                   <p className={`mt-1 text-sm ${t.mutedText}`}>{expert ? 'Review active customer requests that currently match your services and delivery footprint.' : 'Create your expert profile first to start receiving matched request opportunities.'}</p>
+                </Link>
+
+                <Link href={expert ? '/dashboard/messages' : '/dashboard/onboarding'} className={`${mutedCardClass} transition ${t.cardHover}`} aria-disabled={!expert}>
+                  <div className="text-sm font-semibold text-slate-900">Messages</div>
+                  <p className={`mt-1 text-sm ${t.mutedText}`}>{expert ? 'Keep accepted proposal chats moving without leaving the provider dashboard.' : 'Create your expert profile first before private customer chats can open here.'}</p>
                 </Link>
 
                 <div className={mutedCardClass}>

--- a/marketlink-frontend/src/app/dashboard/requests/ProposalForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/ProposalForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
@@ -94,6 +95,14 @@ export default function ProposalForm({ requestId, initialProposal = null }: Prop
             <div className="mt-1 font-medium text-slate-900">{proposal.timelineLabel || 'Not specified'}</div>
           </div>
         </div>
+        {proposal.status === 'ACCEPTED' ? (
+          <Link
+            href={`/dashboard/messages?proposalId=${encodeURIComponent(proposal.id)}`}
+            className="ml-btn-primary mt-4 inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-white"
+          >
+            Open chat
+          </Link>
+        ) : null}
       </section>
     );
   }

--- a/marketlink-frontend/src/app/dashboard/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/page.tsx
@@ -243,7 +243,9 @@ export default function ProviderRequestsPage() {
                         </p>
                       </div>
 
-                      <span className="text-sm font-semibold text-slate-900">{row.proposalStatus ? 'View proposal' : 'Review and respond'}</span>
+                      <span className="text-sm font-semibold text-slate-900">
+                        {row.proposalStatus === 'ACCEPTED' ? 'Open chat' : row.proposalStatus ? 'View proposal' : 'Review and respond'}
+                      </span>
                     </div>
 
                     <div className="flex flex-wrap gap-2">

--- a/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/requests/view/page.tsx
@@ -188,6 +188,14 @@ function ProviderRequestDetailPageContent() {
                   <Link href="/dashboard/requests" className="rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50">
                     Back to inbox
                   </Link>
+                  {proposal?.status === 'ACCEPTED' ? (
+                    <Link
+                      href={`/dashboard/messages?proposalId=${encodeURIComponent(proposal.id)}`}
+                      className="rounded-full border border-slate-200/80 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                    >
+                      Open chat
+                    </Link>
+                  ) : null}
                   <Link href="/dashboard" className="rounded-full bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-slate-800">
                     Dashboard
                   </Link>

--- a/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
+++ b/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
@@ -203,15 +203,18 @@ export default function ConversationWorkspace({
   preferredConversationId,
   preferredProposalId,
   preferredRequestId,
+  mode = 'customer',
 }: Readonly<{
   initialConversations: ConversationSummary[];
   currentUserId: string;
   preferredConversationId?: string | null;
   preferredProposalId?: string | null;
   preferredRequestId?: string | null;
+  mode?: 'customer' | 'provider';
 }>) {
   const pathname = usePathname();
   const router = useRouter();
+  const isCustomerMode = mode === 'customer';
   const [showInboxOnMobile, setShowInboxOnMobile] = useState(
     !preferredConversationId && !preferredProposalId && !preferredRequestId,
   );
@@ -382,6 +385,13 @@ export default function ConversationWorkspace({
   );
   const selectedSubject = getMarketingSubjectById(selectedSummary?.request.marketingSubjectId || '');
   const hasSelection = Boolean(selectedConversationId);
+  const selectedCounterpartyName = selectedSummary
+    ? isCustomerMode
+      ? selectedSummary.expert.businessName
+      : selectedSummary.request.customerProfile?.businessName?.trim() ||
+        selectedSummary.request.customerProfile?.name?.trim() ||
+        'Customer'
+    : '';
 
   async function handleSendMessage() {
     if (!selectedConversationId || sendPending) return;
@@ -443,23 +453,27 @@ export default function ConversationWorkspace({
     return (
       <section className="ml-card rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
         <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">No conversations yet</p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">Accepted proposals will open private chat here.</h2>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+          {isCustomerMode ? 'Accepted proposals will open private chat here.' : 'Accepted requests will open private chat here.'}
+        </h2>
         <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-          Once you accept a provider proposal, the conversation appears here with the request context, estimate details, and live replies.
+          {isCustomerMode
+            ? 'Once you accept a provider proposal, the conversation appears here with the request context, estimate details, and live replies.'
+            : 'Once a customer accepts your proposal, the conversation appears here with the request context, estimate details, and live replies.'}
         </p>
 
         <div className="mt-5 flex flex-col gap-3 sm:flex-row">
           <Link
-            href="/dashboard/customer/proposals"
+            href={isCustomerMode ? '/dashboard/customer/proposals' : '/dashboard/requests'}
             className="ml-btn-primary inline-flex min-h-11 items-center justify-center rounded-xl px-6 text-sm font-semibold text-white"
           >
-            Open proposal inbox
+            {isCustomerMode ? 'Open proposal inbox' : 'Open matched requests'}
           </Link>
           <Link
-            href="/dashboard/customer/requests"
+            href={isCustomerMode ? '/dashboard/customer/requests' : '/dashboard'}
             className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
           >
-            Request history
+            {isCustomerMode ? 'Request history' : 'Back to dashboard'}
           </Link>
         </div>
       </section>
@@ -468,7 +482,7 @@ export default function ConversationWorkspace({
 
   return (
     <section className="grid gap-5 xl:grid-cols-[360px_minmax(0,1fr)]">
-      <aside className={`${showInboxOnMobile ? 'block' : 'hidden'} xl:block ml-card rounded-[28px] p-4 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-5`}>
+      <aside className={`${showInboxOnMobile ? 'block' : 'hidden'} xl:block ml-card overflow-hidden rounded-[28px] p-4 shadow-[0_18px_50px_rgba(23,26,31,0.06)] sm:p-5`}>
         <div className="flex items-center justify-between gap-3 border-b border-slate-200/80 pb-4">
           <div>
             <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Inbox</div>
@@ -500,7 +514,13 @@ export default function ConversationWorkspace({
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <div className={`truncate text-sm font-semibold ${isSelected ? 'text-white' : 'text-slate-950'}`}>{conversation.expert.businessName}</div>
+                    <div className={`truncate text-sm font-semibold ${isSelected ? 'text-white' : 'text-slate-950'}`}>
+                      {isCustomerMode
+                        ? conversation.expert.businessName
+                        : conversation.request.customerProfile?.businessName?.trim() ||
+                          conversation.request.customerProfile?.name?.trim() ||
+                          'Customer'}
+                    </div>
                     <div className={`mt-1 truncate text-sm ${isSelected ? 'text-white/75' : 'text-slate-500'}`}>{conversation.request.title}</div>
                   </div>
                   <div className={`shrink-0 text-xs ${isSelected ? 'text-white/65' : 'text-slate-400'}`}>
@@ -577,7 +597,7 @@ export default function ConversationWorkspace({
                     </span>
                   </div>
 
-                  <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{selectedSummary.expert.businessName}</h2>
+                  <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{selectedCounterpartyName}</h2>
                   <p className="mt-1 text-sm leading-6 text-slate-600">{selectedSummary.request.title}</p>
 
                   <div className="mt-3 flex flex-wrap gap-2 text-sm text-slate-600">
@@ -589,17 +609,23 @@ export default function ConversationWorkspace({
 
                 <div className="flex flex-col gap-3 sm:flex-row">
                   <Link
-                    href={`/dashboard/customer/requests/view?id=${encodeURIComponent(selectedSummary.request.id)}`}
+                    href={
+                      isCustomerMode
+                        ? `/dashboard/customer/requests/view?id=${encodeURIComponent(selectedSummary.request.id)}`
+                        : `/dashboard/requests/view?id=${encodeURIComponent(selectedSummary.request.id)}`
+                    }
                     className="ml-btn-secondary inline-flex min-h-11 items-center justify-center rounded-xl px-5 text-sm font-semibold text-slate-900"
                   >
                     Open request
                   </Link>
-                  <Link
-                    href={`/experts/${selectedSummary.expert.slug}`}
-                    className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
-                  >
-                    Expert profile
-                  </Link>
+                  {isCustomerMode ? (
+                    <Link
+                      href={`/experts/${selectedSummary.expert.slug}`}
+                      className="inline-flex min-h-11 items-center justify-center rounded-xl border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+                    >
+                      Expert profile
+                    </Link>
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -639,7 +665,11 @@ export default function ConversationWorkspace({
                     className="min-h-28 rounded-[24px] border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
                   />
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <p className="text-sm text-slate-500">Messages stay private between you and the accepted provider.</p>
+                    <p className="text-sm text-slate-500">
+                      {isCustomerMode
+                        ? 'Messages stay private between you and the accepted provider.'
+                        : 'Messages stay private between you and the customer for this accepted proposal.'}
+                    </p>
                     <button
                       type="button"
                       onClick={handleSendMessage}

--- a/marketlink-frontend/tests/provider-messages.spec.ts
+++ b/marketlink-frontend/tests/provider-messages.spec.ts
@@ -1,0 +1,124 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { expect, test, type APIRequestContext, type BrowserContext } from '@playwright/test';
+
+const BASE_URL = process.env.ML_BASE_URL || 'http://localhost:3000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const BACKEND_DIR = path.join(ROOT_DIR, 'marketlink-backend');
+const PROVIDER_PASSWORD = 'password123';
+
+type ProviderFixture = {
+  email: string;
+  requestId: string;
+};
+
+function ensureProviderFixture(): ProviderFixture {
+  const script = `
+const fs = require('fs');
+const path = require('path');
+const envText = fs.readFileSync(path.join(process.cwd(), '.env'), 'utf8');
+for (const line of envText.split(/\\r?\\n/)) {
+  const match = line.match(/^\\s*DATABASE_URL\\s*=\\s*['\\"]?(.+?)['\\"]?\\s*$/);
+  if (match) process.env.DATABASE_URL = match[1];
+}
+const bcrypt = require('bcryptjs');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+(async () => {
+  const expert = await prisma.expert.findFirst({
+    where: { slug: 'windy-city-growth' },
+    select: {
+      owner: { select: { id: true, email: true } },
+      conversations: {
+        take: 1,
+        orderBy: { updatedAt: 'desc' },
+        select: { requestId: true },
+      },
+    },
+  });
+
+  if (!expert?.owner?.id || !expert.owner.email) {
+    throw new Error('Provider fixture is missing its owner account.');
+  }
+
+  if (!expert.conversations.length) {
+    throw new Error('Provider fixture is missing an accepted conversation.');
+  }
+
+  await prisma.user.update({
+    where: { id: expert.owner.id },
+    data: {
+      passwordHash: await bcrypt.hash(${JSON.stringify(PROVIDER_PASSWORD)}, 10),
+      mustChangePassword: false,
+      isDisabled: false,
+    },
+  });
+
+  process.stdout.write(JSON.stringify({
+    email: expert.owner.email,
+    requestId: expert.conversations[0].requestId,
+  }));
+  await prisma.$disconnect();
+})().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});
+`;
+
+  return JSON.parse(
+    execFileSync('node', ['-e', script], {
+      cwd: BACKEND_DIR,
+      encoding: 'utf8',
+    }),
+  ) as ProviderFixture;
+}
+
+async function createProviderSession(request: APIRequestContext, context: BrowserContext, email: string) {
+  const response = await request.post(`${API_BASE_URL}/auth/login`, {
+    data: {
+      email,
+      password: PROVIDER_PASSWORD,
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  const setCookie = response.headers()['set-cookie'];
+  expect(setCookie).toBeTruthy();
+
+  const match = /session=([^;]+)/.exec(setCookie || '');
+  expect(match).toBeTruthy();
+
+  await context.addCookies([
+    {
+      name: 'session',
+      value: match?.[1] || '',
+      domain: new URL(BASE_URL).hostname,
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+test('provider can open chat from an accepted request', async ({ page, request }) => {
+  const fixture = ensureProviderFixture();
+
+  await createProviderSession(request, page.context(), fixture.email);
+  await page.goto(`${BASE_URL}/dashboard/requests/view?id=${encodeURIComponent(fixture.requestId)}`);
+
+  const openChatLink = page.getByRole('link', { name: 'Open chat' }).first();
+  await expect(openChatLink).toBeVisible();
+  await expect(openChatLink).toHaveAttribute('href', /\/dashboard\/messages\?proposalId=/);
+
+  const href = await openChatLink.getAttribute('href');
+  expect(href).toBeTruthy();
+  await page.goto(new URL(href || '', BASE_URL).toString());
+
+  await expect(page).toHaveURL(/\/dashboard\/messages/);
+  await expect(page.getByRole('heading', { name: 'Provider chat inbox' })).toBeVisible();
+  await expect(page.getByText('Accepted conversations').locator('xpath=ancestor::aside[1]')).toHaveClass(/overflow-hidden/);
+});


### PR DESCRIPTION
## What changed
- added a dedicated provider messages route at `/dashboard/messages`
- made the shared conversation workspace role-aware so providers see customer-specific copy, request links, and private chat context
- added provider chat entry points from the dashboard, matched requests inbox, accepted proposal state, and request detail page
- fixed the inbox rail overflow so the selected conversation card stays clipped inside the left panel
- added Playwright coverage for the provider accepted-request to chat flow

## Why this changed
MM-68 requires providers to manage accepted-proposal conversations from inside the provider dashboard without duplicating the buyer chat implementation. The shared chat surface needed provider-specific routing and copy, plus the left-rail containment fix.

## Impact
- providers can open a private chat inbox from their dashboard
- accepted proposals now lead directly into provider chat threads
- the provider messaging UI stays aligned with the buyer messaging flow while keeping provider-specific context

## Validation
- `npx playwright test tests/provider-messages.spec.ts`
- `npx eslint src/app/dashboard/messages/page.tsx src/app/dashboard/page.tsx src/app/dashboard/requests/ProposalForm.tsx src/app/dashboard/requests/page.tsx src/app/dashboard/requests/view/page.tsx src/components/chat/ConversationWorkspace.tsx tests/provider-messages.spec.ts`
- `npm run build`
