### PR TITLE
MM-113 add specific and unsure request intake contract

### DIFF
--- a/marketlink-backend/prisma/migrations/20260622210000_mm113_request_modes_and_radius/migration.sql
+++ b/marketlink-backend/prisma/migrations/20260622210000_mm113_request_modes_and_radius/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "CustomerRequestIntakeMode" AS ENUM ('SPECIFIC', 'UNSURE');
+
+-- AlterTable
+ALTER TABLE "CustomerRequest"
+ADD COLUMN "intakeMode" "CustomerRequestIntakeMode" NOT NULL DEFAULT 'SPECIFIC',
+ADD COLUMN "subcategoryId" TEXT,
+ADD COLUMN "radiusMiles" INTEGER,
+ALTER COLUMN "marketingSubjectId" DROP NOT NULL,
+ALTER COLUMN "zip" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "CustomerRequest_intakeMode_status_createdAt_idx" ON "CustomerRequest"("intakeMode", "status", "createdAt");

--- a/marketlink-backend/prisma/schema.prisma
+++ b/marketlink-backend/prisma/schema.prisma
@@ -194,6 +194,11 @@ enum CustomerRequestStatus {
   CANCELLED
 }
 
+enum CustomerRequestIntakeMode {
+  SPECIFIC
+  UNSURE
+}
+
 enum ProposalStatus {
   PENDING
   ACCEPTED
@@ -209,9 +214,12 @@ model CustomerRequest {
   requesterBusinessName String?
   title                 String
   description           String
-  marketingSubjectId    String
+  intakeMode            CustomerRequestIntakeMode @default(SPECIFIC)
+  marketingSubjectId    String?
+  subcategoryId         String?
   serviceTokens         String[]              @default([])
-  zip                   String
+  zip                   String?
+  radiusMiles           Int?
   budgetLabel           String?
   timelineLabel         String?
   status                CustomerRequestStatus @default(ACTIVE)
@@ -224,6 +232,7 @@ model CustomerRequest {
 
   @@index([customerUserId, createdAt])
   @@index([status, createdAt])
+  @@index([intakeMode, status, createdAt])
   @@index([marketingSubjectId, status])
   @@index([zip, status])
 }

--- a/marketlink-backend/src/routes/messaging.ts
+++ b/marketlink-backend/src/routes/messaging.ts
@@ -79,7 +79,7 @@ function serializeConversationSummary(
     request: {
       id: string;
       title: string;
-      marketingSubjectId: string;
+      marketingSubjectId: string | null;
       customerProfile?: {
         name?: string | null;
         businessName?: string | null;

--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { CustomerRequestStatus, ExpertStatus, ProposalStatus } from '@prisma/client';
+import { CustomerRequestIntakeMode, CustomerRequestStatus, ExpertStatus, ProposalStatus } from '@prisma/client';
 import { prisma } from '../lib/prisma';
 import { getUserFromRequest } from '../lib/session';
 import { lookupZipLocation } from '../lib/geocoding';
@@ -11,7 +11,7 @@ type RequestMatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remo
 type DeliveryPreviewInput = {
   id: string;
   serviceTokens: string[];
-  zip: string;
+  zip: string | null;
 };
 
 type ProviderExpertForMatching = {
@@ -32,9 +32,9 @@ type RequestForProviderMatching = {
   id: string;
   title: string;
   description: string;
-  marketingSubjectId: string;
+  marketingSubjectId: string | null;
   serviceTokens: string[];
-  zip: string;
+  zip: string | null;
   budgetLabel: string | null;
   timelineLabel: string | null;
   status: CustomerRequestStatus;
@@ -48,6 +48,11 @@ function asCleanString(input: unknown) {
   return String(input || '').trim();
 }
 
+function asOptionalCleanString(input: unknown) {
+  const value = asCleanString(input);
+  return value || null;
+}
+
 function asServiceTokens(input: unknown) {
   if (!Array.isArray(input)) return [];
 
@@ -58,6 +63,18 @@ function asServiceTokens(input: unknown) {
         .filter(Boolean),
     ),
   );
+}
+
+function asRadiusMiles(input: unknown) {
+  if (input === null || typeof input === 'undefined' || input === '') return null;
+  const value = Number(input);
+  if (!Number.isInteger(value)) return null;
+  return value;
+}
+
+function inferIntakeMode(marketingSubjectId: string | null, serviceTokens: string[]) {
+  if (marketingSubjectId || serviceTokens.length > 0) return CustomerRequestIntakeMode.SPECIFIC;
+  return CustomerRequestIntakeMode.UNSURE;
 }
 
 function normalizeCity(value: string | null | undefined) {
@@ -87,6 +104,8 @@ function isCustomerProposalDecision(status: ProposalStatus) {
 }
 
 async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, request: RequestForProviderMatching) {
+  if (!request.zip || request.serviceTokens.length === 0) return null;
+
   const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
   if (!matchedServiceTokens.length) return null;
 
@@ -123,6 +142,8 @@ async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, r
 }
 
 async function buildDeliveryPreview(input: DeliveryPreviewInput) {
+  if (!input.zip || input.serviceTokens.length === 0) return null;
+
   const locationLookup = await lookupZipLocation({ zip: input.zip });
   const requestCity = locationLookup.ok ? locationLookup.city : null;
   const requestState = locationLookup.ok ? locationLookup.state : null;
@@ -217,31 +238,69 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       title?: unknown;
       description?: unknown;
       marketingSubjectId?: unknown;
+      subcategoryId?: unknown;
       serviceTokens?: unknown;
       zip?: unknown;
+      radiusMiles?: unknown;
       budgetLabel?: unknown;
       timelineLabel?: unknown;
     };
 
     const title = asCleanString(body.title);
     const description = asCleanString(body.description);
-    const marketingSubjectId = asCleanString(body.marketingSubjectId);
+    const marketingSubjectId = asOptionalCleanString(body.marketingSubjectId);
+    const subcategoryId = asOptionalCleanString(body.subcategoryId);
     const serviceTokens = asServiceTokens(body.serviceTokens);
-    const zip = asCleanString(body.zip);
+    const zip = asOptionalCleanString(body.zip);
+    const radiusMiles = asRadiusMiles(body.radiusMiles);
     const budgetLabel = asCleanString(body.budgetLabel) || null;
     const timelineLabel = asCleanString(body.timelineLabel) || null;
+    const intakeMode = inferIntakeMode(marketingSubjectId, serviceTokens);
 
     if (!title) return reply.code(400).send({ ok: false, error: 'title is required' });
     if (!description) return reply.code(400).send({ ok: false, error: 'description is required' });
-    if (!marketingSubjectId) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is required' });
-    if (serviceTokens.length === 0) return reply.code(400).send({ ok: false, error: 'serviceTokens must include at least one item' });
-    if (!zip || !ZIP_RE.test(zip)) return reply.code(400).send({ ok: false, error: 'zip must be a valid 5-digit ZIP code' });
+
+    if (intakeMode === CustomerRequestIntakeMode.SPECIFIC) {
+      if (!marketingSubjectId) {
+        return reply.code(400).send({ ok: false, error: 'marketingSubjectId is required when a specific marketing area is selected' });
+      }
+
+      if (serviceTokens.length === 0) {
+        return reply.code(400).send({
+          ok: false,
+          error: 'serviceTokens must include at least one item when a specific marketing area is selected',
+        });
+      }
+    } else {
+      if (!zip) {
+        return reply.code(400).send({ ok: false, error: 'zip is required when no marketing area is selected' });
+      }
+
+      if (!ZIP_RE.test(zip)) {
+        return reply.code(400).send({ ok: false, error: 'zip must be a valid 5-digit ZIP code' });
+      }
+
+      if (radiusMiles === null) {
+        return reply.code(400).send({ ok: false, error: 'radiusMiles is required when no marketing area is selected' });
+      }
+
+      if (radiusMiles < 1 || radiusMiles > 100) {
+        return reply.code(400).send({ ok: false, error: 'radiusMiles must be between 1 and 100' });
+      }
+
+      const locationLookup = await lookupZipLocation({ zip });
+      if (!locationLookup.ok) {
+        return reply.code(400).send({ ok: false, error: 'We could not verify that ZIP code for an unsure request.' });
+      }
+    }
 
     if (title.length > 140) return reply.code(400).send({ ok: false, error: 'title is too long' });
     if (description.length > 4000) return reply.code(400).send({ ok: false, error: 'description is too long' });
-    if (marketingSubjectId.length > 80) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is too long' });
+    if (marketingSubjectId && marketingSubjectId.length > 80) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is too long' });
+    if (subcategoryId && subcategoryId.length > 80) return reply.code(400).send({ ok: false, error: 'subcategoryId is too long' });
     if (serviceTokens.length > 12) return reply.code(400).send({ ok: false, error: 'serviceTokens cannot exceed 12 items' });
     if (serviceTokens.some((token) => token.length > 80)) return reply.code(400).send({ ok: false, error: 'serviceTokens contains an item that is too long' });
+    if (zip && !ZIP_RE.test(zip)) return reply.code(400).send({ ok: false, error: 'zip must be a valid 5-digit ZIP code' });
     if (budgetLabel && budgetLabel.length > 80) return reply.code(400).send({ ok: false, error: 'budgetLabel is too long' });
     if (timelineLabel && timelineLabel.length > 80) return reply.code(400).send({ ok: false, error: 'timelineLabel is too long' });
 
@@ -266,9 +325,12 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         requesterBusinessName: customerProfile.businessName?.trim() || null,
         title,
         description,
+        intakeMode,
         marketingSubjectId,
+        subcategoryId,
         serviceTokens,
         zip,
+        radiusMiles,
         budgetLabel,
         timelineLabel,
         status: CustomerRequestStatus.ACTIVE,
@@ -281,9 +343,12 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         requesterBusinessName: true,
         title: true,
         description: true,
+        intakeMode: true,
         marketingSubjectId: true,
+        subcategoryId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         budgetLabel: true,
         timelineLabel: true,
         status: true,
@@ -293,11 +358,14 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     });
 
     req.log.info({ requestId: created.id, customerUserId: user.id }, 'customer-request.created');
-    const deliveryPreview = await buildDeliveryPreview({
-      id: created.id,
-      serviceTokens: created.serviceTokens,
-      zip: created.zip,
-    });
+    const deliveryPreview =
+      created.zip && created.serviceTokens.length > 0
+        ? await buildDeliveryPreview({
+            id: created.id,
+            serviceTokens: created.serviceTokens,
+            zip: created.zip,
+          })
+        : null;
 
     return reply.code(201).send({ ok: true, request: created, deliveryPreview });
   });
@@ -313,9 +381,12 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       select: {
         id: true,
         title: true,
+        intakeMode: true,
         marketingSubjectId: true,
+        subcategoryId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         status: true,
         createdAt: true,
         updatedAt: true,
@@ -360,9 +431,12 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         requesterBusinessName: true,
         title: true,
         description: true,
+        intakeMode: true,
         marketingSubjectId: true,
+        subcategoryId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         budgetLabel: true,
         timelineLabel: true,
         status: true,
@@ -373,11 +447,14 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
 
     if (!request) return reply.code(404).send({ ok: false, error: 'Request not found' });
 
-    const deliveryPreview = await buildDeliveryPreview({
-      id: request.id,
-      serviceTokens: request.serviceTokens,
-      zip: request.zip,
-    });
+    const deliveryPreview =
+      request.zip && request.serviceTokens.length > 0
+        ? await buildDeliveryPreview({
+            id: request.id,
+            serviceTokens: request.serviceTokens,
+            zip: request.zip,
+          })
+        : null;
 
     const proposals = await prisma.proposal.findMany({
       where: { requestId: request.id },

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -88,6 +88,236 @@ test('POST /requests validates required request fields', async () => {
   }
 });
 
+test('POST /requests creates a specific request without ZIP when a marketing area is selected', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_specific',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_specific',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    }),
+  };
+
+  prismaModule.prisma.customerRequest = {
+    create: async ({ data }) => ({
+      id: 'request_specific_1',
+      ...data,
+      createdAt: new Date('2026-06-22T10:00:00.000Z'),
+      updatedAt: new Date('2026-06-22T10:00:00.000Z'),
+    }),
+  };
+
+  prismaModule.prisma.expert = {
+    findMany: async () => [],
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Need help with Google Ads',
+        description: 'Looking for a PPC specialist.',
+        marketingSubjectId: 'paid-ads-lead-generation',
+        subcategoryId: 'google-ads',
+        serviceTokens: ['paid-ads', 'google-ads'],
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.request.intakeMode, 'SPECIFIC');
+    assert.equal(body.request.marketingSubjectId, 'paid-ads-lead-generation');
+    assert.equal(body.request.subcategoryId, 'google-ads');
+    assert.equal(body.request.zip, null);
+    assert.equal(body.request.radiusMiles, null);
+    assert.equal(body.deliveryPreview, null);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.expert = originalExpert;
+    await fastify.close();
+  }
+});
+
+test('POST /requests creates an unsure request with ZIP and radius when no marketing area is selected', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_unsure',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_unsure',
+      name: 'Jamie Rivera',
+      businessName: 'Westmont Dental',
+    }),
+  };
+
+  prismaModule.prisma.customerRequest = {
+    create: async ({ data }) => ({
+      id: 'request_unsure_1',
+      ...data,
+      createdAt: new Date('2026-06-22T10:00:00.000Z'),
+      updatedAt: new Date('2026-06-22T10:00:00.000Z'),
+    }),
+  };
+
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Westmont',
+    state: 'IL',
+    zip: '60559',
+    latitude: 41.79,
+    longitude: -87.98,
+    geocodedAt: new Date('2026-06-22T10:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Not sure what kind of marketing help I need',
+        description: 'Need guidance for getting more leads.',
+        zip: '60559',
+        radiusMiles: 15,
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.request.intakeMode, 'UNSURE');
+    assert.equal(body.request.marketingSubjectId, null);
+    assert.equal(body.request.subcategoryId, null);
+    assert.deepEqual(body.request.serviceTokens, []);
+    assert.equal(body.request.zip, '60559');
+    assert.equal(body.request.radiusMiles, 15);
+    assert.equal(body.deliveryPreview, null);
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});
+
+test('POST /requests rejects unsure requests without ZIP', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_unsure_no_zip',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_unsure_no_zip',
+      name: 'Jamie Rivera',
+      businessName: null,
+    }),
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Need help',
+        description: 'Not sure what I need yet.',
+        radiusMiles: 15,
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().error, 'zip is required when no marketing area is selected');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    await fastify.close();
+  }
+});
+
+test('POST /requests rejects unsure requests without radius', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalCustomerProfile = prismaModule.prisma.customerProfile;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'customer_user_unsure_no_radius',
+    email: 'customer@example.com',
+    role: 'customer',
+  });
+
+  prismaModule.prisma.customerProfile = {
+    findUnique: async () => ({
+      id: 'customer_profile_unsure_no_radius',
+      name: 'Jamie Rivera',
+      businessName: null,
+    }),
+  };
+
+  geocodingModule.lookupZipLocation = async () => ({
+    ok: true,
+    city: 'Westmont',
+    state: 'IL',
+    zip: '60559',
+    latitude: 41.79,
+    longitude: -87.98,
+    geocodedAt: new Date('2026-06-22T10:00:00.000Z'),
+    geocodeProvider: 'geoapify',
+  });
+
+  try {
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/requests',
+      payload: {
+        title: 'Need help',
+        description: 'Not sure what I need yet.',
+        zip: '60559',
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.json().error, 'radiusMiles is required when no marketing area is selected');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.customerProfile = originalCustomerProfile;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});
+
 test('POST /requests creates a customer request for the signed-in customer', async () => {
   const fastify = await buildFastify();
 
@@ -120,9 +350,12 @@ test('POST /requests creates a customer request for the signed-in customer', asy
       requesterBusinessName: data.requesterBusinessName,
       title: data.title,
       description: data.description,
+      intakeMode: data.intakeMode,
       marketingSubjectId: data.marketingSubjectId,
+      subcategoryId: data.subcategoryId,
       serviceTokens: data.serviceTokens,
       zip: data.zip,
+      radiusMiles: data.radiusMiles,
       budgetLabel: data.budgetLabel,
       timelineLabel: data.timelineLabel,
       status: data.status,
@@ -205,6 +438,9 @@ test('POST /requests creates a customer request for the signed-in customer', asy
     assert.equal(body.request.id, 'request_1');
     assert.equal(body.request.requesterName, 'Jamie Rivera');
     assert.equal(body.request.requesterBusinessName, 'Westmont Dental');
+    assert.equal(body.request.intakeMode, 'SPECIFIC');
+    assert.equal(body.request.subcategoryId, null);
+    assert.equal(body.request.radiusMiles, null);
     assert.equal(body.request.status, 'ACTIVE');
     assert.equal(body.deliveryPreview.matchingModel, 'city-zip-service-v1');
     assert.equal(body.deliveryPreview.totalMatches, 2);
@@ -242,9 +478,12 @@ test('GET /requests lists only the signed-in customer requests', async () => {
         {
           id: 'request_2',
           title: 'Need local SEO help',
+          intakeMode: 'SPECIFIC',
           marketingSubjectId: 'local-search-seo',
+          subcategoryId: null,
           serviceTokens: ['seo', 'local-seo'],
           zip: '60601',
+          radiusMiles: null,
           status: 'ACTIVE',
           createdAt: new Date('2026-05-24T15:00:00.000Z'),
           updatedAt: new Date('2026-05-24T15:00:00.000Z'),
@@ -268,6 +507,9 @@ test('GET /requests lists only the signed-in customer requests', async () => {
     assert.equal(body.ok, true);
     assert.equal(body.data.length, 1);
     assert.equal(body.data[0].id, 'request_2');
+    assert.equal(body.data[0].intakeMode, 'SPECIFIC');
+    assert.equal(body.data[0].subcategoryId, null);
+    assert.equal(body.data[0].radiusMiles, null);
     assert.deepEqual(body.data[0].proposalSummary, {
       total: 2,
       pending: 1,
@@ -304,9 +546,12 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
         id: 'request_3',
         title: 'Need creator support for a restaurant launch',
         description: 'Looking for local creators who can visit and post.',
+        intakeMode: 'SPECIFIC',
         marketingSubjectId: 'creator-influencer-marketing',
+        subcategoryId: null,
         serviceTokens: ['creator-marketing', 'local-influencer'],
         zip: '60614',
+        radiusMiles: null,
         budgetLabel: '$1k-$2k',
         timelineLabel: 'Next 30 days',
         status: 'ACTIVE',
@@ -374,7 +619,10 @@ test('GET /requests/:id only returns a request owned by the signed-in customer',
     const body = response.json();
     assert.equal(body.ok, true);
     assert.equal(body.request.id, 'request_3');
+    assert.equal(body.request.intakeMode, 'SPECIFIC');
     assert.equal(body.request.marketingSubjectId, 'creator-influencer-marketing');
+    assert.equal(body.request.subcategoryId, null);
+    assert.equal(body.request.radiusMiles, null);
     assert.equal(body.deliveryPreview.totalMatches, 2);
     assert.equal(body.deliveryPreview.matchedExperts[0].primaryReason, 'same_city');
     assert.equal(body.deliveryPreview.matchedExperts[1].primaryReason, 'serves_nationwide');


### PR DESCRIPTION
## Summary
- add `CustomerRequestIntakeMode` plus `subcategoryId` and `radiusMiles` to customer requests
- update `POST /requests` to support specific requests without ZIP and unsure requests with ZIP + radius
- return the new intake fields from customer request list/detail APIs and keep matching preview logic safe for nullable ZIPs
- update request route coverage and align messaging typing with the nullable request category field

## Why
MM-113 adds the backend foundation for the new request intake flow before the frontend work lands. The current contract requires every request to include a marketing category, service tokens, and a ZIP, which blocks the approved unsure path.

## Validation
- `node --test tests/requests.test.js`
- `npm run build`
- `npx prisma validate`
- `npm run prisma:generate`

## Notes
- includes the Prisma migration for the new request intake schema
- README and local planning docs were left out of this PR on purpose