### PR TITLE
MM-69: add unread chat state

### DIFF
--- a/marketlink-backend/src/routes/messaging.ts
+++ b/marketlink-backend/src/routes/messaging.ts
@@ -37,6 +37,85 @@ function serializeMessage(message: {
   };
 }
 
+function getReadAtField(role: User['role']) {
+  return role === 'customer' ? 'customerLastReadAt' : 'expertLastReadAt';
+}
+
+function hasUnreadState(
+  user: Pick<User, 'id' | 'role'>,
+  conversation: {
+    customerLastReadAt?: Date | string | null;
+    expertLastReadAt?: Date | string | null;
+    latestMessage?: {
+      id: string;
+      body: string;
+      senderUserId: string;
+      createdAt: Date | string;
+    } | null;
+  },
+) {
+  const latestMessage = conversation.latestMessage;
+  if (!latestMessage) return false;
+  if (latestMessage.senderUserId === user.id) return false;
+
+  const readAt = user.role === 'customer' ? conversation.customerLastReadAt : conversation.expertLastReadAt;
+  if (!readAt) return true;
+
+  return new Date(latestMessage.createdAt).getTime() > new Date(readAt).getTime();
+}
+
+function serializeConversationSummary(
+  user: Pick<User, 'id' | 'role'>,
+  conversation: {
+    id: string;
+    proposalId: string;
+    requestId: string;
+    customerUserId: string;
+    expertId: string;
+    lastMessageAt?: Date | null;
+    updatedAt: Date;
+    customerLastReadAt?: Date | null;
+    expertLastReadAt?: Date | null;
+    request: {
+      id: string;
+      title: string;
+      marketingSubjectId: string;
+      customerProfile?: {
+        name?: string | null;
+        businessName?: string | null;
+      } | null;
+    };
+    proposal?: {
+      id: string;
+      priceLabel?: string | null;
+      timelineLabel?: string | null;
+      status: 'PENDING' | 'ACCEPTED' | 'DECLINED' | 'WITHDRAWN';
+    } | null;
+    expert: {
+      id: string;
+      businessName: string;
+      slug: string;
+      logo?: string | null;
+    };
+    latestMessage?: {
+      id: string;
+      body: string;
+      senderUserId: string;
+      createdAt: Date;
+    } | null;
+  },
+) {
+  return {
+    ...conversation,
+    lastMessageAt: conversation.lastMessageAt?.toISOString() ?? null,
+    updatedAt: conversation.updatedAt.toISOString(),
+    customerLastReadAt: conversation.customerLastReadAt?.toISOString() ?? null,
+    expertLastReadAt: conversation.expertLastReadAt?.toISOString() ?? null,
+    latestMessage: conversation.latestMessage ? serializeMessage({ ...conversation.latestMessage, conversationId: conversation.id }) : null,
+    hasUnread: hasUnreadState(user, conversation),
+  };
+}
+
 const messagingRoutes: FastifyPluginAsync = async (fastify) => {
   fastify.get('/conversations', async (req, reply) => {
     const user = await getUserFromRequest(fastify, req);
@@ -58,6 +137,8 @@ const messagingRoutes: FastifyPluginAsync = async (fastify) => {
         customerUserId: true,
         expertId: true,
         lastMessageAt: true,
+        customerLastReadAt: true,
+        expertLastReadAt: true,
         updatedAt: true,
         request: {
           select: {
@@ -101,10 +182,12 @@ const messagingRoutes: FastifyPluginAsync = async (fastify) => {
       },
     });
 
-    const data = rows.map(({ messages, ...conversation }) => ({
-      ...conversation,
-      latestMessage: messages[0] ?? null,
-    }));
+    const data = rows.map(({ messages, ...conversation }) =>
+      serializeConversationSummary(user, {
+        ...conversation,
+        latestMessage: messages[0] ?? null,
+      }),
+    );
 
     return reply.send({ ok: true, data });
   });
@@ -181,7 +264,37 @@ const messagingRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     if (!conversation) return reply.code(404).send({ error: 'Conversation not found' });
-    return reply.send({ ok: true, conversation });
+    const latestMessage = conversation.messages[conversation.messages.length - 1] ?? null;
+    const readField = getReadAtField(user.role);
+    let nextReadAt = conversation[readField];
+
+    if (
+      latestMessage &&
+      latestMessage.senderUserId !== user.id &&
+      (!nextReadAt || latestMessage.createdAt.getTime() > nextReadAt.getTime())
+    ) {
+      nextReadAt = new Date();
+      await prisma.conversation.update({
+        where: { id: conversation.id },
+        data: {
+          [readField]: nextReadAt,
+        },
+      });
+    }
+
+    return reply.send({
+      ok: true,
+      conversation: {
+        ...serializeConversationSummary(user, {
+          ...conversation,
+          latestMessage,
+          [readField]: nextReadAt ?? null,
+        }),
+        createdAt: conversation.createdAt.toISOString(),
+        messages: conversation.messages.map(serializeMessage),
+        hasUnread: false,
+      },
+    });
   });
 
   fastify.post('/conversations/:id/messages', async (req, reply) => {
@@ -232,6 +345,7 @@ const messagingRoutes: FastifyPluginAsync = async (fastify) => {
       where: { id: conversation.id },
       data: {
         lastMessageAt: message.createdAt,
+        [getReadAtField(user.role)]: message.createdAt,
       },
     });
 
@@ -245,6 +359,44 @@ const messagingRoutes: FastifyPluginAsync = async (fastify) => {
 
     publishConversationEvent(conversation.id, event);
     return reply.code(201).send({ ok: true, message: responseMessage });
+  });
+
+  fastify.post('/conversations/:id/read', async (req, reply) => {
+    const user = await getUserFromRequest(fastify, req);
+    if (!user) return reply.code(401).send({ error: 'Not authenticated' });
+    if (user.role !== 'customer' && user.role !== 'provider') {
+      return reply.code(403).send({ error: 'Only customers and providers can update conversation read state.' });
+    }
+
+    const access = await getConversationAccess(user);
+    if (!access) return reply.code(404).send({ error: "You don't have an expert profile yet." });
+
+    const { id } = (req.params || {}) as { id?: string };
+    if (!id) return reply.code(400).send({ ok: false, error: 'Missing conversation id' });
+
+    const conversation = await prisma.conversation.findFirst({
+      where: {
+        id,
+        ...access,
+      },
+      select: { id: true },
+    });
+
+    if (!conversation) return reply.code(404).send({ error: 'Conversation not found' });
+
+    const readAt = new Date();
+    await prisma.conversation.update({
+      where: { id: conversation.id },
+      data: {
+        [getReadAtField(user.role)]: readAt,
+      },
+    });
+
+    return reply.send({
+      ok: true,
+      conversationId: conversation.id,
+      readAt: readAt.toISOString(),
+    });
   });
 
   fastify.get('/conversations/:id/live', { websocket: true }, async (socket: WebSocket, req) => {

--- a/marketlink-backend/tests/messaging.test.js
+++ b/marketlink-backend/tests/messaging.test.js
@@ -43,21 +43,23 @@ test('GET /conversations lists only the signed-in customer conversations', async
           customerUserId: 'customer_user_1',
           expertId: 'expert_1',
           lastMessageAt: new Date('2026-06-18T01:00:00.000Z'),
+          customerLastReadAt: new Date('2026-06-18T00:30:00.000Z'),
+          expertLastReadAt: new Date('2026-06-18T00:30:00.000Z'),
           updatedAt: new Date('2026-06-18T01:00:00.000Z'),
           request: {
             id: 'request_1',
             title: 'Need Google Ads help',
             marketingSubjectId: 'paid-ads',
+            customerProfile: {
+              name: 'Jamie Rivera',
+              businessName: 'Westmont Dental',
+            },
           },
           proposal: {
             id: 'proposal_1',
             priceLabel: '$3k-$5k',
             timelineLabel: 'This month',
             status: 'ACCEPTED',
-          },
-          customerProfile: {
-            name: 'Jamie Rivera',
-            businessName: 'Westmont Dental',
           },
           expert: {
             id: 'expert_1',
@@ -92,6 +94,94 @@ test('GET /conversations lists only the signed-in customer conversations', async
     assert.equal(body.data[0].request.title, 'Need Google Ads help');
     assert.equal(body.data[0].expert.businessName, 'Windy City Growth');
     assert.equal(body.data[0].latestMessage.id, 'message_1');
+    assert.equal(body.data[0].hasUnread, true);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    await fastify.close();
+  }
+});
+
+test('GET /conversations/:id marks the opened conversation as read for the current participant', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+  let updatedReadAt = null;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_1',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.conversation = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.equal(where.customerUserId, 'customer_user_1');
+      return {
+        id: 'conversation_1',
+        proposalId: 'proposal_1',
+        requestId: 'request_1',
+        customerUserId: 'customer_user_1',
+        expertId: 'expert_1',
+        lastMessageAt: new Date('2026-06-18T02:00:00.000Z'),
+        customerLastReadAt: new Date('2026-06-18T01:00:00.000Z'),
+        expertLastReadAt: new Date('2026-06-18T01:00:00.000Z'),
+        createdAt: new Date('2026-06-18T00:00:00.000Z'),
+        updatedAt: new Date('2026-06-18T02:00:00.000Z'),
+        request: {
+          id: 'request_1',
+          title: 'Need Google Ads help',
+          marketingSubjectId: 'paid-ads',
+          customerProfile: {
+            name: 'Jamie Rivera',
+            businessName: 'Westmont Dental',
+          },
+        },
+        proposal: {
+          id: 'proposal_1',
+          priceLabel: '$3k-$5k',
+          timelineLabel: 'This month',
+          status: 'ACCEPTED',
+        },
+        expert: {
+          id: 'expert_1',
+          businessName: 'Windy City Growth',
+          slug: 'windy-city-growth',
+          logo: null,
+        },
+        messages: [
+          {
+            id: 'message_1',
+            conversationId: 'conversation_1',
+            senderUserId: 'provider_user_1',
+            body: 'Happy to help.',
+            createdAt: new Date('2026-06-18T02:00:00.000Z'),
+          },
+        ],
+      };
+    },
+    update: async ({ where, data }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.ok(data.customerLastReadAt instanceof Date);
+      updatedReadAt = data.customerLastReadAt;
+      return { id: 'conversation_1' };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/conversations/conversation_1',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.conversation.id, 'conversation_1');
+    assert.equal(body.conversation.hasUnread, false);
+    assert.ok(updatedReadAt instanceof Date);
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.conversation = originalConversation;
@@ -209,6 +299,7 @@ test('POST /conversations/:id/messages creates a message and broadcasts it to th
     update: async ({ where, data }) => {
       assert.equal(where.id, 'conversation_1');
       assert.ok(data.lastMessageAt instanceof Date);
+      assert.ok(data.customerLastReadAt instanceof Date);
       return { id: 'conversation_1' };
     },
   };
@@ -266,6 +357,60 @@ test('POST /conversations/:id/messages creates a message and broadcasts it to th
     prismaModule.prisma.conversation = originalConversation;
     prismaModule.prisma.message = originalMessage;
     realtimeModule.publishConversationEvent = originalPublishConversationEvent;
+    await fastify.close();
+  }
+});
+
+test('POST /conversations/:id/read clears unread state for the current participant', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalConversation = prismaModule.prisma.conversation;
+  let updatedReadAt = null;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  const originalExpert = prismaModule.prisma.expert;
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.userId, 'provider_user_1');
+      return { id: 'expert_1' };
+    },
+  };
+
+  prismaModule.prisma.conversation = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.equal(where.expertId, 'expert_1');
+      return { id: 'conversation_1' };
+    },
+    update: async ({ where, data }) => {
+      assert.equal(where.id, 'conversation_1');
+      assert.ok(data.expertLastReadAt instanceof Date);
+      updatedReadAt = data.expertLastReadAt;
+      return { id: 'conversation_1' };
+    },
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/conversations/conversation_1/read',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.conversationId, 'conversation_1');
+    assert.ok(updatedReadAt instanceof Date);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.conversation = originalConversation;
+    prismaModule.prisma.expert = originalExpert;
     await fastify.close();
   }
 });

--- a/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
+++ b/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { getMarketingSubjectById } from '@/lib/marketingTaxonomy';
 
@@ -22,7 +22,10 @@ export type ConversationSummary = {
   customerUserId: string;
   expertId: string;
   lastMessageAt?: string | null;
+  customerLastReadAt?: string | null;
+  expertLastReadAt?: string | null;
   updatedAt: string;
+  hasUnread?: boolean;
   request: {
     id: string;
     title: string;
@@ -71,6 +74,13 @@ type SendMessageResponse = {
   error?: string;
 };
 
+type MarkReadResponse = {
+  ok?: boolean;
+  conversationId?: string;
+  readAt?: string;
+  error?: string;
+};
+
 type LiveConversationEvent =
   | { type: 'connected'; conversationId: string }
   | {
@@ -87,6 +97,10 @@ function toWebSocketBase(apiBase: string) {
 
 function sortConversations(conversations: ConversationSummary[]) {
   return [...conversations].sort((left, right) => {
+    const leftUnread = Boolean(left.hasUnread);
+    const rightUnread = Boolean(right.hasUnread);
+    if (leftUnread !== rightUnread) return leftUnread ? -1 : 1;
+
     const leftTime = left.lastMessageAt || left.updatedAt;
     const rightTime = right.lastMessageAt || right.updatedAt;
     return new Date(rightTime).getTime() - new Date(leftTime).getTime();
@@ -168,6 +182,10 @@ function updateConversationWithMessage(conversation: ConversationSummary, messag
   };
 }
 
+function getReadAtField(mode: 'customer' | 'provider') {
+  return mode === 'customer' ? 'customerLastReadAt' : 'expertLastReadAt';
+}
+
 function summarizeLiveStatus(status: 'connecting' | 'live' | 'offline') {
   if (status === 'live') return 'Live';
   if (status === 'connecting') return 'Connecting';
@@ -230,6 +248,49 @@ export default function ConversationWorkspace({
   const [sendError, setSendError] = useState<string | null>(null);
   const [liveStatus, setLiveStatus] = useState<'connecting' | 'live' | 'offline'>('offline');
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const unreadCount = useMemo(() => conversations.filter((conversation) => conversation.hasUnread).length, [conversations]);
+
+  const markConversationRead = useCallback(async (conversationId: string) => {
+    try {
+      const response = await fetch(`${API_BASE}/conversations/${conversationId}/read`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      const payload = (await response.json().catch(() => ({}))) as MarkReadResponse;
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error || `Failed to mark conversation read (${response.status})`);
+      }
+
+      const readAt = payload.readAt || new Date().toISOString();
+      const readField = getReadAtField(mode);
+
+      setConversations((current) =>
+        sortConversations(
+          current.map((conversation) =>
+            conversation.id === conversationId
+              ? {
+                  ...conversation,
+                  hasUnread: false,
+                  [readField]: readAt,
+                }
+              : conversation,
+          ),
+        ),
+      );
+      setSelectedConversation((current) =>
+        current && current.id === conversationId
+          ? {
+              ...current,
+              hasUnread: false,
+              [readField]: readAt,
+            }
+          : current,
+      );
+    } catch {
+      // best effort; keep live thread responsive even if the read marker write fails
+    }
+  }, [mode]);
 
   useEffect(() => {
     setConversations(sortConversations(initialConversations));
@@ -294,11 +355,14 @@ export default function ConversationWorkspace({
               conversation.id === body.conversation?.id
                 ? {
                     ...conversation,
+                    customerLastReadAt: body.conversation?.customerLastReadAt || conversation.customerLastReadAt,
+                    expertLastReadAt: body.conversation?.expertLastReadAt || conversation.expertLastReadAt,
                     lastMessageAt:
                       body.conversation?.messages[body.conversation.messages.length - 1]?.createdAt ||
                       conversation.lastMessageAt,
                     latestMessage:
                       body.conversation?.messages[body.conversation.messages.length - 1] || conversation.latestMessage,
+                    hasUnread: false,
                   }
                 : conversation,
             ),
@@ -315,7 +379,7 @@ export default function ConversationWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [selectedConversationId]);
+  }, [currentUserId, markConversationRead, selectedConversationId]);
 
   useEffect(() => {
     if (!selectedConversationId) {
@@ -335,6 +399,8 @@ export default function ConversationWorkspace({
       }
 
       if (payload.type !== 'message.created') return;
+      const isOwnMessage = payload.message.senderUserId === currentUserId;
+      const isSelectedThread = payload.conversationId === selectedConversationId;
 
       setSelectedConversation((current) => {
         if (!current || current.id !== payload.conversationId) return current;
@@ -348,6 +414,7 @@ export default function ConversationWorkspace({
             createdAt: payload.message.createdAt,
           },
           messages: upsertMessage(current.messages, payload.message),
+          hasUnread: false,
         };
       });
 
@@ -355,11 +422,18 @@ export default function ConversationWorkspace({
         sortConversations(
           current.map((conversation) =>
             conversation.id === payload.conversationId
-              ? updateConversationWithMessage(conversation, payload.message)
+              ? {
+                  ...updateConversationWithMessage(conversation, payload.message),
+                  hasUnread: isOwnMessage ? false : !isSelectedThread,
+                }
               : conversation,
           ),
         ),
       );
+
+      if (!isOwnMessage && isSelectedThread) {
+        void markConversationRead(payload.conversationId);
+      }
     };
 
     socket.onerror = () => {
@@ -373,7 +447,7 @@ export default function ConversationWorkspace({
     return () => {
       socket.close();
     };
-  }, [selectedConversationId]);
+  }, [currentUserId, markConversationRead, selectedConversationId]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
@@ -431,13 +505,17 @@ export default function ConversationWorkspace({
             createdAt: payload.message!.createdAt,
           },
           messages: upsertMessage(current.messages, payload.message!),
+          hasUnread: false,
         };
       });
       setConversations((current) =>
         sortConversations(
           current.map((conversation) =>
             conversation.id === selectedConversationId
-              ? updateConversationWithMessage(conversation, payload.message!)
+              ? {
+                  ...updateConversationWithMessage(conversation, payload.message!),
+                  hasUnread: false,
+                }
               : conversation,
           ),
         ),
@@ -488,9 +566,16 @@ export default function ConversationWorkspace({
             <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Inbox</div>
             <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">Accepted conversations</h2>
           </div>
-          <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-            {conversations.length}
-          </span>
+          <div className="flex items-center gap-2">
+            {unreadCount ? (
+              <span className="inline-flex rounded-xl bg-slate-900 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white">
+                {unreadCount} unread
+              </span>
+            ) : null}
+            <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+              {conversations.length}
+            </span>
+          </div>
         </div>
 
         <div className="mt-4 grid gap-3">
@@ -529,6 +614,15 @@ export default function ConversationWorkspace({
                 </div>
 
                 <div className="mt-3 flex flex-wrap gap-2">
+                  {conversation.hasUnread ? (
+                    <span
+                      className={`inline-flex rounded-xl px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] ${
+                        isSelected ? 'bg-white/15 text-white' : 'bg-[#1f314d] text-white'
+                      }`}
+                    >
+                      Unread
+                    </span>
+                  ) : null}
                   <span className={`inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] ${isSelected ? 'bg-white/10 text-white/80' : 'bg-slate-100 text-slate-500'}`}>
                     {subject?.label || conversation.request.marketingSubjectId}
                   </span>

--- a/marketlink-frontend/tests/conversation-unread.spec.ts
+++ b/marketlink-frontend/tests/conversation-unread.spec.ts
@@ -1,0 +1,307 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { expect, test, type APIRequestContext, type BrowserContext, type Locator } from '@playwright/test';
+
+const BASE_URL = process.env.ML_BASE_URL || 'http://localhost:3000';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+const BACKEND_DIR = path.join(ROOT_DIR, 'marketlink-backend');
+const PROVIDER_PASSWORD = 'password123';
+
+type Fixture = {
+  providerEmail: string;
+  readProposalId: string;
+  unreadBusinessName: string;
+};
+
+function ensureUnreadFixture(): Fixture {
+  const script = `
+const fs = require('fs');
+const path = require('path');
+const envText = fs.readFileSync(path.join(process.cwd(), '.env'), 'utf8');
+for (const line of envText.split(/\\r?\\n/)) {
+  const match = line.match(/^\\s*DATABASE_URL\\s*=\\s*['\\"]?(.+?)['\\"]?\\s*$/);
+  if (match) process.env.DATABASE_URL = match[1];
+}
+const bcrypt = require('bcryptjs');
+const { PrismaClient } = require('@prisma/client');
+const prisma = new PrismaClient();
+
+async function ensureCustomer(email, name, businessName) {
+  const passwordHash = await bcrypt.hash('password123', 10);
+  return prisma.user.upsert({
+    where: { email },
+    update: {
+      role: 'customer',
+      passwordHash,
+      mustChangePassword: false,
+      isDisabled: false,
+      customerProfile: {
+        upsert: {
+          update: { name, businessName },
+          create: { name, businessName },
+        },
+      },
+    },
+    create: {
+      email,
+      role: 'customer',
+      passwordHash,
+      mustChangePassword: false,
+      isDisabled: false,
+      customerProfile: {
+        create: { name, businessName },
+      },
+    },
+    include: { customerProfile: true },
+  });
+}
+
+async function ensureRequest(customer, title) {
+  const existing = await prisma.customerRequest.findFirst({
+    where: { customerUserId: customer.id, title },
+  });
+
+  if (existing) return existing;
+
+  return prisma.customerRequest.create({
+    data: {
+      customerUserId: customer.id,
+      customerProfileId: customer.customerProfile.id,
+      requesterName: customer.customerProfile.name,
+      requesterBusinessName: customer.customerProfile.businessName,
+      title,
+      description: title + ' description',
+      marketingSubjectId: 'paid-ads',
+      serviceTokens: ['paid-ads', 'google-ads'],
+      zip: '60559',
+      budgetLabel: '$4k starter sprint',
+      timelineLabel: '2-3 weeks',
+      status: 'ACTIVE',
+    },
+  });
+}
+
+(async () => {
+  const expert = await prisma.expert.findFirst({
+    where: { slug: 'windy-city-growth' },
+    select: {
+      id: true,
+      owner: { select: { id: true, email: true } },
+    },
+  });
+
+  if (!expert?.owner?.id || !expert.owner.email) {
+    throw new Error('Provider fixture is missing its owner account.');
+  }
+
+  await prisma.user.update({
+    where: { id: expert.owner.id },
+    data: {
+      passwordHash: await bcrypt.hash('password123', 10),
+      mustChangePassword: false,
+      isDisabled: false,
+    },
+  });
+
+  const readCustomer = await ensureCustomer('mm69-read@example.com', 'Read Fixture', 'Read Fixture LLC');
+  const unreadCustomer = await ensureCustomer('mm69-unread@example.com', 'Unread Fixture', 'Unread Fixture LLC');
+
+  const readRequest = await ensureRequest(readCustomer, 'MM69 Read Fixture Request');
+  const unreadRequest = await ensureRequest(unreadCustomer, 'MM69 Unread Fixture Request');
+
+  const readProposal = await prisma.proposal.upsert({
+    where: { requestId_expertId: { requestId: readRequest.id, expertId: expert.id } },
+    update: {
+      status: 'ACCEPTED',
+      message: 'Read fixture proposal',
+      priceLabel: '$4k starter sprint',
+      timelineLabel: '2-3 weeks',
+    },
+    create: {
+      requestId: readRequest.id,
+      expertId: expert.id,
+      status: 'ACCEPTED',
+      message: 'Read fixture proposal',
+      priceLabel: '$4k starter sprint',
+      timelineLabel: '2-3 weeks',
+    },
+  });
+
+  const unreadProposal = await prisma.proposal.upsert({
+    where: { requestId_expertId: { requestId: unreadRequest.id, expertId: expert.id } },
+    update: {
+      status: 'ACCEPTED',
+      message: 'Unread fixture proposal',
+      priceLabel: '$4k starter sprint',
+      timelineLabel: '2-3 weeks',
+    },
+    create: {
+      requestId: unreadRequest.id,
+      expertId: expert.id,
+      status: 'ACCEPTED',
+      message: 'Unread fixture proposal',
+      priceLabel: '$4k starter sprint',
+      timelineLabel: '2-3 weeks',
+    },
+  });
+
+  const readConversation = await prisma.conversation.upsert({
+    where: { proposalId: readProposal.id },
+    update: {
+      requestId: readRequest.id,
+      customerUserId: readCustomer.id,
+      expertId: expert.id,
+    },
+    create: {
+      proposalId: readProposal.id,
+      requestId: readRequest.id,
+      customerUserId: readCustomer.id,
+      expertId: expert.id,
+    },
+  });
+
+  const unreadConversation = await prisma.conversation.upsert({
+    where: { proposalId: unreadProposal.id },
+    update: {
+      requestId: unreadRequest.id,
+      customerUserId: unreadCustomer.id,
+      expertId: expert.id,
+    },
+    create: {
+      proposalId: unreadProposal.id,
+      requestId: unreadRequest.id,
+      customerUserId: unreadCustomer.id,
+      expertId: expert.id,
+    },
+  });
+
+  await prisma.message.deleteMany({ where: { conversationId: { in: [readConversation.id, unreadConversation.id] } } });
+
+  const readCustomerMessageAt = new Date('2026-06-20T17:00:00.000Z');
+  const readProviderMessageAt = new Date('2026-06-20T17:10:00.000Z');
+  const unreadCustomerMessageAt = new Date('2026-06-20T17:20:00.000Z');
+
+  await prisma.message.createMany({
+    data: [
+      {
+        conversationId: readConversation.id,
+        senderUserId: readCustomer.id,
+        body: 'Read fixture customer note',
+        createdAt: readCustomerMessageAt,
+      },
+      {
+        conversationId: readConversation.id,
+        senderUserId: expert.owner.id,
+        body: 'Read fixture provider reply',
+        createdAt: readProviderMessageAt,
+      },
+      {
+        conversationId: unreadConversation.id,
+        senderUserId: unreadCustomer.id,
+        body: 'Unread fixture latest customer message',
+        createdAt: unreadCustomerMessageAt,
+      },
+    ],
+  });
+
+  await prisma.conversation.update({
+    where: { id: readConversation.id },
+    data: {
+      lastMessageAt: readProviderMessageAt,
+      expertLastReadAt: readProviderMessageAt,
+      customerLastReadAt: readProviderMessageAt,
+    },
+  });
+
+  await prisma.conversation.update({
+    where: { id: unreadConversation.id },
+    data: {
+      lastMessageAt: unreadCustomerMessageAt,
+      expertLastReadAt: new Date('2026-06-20T17:00:00.000Z'),
+      customerLastReadAt: unreadCustomerMessageAt,
+    },
+  });
+
+  await prisma.conversation.updateMany({
+    where: {
+      expertId: expert.id,
+      NOT: { id: unreadConversation.id },
+    },
+    data: {
+      expertLastReadAt: new Date('2100-01-01T00:00:00.000Z'),
+    },
+  });
+
+  process.stdout.write(JSON.stringify({
+    providerEmail: expert.owner.email,
+    readProposalId: readProposal.id,
+    unreadBusinessName: 'Unread Fixture LLC',
+  }));
+  await prisma.$disconnect();
+})().catch(async (error) => {
+  console.error(error);
+  await prisma.$disconnect();
+  process.exit(1);
+});
+`;
+
+  return JSON.parse(
+    execFileSync('node', ['-e', script], {
+      cwd: BACKEND_DIR,
+      encoding: 'utf8',
+    }),
+  ) as Fixture;
+}
+
+async function createProviderSession(request: APIRequestContext, context: BrowserContext, email: string) {
+  const response = await request.post(`${API_BASE_URL}/auth/login`, {
+    data: {
+      email,
+      password: PROVIDER_PASSWORD,
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  const setCookie = response.headers()['set-cookie'];
+  expect(setCookie).toBeTruthy();
+
+  const match = /session=([^;]+)/.exec(setCookie || '');
+  expect(match).toBeTruthy();
+
+  await context.addCookies([
+    {
+      name: 'session',
+      value: match?.[1] || '',
+      domain: new URL(BASE_URL).hostname,
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+function unreadCard(page: import('@playwright/test').Page, businessName: string): Locator {
+  return page.getByRole('button').filter({ hasText: businessName });
+}
+
+test('provider inbox shows unread threads and clears them when opened', async ({ page, request }) => {
+  const fixture = ensureUnreadFixture();
+
+  await createProviderSession(request, page.context(), fixture.providerEmail);
+  await page.goto(`${BASE_URL}/dashboard/messages?proposalId=${encodeURIComponent(fixture.readProposalId)}`);
+
+  const unreadBadges = page.getByRole('button').getByText('Unread', { exact: true });
+  await expect(page.getByText(/1 unread/i)).toBeVisible();
+  await expect(unreadBadges).toHaveCount(1);
+
+  const unreadThread = unreadCard(page, fixture.unreadBusinessName);
+  await expect(unreadThread.getByText('Unread', { exact: true })).toBeVisible();
+
+  await unreadThread.click();
+
+  await expect(unreadThread.getByText('Unread', { exact: true })).toHaveCount(0);
+  await expect(page.getByText(/1 unread/i)).toHaveCount(0);
+  await expect(unreadBadges).toHaveCount(0);
+});


### PR DESCRIPTION
## What changed
- added unread-state handling to messaging routes so conversation list responses include whether a thread needs attention
- marked conversations read when a participant opens a thread and added an explicit read endpoint for live-thread updates
- updated send-message behavior so the sender's side is marked read immediately
- updated the shared chat workspace to sort unread threads first and show unread badges in the inbox
- added backend and Playwright coverage for unread thread behavior

## Why this changed
MM-69 requires conversation-list behavior on top of the live chat foundation so both buyers and providers can tell which threads need attention and have unread state clear correctly when they open a thread.

## Impact
- inboxes now surface unread conversation state instead of forcing users to infer it from timestamps
- opening a thread clears unread state reliably
- live chat behavior stays aligned with persisted read markers on the backend

## Validation
- `node --test tests/messaging.test.js`
- `npx playwright test tests/conversation-unread.spec.ts tests/provider-messages.spec.ts`
- `npx eslint src/components/chat/ConversationWorkspace.tsx src/app/dashboard/messages/page.tsx src/app/dashboard/customer/messages/page.tsx tests/conversation-unread.spec.ts tests/provider-messages.spec.ts`
- `npm run build`
