### PR TITLE
MM-114 update customer request intake form

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -5,6 +5,7 @@ import { getUserFromRequest } from '../lib/session';
 import { lookupZipLocation } from '../lib/geocoding';
 
 const ZIP_RE = /^\d{5}$/;
+const MAX_REQUEST_SERVICE_TOKENS = 24;
 
 type RequestMatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
 
@@ -298,7 +299,9 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     if (description.length > 4000) return reply.code(400).send({ ok: false, error: 'description is too long' });
     if (marketingSubjectId && marketingSubjectId.length > 80) return reply.code(400).send({ ok: false, error: 'marketingSubjectId is too long' });
     if (subcategoryId && subcategoryId.length > 80) return reply.code(400).send({ ok: false, error: 'subcategoryId is too long' });
-    if (serviceTokens.length > 12) return reply.code(400).send({ ok: false, error: 'serviceTokens cannot exceed 12 items' });
+    if (serviceTokens.length > MAX_REQUEST_SERVICE_TOKENS) {
+      return reply.code(400).send({ ok: false, error: `serviceTokens cannot exceed ${MAX_REQUEST_SERVICE_TOKENS} items` });
+    }
     if (serviceTokens.some((token) => token.length > 80)) return reply.code(400).send({ ok: false, error: 'serviceTokens contains an item that is too long' });
     if (zip && !ZIP_RE.test(zip)) return reply.code(400).send({ ok: false, error: 'zip must be a valid 5-digit ZIP code' });
     if (budgetLabel && budgetLabel.length > 80) return reply.code(400).send({ ok: false, error: 'budgetLabel is too long' });

--- a/marketlink-frontend/src/app/dashboard/customer/proposals/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/proposals/page.tsx
@@ -24,7 +24,7 @@ type ProposalInboxItem = {
   request: {
     id: string;
     title: string;
-    marketingSubjectId: string;
+    marketingSubjectId?: string | null;
     status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
   };
   expert: {
@@ -148,7 +148,7 @@ export default async function CustomerProposalsPage() {
         {proposals.length ? (
           <section className="mt-5 grid gap-4">
             {proposals.map((proposal) => {
-              const subject = getMarketingSubjectById(proposal.request.marketingSubjectId);
+              const subject = getMarketingSubjectById(proposal.request.marketingSubjectId || '');
               return (
                 <article key={proposal.id} className="ml-card rounded-[28px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -158,7 +158,7 @@ export default async function CustomerProposalsPage() {
                           {formatProposalStatus(proposal.status)}
                         </span>
                         <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                          {subject?.label || proposal.request.marketingSubjectId}
+                          {subject?.label || 'Not sure yet'}
                         </span>
                         {proposal.expert.verified ? (
                           <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">

--- a/marketlink-frontend/src/app/dashboard/customer/requests/CustomerRequestForm.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/CustomerRequestForm.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
-  formatServiceTokenLabel,
   getMarketingSubjectById,
   getServiceTokensForSubject,
   getServiceTokensForSubcategory,
@@ -16,30 +15,49 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
 
 const budgetOptions = ['Under $1k', '$1k-$2k', '$2k-$5k', '$5k-$10k', '$10k+'] as const;
 const timelineOptions = ['ASAP', 'This month', 'Next 30 days', 'Next quarter', 'Just researching'] as const;
+const radiusOptions = [5, 10, 20, 50, 100] as const;
 
 type CustomerRequestFormProps = {
   returnHref?: string;
 };
 
+type IntakeMode = 'specific' | 'unsure';
+
 function getRequestServiceTokens(subjectId: string, subcategoryId: string) {
-  return subcategoryId ? getServiceTokensForSubcategory(subjectId, subcategoryId) : getServiceTokensForSubject(subjectId);
+  if (!subjectId) return [];
+
+  return subcategoryId
+    ? getServiceTokensForSubcategory(subjectId, subcategoryId)
+    : getMarketingSubjectById(subjectId)?.serviceTokens ?? getServiceTokensForSubject(subjectId);
+}
+
+function getPathCardClass(active: boolean) {
+  return active
+    ? 'rounded-[24px] border border-slate-900 bg-slate-900 px-5 py-5 text-left text-white shadow-[0_16px_34px_rgba(15,23,42,0.16)]'
+    : 'rounded-[24px] border border-slate-200/80 bg-white px-5 py-5 text-left text-slate-900 shadow-[0_12px_24px_rgba(15,23,42,0.05)] transition hover:border-slate-300 hover:bg-slate-50';
 }
 
 export default function CustomerRequestForm({ returnHref = '/dashboard/customer/requests' }: CustomerRequestFormProps) {
   const router = useRouter();
+  const [intakeMode, setIntakeMode] = useState<IntakeMode>('specific');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [subjectId, setSubjectId] = useState(marketingSubjects[0]?.id ?? '');
+  const [subjectId, setSubjectId] = useState('');
   const [subcategoryId, setSubcategoryId] = useState('');
   const [zip, setZip] = useState('');
+  const [radiusMiles, setRadiusMiles] = useState(String(radiusOptions[1]));
   const [budgetLabel, setBudgetLabel] = useState('');
   const [timelineLabel, setTimelineLabel] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const subject = getMarketingSubjectById(subjectId);
-  const subcategories = getSubcategoriesForSubject(subjectId);
+  const fieldClassName = 'ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900';
+
+  const subject = subjectId ? getMarketingSubjectById(subjectId) : null;
+  const subcategories = subjectId ? getSubcategoriesForSubject(subjectId) : [];
+  const selectedSubcategory = subcategories.find((item) => item.id === subcategoryId) ?? null;
   const selectedServiceTokens = useMemo(() => getRequestServiceTokens(subjectId, subcategoryId), [subjectId, subcategoryId]);
+  const cleanZip = zip.replace(/\D/g, '').slice(0, 5);
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -47,48 +65,66 @@ export default function CustomerRequestForm({ returnHref = '/dashboard/customer/
 
     const cleanTitle = title.trim();
     const cleanDescription = description.trim();
-    const cleanZip = zip.trim();
 
     if (!cleanTitle) {
-      setError('Title is required.');
+      setError('Add a short title for the request.');
       return;
     }
 
     if (!cleanDescription) {
-      setError('Description is required.');
+      setError('Add a few details so providers understand what you need.');
       return;
     }
 
-    if (!subjectId) {
-      setError('Marketing area is required.');
-      return;
-    }
+    if (intakeMode === 'specific') {
+      if (!subjectId) {
+        setError('Choose a marketing area, or switch to the "I am not sure yet" card at the top of the form.');
+        return;
+      }
 
-    if (!/^\d{5}$/.test(cleanZip)) {
-      setError('ZIP must be 5 digits.');
-      return;
-    }
+      if (!selectedServiceTokens.length) {
+        setError('Choose a marketing area or a specific help type before continuing.');
+        return;
+      }
+    } else {
+      if (!/^\d{5}$/.test(cleanZip)) {
+        setError('Enter a valid 5-digit ZIP code for the unsure path.');
+        return;
+      }
 
-    if (!selectedServiceTokens.length) {
-      setError('Choose a marketing area or specific help option.');
-      return;
+      if (!radiusMiles) {
+        setError('Choose how far out to search.');
+        return;
+      }
     }
 
     setSaving(true);
     try {
+      const payload =
+        intakeMode === 'specific'
+          ? {
+              title: cleanTitle,
+              description: cleanDescription,
+              marketingSubjectId: subjectId,
+              subcategoryId: subcategoryId || undefined,
+              serviceTokens: selectedServiceTokens,
+              budgetLabel: budgetLabel || undefined,
+              timelineLabel: timelineLabel || undefined,
+            }
+          : {
+              title: cleanTitle,
+              description: cleanDescription,
+              zip: cleanZip,
+              radiusMiles: Number(radiusMiles),
+              budgetLabel: budgetLabel || undefined,
+              timelineLabel: timelineLabel || undefined,
+            };
+
       const response = await fetch(`${API_BASE}/requests`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          title: cleanTitle,
-          description: cleanDescription,
-          marketingSubjectId: subjectId,
-          serviceTokens: selectedServiceTokens,
-          zip: cleanZip,
-          budgetLabel: budgetLabel || undefined,
-          timelineLabel: timelineLabel || undefined,
-        }),
+        body: JSON.stringify(payload),
       });
 
       const body = (await response.json().catch(() => ({}))) as { error?: string; request?: { id?: string } };
@@ -106,14 +142,39 @@ export default function CustomerRequestForm({ returnHref = '/dashboard/customer/
   }
 
   return (
-    <form onSubmit={handleSubmit} className="grid gap-5">
+    <form onSubmit={handleSubmit} className="grid gap-6">
+      <section className="grid gap-3">
+        <div>
+          <div className="text-sm font-medium text-slate-700">How do you want to start?</div>
+          <p className="mt-1 text-sm leading-6 text-slate-500">Pick the path that feels easiest right now. You do not need to overfill this form.</p>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          <button type="button" onClick={() => setIntakeMode('specific')} className={getPathCardClass(intakeMode === 'specific')}>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">Specific path</div>
+            <div className="mt-2 text-xl font-semibold tracking-tight">I know the kind of help I need</div>
+            <p className={`mt-2 text-sm leading-6 ${intakeMode === 'specific' ? 'text-white/78' : 'text-slate-600'}`}>
+              Choose a marketing area first, then narrow it down only if you want.
+            </p>
+          </button>
+
+          <button type="button" onClick={() => setIntakeMode('unsure')} className={getPathCardClass(intakeMode === 'unsure')}>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">Unsure path</div>
+            <div className="mt-2 text-xl font-semibold tracking-tight">I am not sure yet</div>
+            <p className={`mt-2 text-sm leading-6 ${intakeMode === 'unsure' ? 'text-white/78' : 'text-slate-600'}`}>
+              Start with the problem and where the business is located. We will keep it broad.
+            </p>
+          </button>
+        </div>
+      </section>
+
       <div className="grid gap-2">
         <label htmlFor="request-title" className="text-sm font-medium text-slate-700">
           Request title
         </label>
         <input
           id="request-title"
-          className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+          className={fieldClassName}
           value={title}
           onChange={(event) => setTitle(event.target.value)}
           maxLength={140}
@@ -126,84 +187,123 @@ export default function CustomerRequestForm({ returnHref = '/dashboard/customer/
         </label>
         <textarea
           id="request-description"
-          className="ml-input min-h-36 w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+          className={`${fieldClassName} min-h-36`}
           value={description}
           onChange={(event) => setDescription(event.target.value)}
           maxLength={4000}
         />
       </div>
 
-      <div className="grid gap-5 md:grid-cols-2">
-        <div className="grid gap-2">
-          <label htmlFor="request-subject" className="text-sm font-medium text-slate-700">
-            Marketing area
-          </label>
-          <select
-            id="request-subject"
-            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
-            value={subjectId}
-            onChange={(event) => {
-              setSubjectId(event.target.value);
-              setSubcategoryId('');
-            }}
-          >
-            {marketingSubjects.map((item) => (
-              <option key={item.id} value={item.id}>
-                {item.label}
-              </option>
-            ))}
-          </select>
-          {subject ? <p className="text-xs text-slate-500">{subject.shortDescription}</p> : null}
-        </div>
+      {intakeMode === 'specific' ? (
+        <section className="grid gap-5 rounded-[28px] border border-slate-200/80 bg-slate-50/70 p-5">
+          <div>
+            <div className="text-sm font-medium text-slate-800">Specific request setup</div>
+            <p className="mt-1 text-sm leading-6 text-slate-500">Start with the broader area. Specific help stays optional, and it unlocks only after the parent area is chosen.</p>
+          </div>
 
-        <div className="grid gap-2">
-          <label htmlFor="request-subcategory" className="text-sm font-medium text-slate-700">
-            Specific help
-          </label>
-          <select
-            id="request-subcategory"
-            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
-            value={subcategoryId}
-            onChange={(event) => setSubcategoryId(event.target.value)}
-          >
-            <option value="">Keep it broad</option>
-            {subcategories.map((item) => (
-              <option key={item.id} value={item.id}>
-                {item.label}
-              </option>
-            ))}
-          </select>
-          <p className="text-xs text-slate-500">Optional. Choose this if you already know the exact kind of help you want.</p>
-        </div>
-      </div>
+          <div className="grid gap-5 md:grid-cols-2">
+            <div className="grid gap-2">
+              <label htmlFor="request-subject" className="text-sm font-medium text-slate-700">
+                Marketing area
+              </label>
+              <select
+                id="request-subject"
+                className={fieldClassName}
+                value={subjectId}
+                onChange={(event) => {
+                  setSubjectId(event.target.value);
+                  setSubcategoryId('');
+                }}
+              >
+                <option value=""></option>
+                {marketingSubjects.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs leading-6 text-slate-500">{subject ? subject.shortDescription : 'Pick the closest area first. You can keep the request broad if that is enough.'}</p>
+            </div>
 
-      <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
-        <div className="grid gap-2">
-          <label htmlFor="request-zip" className="text-sm font-medium text-slate-700">
-            ZIP
-          </label>
-          <input
-            id="request-zip"
-            inputMode="numeric"
-            pattern="\d{5}"
-            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
-            value={zip}
-            onChange={(event) => setZip(event.target.value)}
-            maxLength={5}
-          />
-        </div>
+            <div className="grid gap-2">
+              <label htmlFor="request-subcategory" className="text-sm font-medium text-slate-700">
+                Specific help
+              </label>
+              <select
+                id="request-subcategory"
+                className={fieldClassName}
+                value={subcategoryId}
+                onChange={(event) => setSubcategoryId(event.target.value)}
+                disabled={!subjectId}
+              >
+                <option value=""></option>
+                {subcategories.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs leading-6 text-slate-500">
+                {selectedSubcategory ? selectedSubcategory.shortDescription : 'Optional. Use this only if you already know the exact type of help you want.'}
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : (
+        <section className="grid gap-5 rounded-[28px] border border-slate-200/80 bg-slate-50/70 p-5">
+          <div>
+            <div className="text-sm font-medium text-slate-800">Unsure request setup</div>
+            <p className="mt-1 text-sm leading-6 text-slate-500">If you do not know the category yet, keep the request broad and tell us where to start looking.</p>
+          </div>
 
+          <div className="grid gap-5 md:grid-cols-[minmax(0,220px)_180px] md:items-end">
+            <div className="grid gap-2">
+              <label htmlFor="request-zip" className="text-sm font-medium text-slate-700">
+                ZIP code
+              </label>
+              <input
+                id="request-zip"
+                inputMode="numeric"
+                pattern="\d{5}"
+                className={fieldClassName}
+                value={zip}
+                onChange={(event) => setZip(event.target.value.replace(/\D/g, '').slice(0, 5))}
+                maxLength={5}
+              />
+              <p className={`text-xs leading-6 ${zip.length > 0 && cleanZip.length < 5 ? 'text-red-600' : 'text-slate-500'}`}>
+                {zip.length > 0 && cleanZip.length < 5 ? 'Enter the full 5-digit ZIP code.' : 'Required for the unsure path so the request stays local.'}
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <label htmlFor="request-radius" className="text-sm font-medium text-slate-700">
+                Search radius
+              </label>
+              <select id="request-radius" className={fieldClassName} value={radiusMiles} onChange={(event) => setRadiusMiles(event.target.value)}>
+                {radiusOptions.map((option) => (
+                  <option key={option} value={option}>
+                    Within {option} miles
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs leading-6 text-slate-500">We will treat this as the local search area for the request.</p>
+            </div>
+          </div>
+        </section>
+      )}
+
+      <div className="grid gap-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div className="grid gap-2">
           <label htmlFor="request-budget" className="text-sm font-medium text-slate-700">
             Budget
           </label>
           <select
             id="request-budget"
-            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            className={fieldClassName}
             value={budgetLabel}
             onChange={(event) => setBudgetLabel(event.target.value)}
           >
-            <option value="">Optional</option>
+            <option value=""></option>
             {budgetOptions.map((option) => (
               <option key={option} value={option}>
                 {option}
@@ -218,11 +318,11 @@ export default function CustomerRequestForm({ returnHref = '/dashboard/customer/
           </label>
           <select
             id="request-timeline"
-            className="ml-input w-full rounded-2xl px-4 py-3 text-sm text-slate-900"
+            className={fieldClassName}
             value={timelineLabel}
             onChange={(event) => setTimelineLabel(event.target.value)}
           >
-            <option value="">Optional</option>
+            <option value=""></option>
             {timelineOptions.map((option) => (
               <option key={option} value={option}>
                 {option}
@@ -232,19 +332,37 @@ export default function CustomerRequestForm({ returnHref = '/dashboard/customer/
         </div>
       </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-        <div className="text-sm font-semibold text-slate-900">This request will be matched using</div>
-        <div className="mt-2 flex flex-wrap gap-2">
-          {selectedServiceTokens.map((token) => (
-            <span
-              key={token}
-              className="inline-flex rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
-            >
-              {formatServiceTokenLabel(token)}
-            </span>
-          ))}
-        </div>
-      </div>
+      <section className="rounded-[28px] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(248,250,252,0.96),rgba(255,255,255,0.9))] px-5 py-5">
+        <div className="text-sm font-semibold text-slate-900">{intakeMode === 'specific' ? 'This request will use these matching tags' : 'This request will stay broad for now'}</div>
+        {intakeMode === 'specific' ? (
+          subject ? (
+            <div className="mt-3 grid gap-3">
+              <div className="flex flex-wrap gap-2">
+                <span className="inline-flex rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                  {subject.label}
+                </span>
+                {selectedSubcategory ? (
+                  <span className="inline-flex rounded-xl bg-white px-3 py-1 text-xs font-medium text-slate-700 ring-1 ring-slate-200">
+                    {selectedSubcategory.label}
+                  </span>
+                ) : null}
+              </div>
+              <p className="text-sm leading-6 text-slate-500">
+                {selectedSubcategory
+                  ? 'MarketLink will use the selected area and help type to match this request behind the scenes.'
+                  : 'This will stay broad inside the selected marketing area. Internal matching tags are applied behind the scenes.'}
+              </p>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-slate-500">Choose a marketing area to generate the matching tags for this request.</p>
+          )
+        ) : (
+          <div className="mt-3 grid gap-2 text-sm leading-6 text-slate-600">
+            <p>We will save this as an open request without locking it into one marketing category yet.</p>
+            <p>{cleanZip ? `Current local starting point: ZIP ${cleanZip} within ${radiusMiles} miles.` : 'Add a ZIP code and radius above to finish the unsure path.'}</p>
+          </div>
+        )}
+      </section>
 
       {error ? (
         <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">

--- a/marketlink-frontend/src/app/dashboard/customer/requests/new/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/new/page.tsx
@@ -44,7 +44,7 @@ export default async function CustomerNewRequestPage() {
               <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
               <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Create a request</h1>
               <p className="max-w-2xl text-sm leading-6 text-slate-600">
-                Keep this simple. Tell us the problem, the marketing area, and where the business is located, then MarketLink will show the first plausible expert matches privately inside your dashboard.
+                Keep this simple. If you know the kind of help you want, choose it. If not, start broad with your ZIP code and radius, and keep the request easy to understand.
               </p>
             </div>
 
@@ -61,8 +61,8 @@ export default async function CustomerNewRequestPage() {
                 <p className="mt-1 text-sm leading-6 text-slate-600">Requests stay inside your customer dashboard. Nothing here becomes a public marketplace page.</p>
               </div>
               <div className="ml-surface-muted rounded-2xl p-4">
-                <div className="text-sm font-semibold text-slate-900">Locality is MVP-simple</div>
-                <p className="mt-1 text-sm leading-6 text-slate-600">Matching currently uses service tags plus same ZIP, same city, nationwide coverage, or remote-friendly service area.</p>
+                <div className="text-sm font-semibold text-slate-900">Two ways to start</div>
+                <p className="mt-1 text-sm leading-6 text-slate-600">Use the specific path when you know the marketing area. Use the unsure path when you just want nearby help without picking a category first.</p>
               </div>
             </div>
 

--- a/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/page.tsx
@@ -13,9 +13,12 @@ type SummaryResponse = {
 type RequestHistoryItem = {
   id: string;
   title: string;
-  marketingSubjectId: string;
+  intakeMode: 'SPECIFIC' | 'UNSURE';
+  marketingSubjectId?: string | null;
+  subcategoryId?: string | null;
   serviceTokens: string[];
-  zip: string;
+  zip?: string | null;
+  radiusMiles?: number | null;
   status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
   createdAt: string;
   updatedAt: string;
@@ -44,6 +47,23 @@ function formatShortDate(value: string) {
     day: 'numeric',
     year: 'numeric',
   });
+}
+
+function getRequestAreaLabel(request: RequestHistoryItem) {
+  const subject = request.marketingSubjectId ? getMarketingSubjectById(request.marketingSubjectId) : null;
+  const subcategory = request.subcategoryId ? subject?.subcategories.find((item) => item.id === request.subcategoryId) ?? null : null;
+
+  if (subcategory) return subcategory.label;
+  if (subject) return subject.label;
+  if (request.intakeMode === 'UNSURE') return 'Not sure yet';
+  return 'General request';
+}
+
+function getRequestLocationLabel(request: RequestHistoryItem) {
+  if (request.zip && request.radiusMiles) return `ZIP ${request.zip} • ${request.radiusMiles} miles`;
+  if (request.zip) return `ZIP ${request.zip}`;
+  if (request.intakeMode === 'UNSURE') return 'Open local request';
+  return 'Specific request';
 }
 
 export default async function CustomerRequestsPage() {
@@ -125,48 +145,47 @@ export default async function CustomerRequestsPage() {
           </section>
         ) : (
           <section className="mt-5 grid gap-4">
-            {requests.map((request) => {
-              const subject = getMarketingSubjectById(request.marketingSubjectId);
-              return (
-                <Link
-                  key={request.id}
-                  href={`/dashboard/customer/requests/view?id=${encodeURIComponent(request.id)}`}
-                  className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(23,26,31,0.08)]"
-                >
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <div className="flex flex-wrap gap-2">
-                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                          {formatRequestStatus(request.status)}
+            {requests.map((request) => (
+              <Link
+                key={request.id}
+                href={`/dashboard/customer/requests/view?id=${encodeURIComponent(request.id)}`}
+                className="ml-card rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)] transition hover:-translate-y-0.5 hover:shadow-[0_22px_48px_rgba(23,26,31,0.08)]"
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <div className="flex flex-wrap gap-2">
+                      <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                        {formatRequestStatus(request.status)}
+                      </span>
+                      <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                        {getRequestAreaLabel(request)}
+                      </span>
+                      {request.proposalSummary.pending > 0 ? (
+                        <span className="inline-flex rounded-xl bg-amber-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700 ring-1 ring-amber-200">
+                          {request.proposalSummary.pending} needs decision
                         </span>
-                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                          {subject?.label || request.marketingSubjectId}
+                      ) : request.proposalSummary.accepted > 0 ? (
+                        <span className="inline-flex rounded-xl bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 ring-1 ring-emerald-200">
+                          Proposal accepted
                         </span>
-                        {request.proposalSummary.pending > 0 ? (
-                          <span className="inline-flex rounded-xl bg-amber-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700 ring-1 ring-amber-200">
-                            {request.proposalSummary.pending} needs decision
-                          </span>
-                        ) : request.proposalSummary.accepted > 0 ? (
-                          <span className="inline-flex rounded-xl bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 ring-1 ring-emerald-200">
-                            Proposal accepted
-                          </span>
-                        ) : request.proposalSummary.total > 0 ? (
-                          <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                            {request.proposalSummary.total} proposal{request.proposalSummary.total === 1 ? '' : 's'}
-                          </span>
-                        ) : null}
-                      </div>
-                      <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{request.title}</h2>
-                      <p className="mt-2 text-sm text-slate-600">
-                        Created {formatShortDate(request.createdAt)} • ZIP {request.zip}
-                      </p>
+                      ) : request.proposalSummary.total > 0 ? (
+                        <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                          {request.proposalSummary.total} proposal{request.proposalSummary.total === 1 ? '' : 's'}
+                        </span>
+                      ) : null}
                     </div>
-
-                    <span className="text-sm font-semibold text-slate-900">
-                      {request.proposalSummary.pending > 0 ? 'Review proposals' : 'Open'}
-                    </span>
+                    <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">{request.title}</h2>
+                    <p className="mt-2 text-sm text-slate-600">
+                      Created {formatShortDate(request.createdAt)} • {getRequestLocationLabel(request)}
+                    </p>
                   </div>
 
+                  <span className="text-sm font-semibold text-slate-900">
+                    {request.proposalSummary.pending > 0 ? 'Review proposals' : 'Open'}
+                  </span>
+                </div>
+
+                {request.serviceTokens.length ? (
                   <div className="mt-4 flex flex-wrap gap-2">
                     {request.serviceTokens.slice(0, 4).map((token) => (
                       <span
@@ -177,9 +196,11 @@ export default async function CustomerRequestsPage() {
                       </span>
                     ))}
                   </div>
-                </Link>
-              );
-            })}
+                ) : (
+                  <p className="mt-4 text-sm leading-6 text-slate-500">This request started broad, without a specific marketing category yet.</p>
+                )}
+              </Link>
+            ))}
           </section>
         )}
       </div>

--- a/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
+++ b/marketlink-frontend/src/app/dashboard/customer/requests/view/page.tsx
@@ -34,24 +34,29 @@ type DeliveryPreview = {
   }>;
 };
 
+type RequestDetail = {
+  id: string;
+  requesterName: string;
+  requesterBusinessName?: string | null;
+  title: string;
+  description: string;
+  intakeMode: 'SPECIFIC' | 'UNSURE';
+  marketingSubjectId?: string | null;
+  subcategoryId?: string | null;
+  serviceTokens: string[];
+  zip?: string | null;
+  radiusMiles?: number | null;
+  budgetLabel?: string | null;
+  timelineLabel?: string | null;
+  status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
+  createdAt: string;
+  updatedAt: string;
+};
+
 type RequestDetailResponse = {
   ok?: boolean;
-  request?: {
-    id: string;
-    requesterName: string;
-    requesterBusinessName?: string | null;
-    title: string;
-    description: string;
-    marketingSubjectId: string;
-    serviceTokens: string[];
-    zip: string;
-    budgetLabel?: string | null;
-    timelineLabel?: string | null;
-    status: 'ACTIVE' | 'CLOSED' | 'CANCELLED';
-    createdAt: string;
-    updatedAt: string;
-  };
-  deliveryPreview?: DeliveryPreview;
+  request?: RequestDetail;
+  deliveryPreview?: DeliveryPreview | null;
   proposals?: Array<{
     id: string;
     requestId: string;
@@ -96,7 +101,7 @@ function formatReason(reason: DeliveryPreview['matchedExperts'][number]['primary
   }
 }
 
-function formatStatus(status: NonNullable<RequestDetailResponse['request']>['status']) {
+function formatStatus(status: RequestDetail['status']) {
   if (status === 'ACTIVE') return 'Active';
   if (status === 'CLOSED') return 'Closed';
   return 'Cancelled';
@@ -117,6 +122,32 @@ function formatExpertType(value?: string | null) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
     .join(' ');
+}
+
+function getRequestAreaDetails(request: RequestDetail) {
+  const subject = request.marketingSubjectId ? getMarketingSubjectById(request.marketingSubjectId) : null;
+  const subcategory = request.subcategoryId ? subject?.subcategories.find((item) => item.id === request.subcategoryId) ?? null : null;
+
+  return {
+    subject,
+    subcategory,
+    label: subcategory?.label || subject?.label || (request.intakeMode === 'UNSURE' ? 'Not sure yet' : 'General request'),
+  };
+}
+
+function getLocationSummary(request: RequestDetail) {
+  if (request.zip && request.radiusMiles) return `ZIP ${request.zip} • ${request.radiusMiles} mile radius`;
+  if (request.zip) return `ZIP ${request.zip}`;
+  if (request.intakeMode === 'UNSURE') return 'Open local request';
+  return 'Specific request';
+}
+
+function getPreviewEmptyMessage(request: RequestDetail) {
+  if (request.intakeMode === 'UNSURE') {
+    return 'This request started broad. The location is saved, and the next matching step can use it without locking the request into one category.';
+  }
+
+  return 'No matching preview is available for this request yet. Providers can still respond privately through the normal request flow.';
 }
 
 export default async function CustomerRequestDetailPage({
@@ -172,7 +203,7 @@ export default async function CustomerRequestDetailPage({
     throw new Error('Customer request payload was missing.');
   }
 
-  const subject = getMarketingSubjectById(request.marketingSubjectId);
+  const areaDetails = getRequestAreaDetails(request);
   const preview = data.deliveryPreview;
   const proposals = data.proposals || [];
   const pendingProposalCount = proposals.filter((proposal) => proposal.status === 'PENDING').length;
@@ -185,7 +216,7 @@ export default async function CustomerRequestDetailPage({
             <p className="text-xs font-semibold uppercase tracking-[0.32em] text-slate-500">Customer requests</p>
             <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">{request.title}</h1>
             <p className="mt-3 text-sm leading-6 text-slate-600">
-              Created {formatShortDate(request.createdAt)} • {formatStatus(request.status)} • ZIP {request.zip}
+              Created {formatShortDate(request.createdAt)} • {formatStatus(request.status)} • {getLocationSummary(request)}
             </p>
           </div>
 
@@ -206,7 +237,10 @@ export default async function CustomerRequestDetailPage({
                 {formatStatus(request.status)}
               </span>
               <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                {subject?.label || request.marketingSubjectId}
+                {areaDetails.label}
+              </span>
+              <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
+                {request.intakeMode === 'UNSURE' ? 'Unsure path' : 'Specific path'}
               </span>
             </div>
 
@@ -218,8 +252,12 @@ export default async function CustomerRequestDetailPage({
 
               <div className="space-y-4">
                 <div>
+                  <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request path</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">{request.intakeMode === 'UNSURE' ? 'Not sure yet' : 'Specific marketing area selected'}</div>
+                </div>
+                <div>
                   <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Business location</div>
-                  <div className="mt-1 text-sm font-medium text-slate-900">ZIP {request.zip}</div>
+                  <div className="mt-1 text-sm font-medium text-slate-900">{getLocationSummary(request)}</div>
                 </div>
                 <div>
                   <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Budget</div>
@@ -234,33 +272,39 @@ export default async function CustomerRequestDetailPage({
 
             <div className="mt-5">
               <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Matching tags</div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {request.serviceTokens.map((token) => (
-                  <span
-                    key={token}
-                    className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
-                  >
-                    {formatServiceTokenLabel(token)}
-                  </span>
-                ))}
-              </div>
+              {request.serviceTokens.length ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {request.serviceTokens.map((token) => (
+                    <span
+                      key={token}
+                      className="inline-flex rounded-xl bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200"
+                    >
+                      {formatServiceTokenLabel(token)}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-2 text-sm leading-6 text-slate-500">This request was kept broad, so there are no category tags attached yet.</p>
+              )}
             </div>
           </section>
 
           <aside className="ml-card rounded-[28px] p-6 shadow-[0_18px_50px_rgba(23,26,31,0.06)]">
             <div className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">Matching preview</div>
             <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
-              {preview?.totalMatches ?? 0} plausible match{preview?.totalMatches === 1 ? '' : 'es'}
+              {preview ? `${preview.totalMatches} plausible match${preview.totalMatches === 1 ? '' : 'es'}` : 'Preview not available yet'}
             </h2>
             <p className="mt-2 text-sm leading-6 text-slate-600">
-              This preview is private and based on the current MVP model: service tags plus ZIP, city, nationwide coverage, or remote-friendly service area.
+              {preview
+                ? 'This preview is private and based on the current MVP model: service tags plus ZIP, city, nationwide coverage, or remote-friendly service area.'
+                : getPreviewEmptyMessage(request)}
             </p>
 
             {preview?.requestLocation ? (
               <div className="mt-4 rounded-2xl bg-slate-50 px-4 py-4">
                 <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">Request location</div>
                 <div className="mt-2 text-sm font-medium text-slate-900">
-                  {[preview.requestLocation.city, preview.requestLocation.state].filter(Boolean).join(', ') || `ZIP ${request.zip}`}
+                  {[preview.requestLocation.city, preview.requestLocation.state].filter(Boolean).join(', ') || getLocationSummary(request)}
                 </div>
               </div>
             ) : null}
@@ -424,9 +468,7 @@ export default async function CustomerRequestDetailPage({
             </div>
           ) : (
             <div className="ml-card mt-4 rounded-[24px] p-5 shadow-[0_18px_44px_rgba(23,26,31,0.05)]">
-              <p className="text-sm leading-6 text-slate-600">
-                No plausible matches showed up yet. Try broadening the marketing area, adjusting the ZIP, or browsing experts directly.
-              </p>
+              <p className="text-sm leading-6 text-slate-600">{getPreviewEmptyMessage(request)}</p>
             </div>
           )}
         </section>

--- a/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
+++ b/marketlink-frontend/src/components/chat/ConversationWorkspace.tsx
@@ -29,7 +29,7 @@ export type ConversationSummary = {
   request: {
     id: string;
     title: string;
-    marketingSubjectId: string;
+    marketingSubjectId?: string | null;
     customerProfile?: {
       name?: string | null;
       businessName?: string | null;
@@ -580,7 +580,7 @@ export default function ConversationWorkspace({
 
         <div className="mt-4 grid gap-3">
           {conversations.map((conversation) => {
-            const subject = getMarketingSubjectById(conversation.request.marketingSubjectId);
+            const subject = getMarketingSubjectById(conversation.request.marketingSubjectId || '');
             const isSelected = conversation.id === selectedConversationId;
 
             return (
@@ -624,7 +624,7 @@ export default function ConversationWorkspace({
                     </span>
                   ) : null}
                   <span className={`inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] ${isSelected ? 'bg-white/10 text-white/80' : 'bg-slate-100 text-slate-500'}`}>
-                    {subject?.label || conversation.request.marketingSubjectId}
+                    {subject?.label || 'Not sure yet'}
                   </span>
                   {conversation.proposal?.priceLabel ? (
                     <span className={`inline-flex rounded-xl px-3 py-1 text-[11px] font-medium ${isSelected ? 'bg-white/10 text-white/80' : 'bg-slate-100 text-slate-500'}`}>
@@ -678,7 +678,7 @@ export default function ConversationWorkspace({
 
                   <div className="mt-1 flex flex-wrap gap-2 xl:mt-0">
                     <span className="ml-pill inline-flex rounded-xl px-3 py-1 text-[11px] font-medium uppercase tracking-[0.16em] text-slate-500">
-                      {selectedSubject?.label || selectedSummary.request.marketingSubjectId}
+                      {selectedSubject?.label || 'Not sure yet'}
                     </span>
                     <span
                       className={


### PR DESCRIPTION
## Summary
- add the specific-vs-unsure customer request intake flow with blank top-level selections and locked subcategory behavior until a marketing area is chosen
- require ZIP and radius only for the unsure path, while keeping specific requests category-driven and updating the request detail/history/proposal/chat UI for nullable marketing areas
- raise the backend request service token cap to 24 so broad parent-category requests no longer fail validation

## Testing
- cd marketlink-backend && node --test tests/requests.test.js
- cd marketlink-backend && npm run build
- cd marketlink-frontend && npm run build
- cd marketlink-frontend && npx eslint src/app/dashboard/customer/requests/CustomerRequestForm.tsx src/app/dashboard/customer/requests/new/page.tsx src/app/dashboard/customer/requests/page.tsx src/app/dashboard/customer/requests/view/page.tsx src/app/dashboard/customer/proposals/page.tsx src/components/chat/ConversationWorkspace.tsx