### PR TITLE
MM-115 add unsure request radius delivery

### DIFF
--- a/marketlink-backend/src/routes/requests.ts
+++ b/marketlink-backend/src/routes/requests.ts
@@ -7,12 +7,14 @@ import { lookupZipLocation } from '../lib/geocoding';
 const ZIP_RE = /^\d{5}$/;
 const MAX_REQUEST_SERVICE_TOKENS = 24;
 
-type RequestMatchReason = 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
+type RequestMatchReason = 'within_radius' | 'same_zip' | 'same_city' | 'serves_nationwide' | 'remote_friendly';
 
 type DeliveryPreviewInput = {
   id: string;
+  intakeMode: CustomerRequestIntakeMode;
   serviceTokens: string[];
   zip: string | null;
+  radiusMiles: number | null;
 };
 
 type ProviderExpertForMatching = {
@@ -22,6 +24,8 @@ type ProviderExpertForMatching = {
   city: string;
   state: string;
   zip: string | null;
+  latitude: number | null;
+  longitude: number | null;
   remoteFriendly: boolean;
   servesNationwide: boolean;
   services: string[];
@@ -33,9 +37,11 @@ type RequestForProviderMatching = {
   id: string;
   title: string;
   description: string;
+  intakeMode: CustomerRequestIntakeMode;
   marketingSubjectId: string | null;
   serviceTokens: string[];
   zip: string | null;
+  radiusMiles: number | null;
   budgetLabel: string | null;
   timelineLabel: string | null;
   status: CustomerRequestStatus;
@@ -86,7 +92,23 @@ function normalizeState(value: string | null | undefined) {
   return String(value || '').trim().toUpperCase();
 }
 
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function haversineMiles(fromLat: number, fromLng: number, toLat: number, toLng: number) {
+  const earthRadiusMiles = 3958.7613;
+  const dLat = toRadians(toLat - fromLat);
+  const dLng = toRadians(toLng - fromLng);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(fromLat)) * Math.cos(toRadians(toLat)) * Math.sin(dLng / 2) ** 2;
+
+  return earthRadiusMiles * (2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a)));
+}
+
 function getReasonWeight(reason: RequestMatchReason) {
+  if (reason === 'within_radius') return 500;
   if (reason === 'same_zip') return 400;
   if (reason === 'same_city') return 300;
   if (reason === 'serves_nationwide') return 200;
@@ -105,15 +127,40 @@ function isCustomerProposalDecision(status: ProposalStatus) {
 }
 
 async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, request: RequestForProviderMatching) {
-  if (!request.zip || request.serviceTokens.length === 0) return null;
-
-  const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
-  if (!matchedServiceTokens.length) return null;
+  if (!request.zip) return null;
 
   const locationLookup = await lookupZipLocation({ zip: request.zip });
   const requestCity = locationLookup.ok ? locationLookup.city : null;
   const requestState = locationLookup.ok ? locationLookup.state : null;
   const requestZip = locationLookup.ok ? locationLookup.zip : request.zip;
+
+  if (request.intakeMode === CustomerRequestIntakeMode.UNSURE) {
+    if (!locationLookup.ok || request.radiusMiles === null) return null;
+    if (typeof expert.latitude !== 'number' || typeof expert.longitude !== 'number') return null;
+
+    const distanceMiles = Number(
+      haversineMiles(locationLookup.latitude, locationLookup.longitude, expert.latitude, expert.longitude).toFixed(1),
+    );
+    if (distanceMiles > request.radiusMiles) return null;
+
+    return {
+      primaryReason: 'within_radius' as const,
+      reasons: ['within_radius' as const],
+      matchedServiceTokens: [],
+      distanceMiles,
+      requestLocation: {
+        zip: requestZip,
+        city: requestCity,
+        state: requestState,
+        source: 'zip_lookup',
+      },
+    };
+  }
+
+  if (request.serviceTokens.length === 0) return null;
+
+  const matchedServiceTokens = expert.services.filter((token) => request.serviceTokens.includes(token));
+  if (!matchedServiceTokens.length) return null;
 
   const sameZip = Boolean(expert.zip && expert.zip.trim() === requestZip);
   const sameCity =
@@ -143,12 +190,86 @@ async function buildProviderMatchForRequest(expert: ProviderExpertForMatching, r
 }
 
 async function buildDeliveryPreview(input: DeliveryPreviewInput) {
-  if (!input.zip || input.serviceTokens.length === 0) return null;
+  if (!input.zip) return null;
 
   const locationLookup = await lookupZipLocation({ zip: input.zip });
   const requestCity = locationLookup.ok ? locationLookup.city : null;
   const requestState = locationLookup.ok ? locationLookup.state : null;
   const requestZip = locationLookup.ok ? locationLookup.zip : input.zip;
+
+  if (input.intakeMode === CustomerRequestIntakeMode.UNSURE) {
+    if (!locationLookup.ok || input.radiusMiles === null) return null;
+    const radiusMiles = input.radiusMiles;
+
+    const experts = await prisma.expert.findMany({
+      where: {
+        status: ExpertStatus.active,
+        latitude: { not: null },
+        longitude: { not: null },
+      },
+      select: {
+        id: true,
+        slug: true,
+        businessName: true,
+        city: true,
+        state: true,
+        zip: true,
+        latitude: true,
+        longitude: true,
+        remoteFriendly: true,
+        servesNationwide: true,
+        services: true,
+        verified: true,
+        rating: true,
+      },
+      take: 200,
+    });
+
+    const matches = experts
+      .map((expert) => {
+        if (typeof expert.latitude !== 'number' || typeof expert.longitude !== 'number') return null;
+
+        const distanceMiles = Number(
+          haversineMiles(locationLookup.latitude, locationLookup.longitude, expert.latitude, expert.longitude).toFixed(1),
+        );
+        if (distanceMiles > radiusMiles) return null;
+
+        return {
+          id: expert.id,
+          slug: expert.slug,
+          businessName: expert.businessName,
+          city: expert.city,
+          state: expert.state,
+          zip: expert.zip,
+          verified: expert.verified,
+          rating: expert.rating,
+          remoteFriendly: expert.remoteFriendly,
+          servesNationwide: expert.servesNationwide,
+          matchedServiceTokens: [],
+          primaryReason: 'within_radius' as const,
+          reasons: ['within_radius' as const],
+          distanceMiles,
+        };
+      })
+      .filter((match): match is NonNullable<typeof match> => Boolean(match))
+      .sort((a, b) => a.distanceMiles - b.distanceMiles || b.rating - a.rating || a.businessName.localeCompare(b.businessName));
+
+    return {
+      requestId: input.id,
+      matchingModel: 'zip-radius-v1',
+      requestLocation: {
+        zip: requestZip,
+        city: requestCity,
+        state: requestState,
+        source: 'zip_lookup',
+      },
+      notes: ['Unsure requests are delivered only to experts with saved coordinates inside the selected ZIP-centered radius.'],
+      totalMatches: matches.length,
+      matchedExperts: matches,
+    };
+  }
+
+  if (input.serviceTokens.length === 0) return null;
 
   const experts = await prisma.expert.findMany({
     where: {
@@ -162,6 +283,8 @@ async function buildDeliveryPreview(input: DeliveryPreviewInput) {
       city: true,
       state: true,
       zip: true,
+      latitude: true,
+      longitude: true,
       remoteFriendly: true,
       servesNationwide: true,
       services: true,
@@ -362,11 +485,13 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
 
     req.log.info({ requestId: created.id, customerUserId: user.id }, 'customer-request.created');
     const deliveryPreview =
-      created.zip && created.serviceTokens.length > 0
+      created.zip
         ? await buildDeliveryPreview({
             id: created.id,
+            intakeMode: created.intakeMode,
             serviceTokens: created.serviceTokens,
             zip: created.zip,
+            radiusMiles: created.radiusMiles,
           })
         : null;
 
@@ -451,11 +576,13 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
     if (!request) return reply.code(404).send({ ok: false, error: 'Request not found' });
 
     const deliveryPreview =
-      request.zip && request.serviceTokens.length > 0
+      request.zip
         ? await buildDeliveryPreview({
             id: request.id,
+            intakeMode: request.intakeMode,
             serviceTokens: request.serviceTokens,
             zip: request.zip,
+            radiusMiles: request.radiusMiles,
           })
         : null;
 
@@ -701,6 +828,8 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         city: true,
         state: true,
         zip: true,
+        latitude: true,
+        longitude: true,
         remoteFriendly: true,
         servesNationwide: true,
         services: true,
@@ -718,9 +847,11 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         id: true,
         title: true,
         description: true,
+        intakeMode: true,
         marketingSubjectId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         budgetLabel: true,
         timelineLabel: true,
         status: true,
@@ -740,8 +871,10 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
       matches.push({
         id: request.id,
         title: request.title,
+        intakeMode: request.intakeMode,
         marketingSubjectId: request.marketingSubjectId,
         zip: request.zip,
+        radiusMiles: request.radiusMiles,
         budgetLabel: request.budgetLabel,
         timelineLabel: request.timelineLabel,
         status: request.status,
@@ -792,6 +925,8 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         city: true,
         state: true,
         zip: true,
+        latitude: true,
+        longitude: true,
         remoteFriendly: true,
         servesNationwide: true,
         services: true,
@@ -814,9 +949,11 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         id: true,
         title: true,
         description: true,
+        intakeMode: true,
         marketingSubjectId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         budgetLabel: true,
         timelineLabel: true,
         status: true,
@@ -896,6 +1033,8 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         city: true,
         state: true,
         zip: true,
+        latitude: true,
+        longitude: true,
         remoteFriendly: true,
         servesNationwide: true,
         services: true,
@@ -915,9 +1054,11 @@ const requestsRoutes: FastifyPluginAsync = async (fastify) => {
         id: true,
         title: true,
         description: true,
+        intakeMode: true,
         marketingSubjectId: true,
         serviceTokens: true,
         zip: true,
+        radiusMiles: true,
         budgetLabel: true,
         timelineLabel: true,
         status: true,

--- a/marketlink-backend/tests/requests.test.js
+++ b/marketlink-backend/tests/requests.test.js
@@ -159,6 +159,7 @@ test('POST /requests creates an unsure request with ZIP and radius when no marke
   const originalGetUserFromRequest = sessionModule.getUserFromRequest;
   const originalCustomerProfile = prismaModule.prisma.customerProfile;
   const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalExpert = prismaModule.prisma.expert;
   const originalLookupZipLocation = geocodingModule.lookupZipLocation;
 
   sessionModule.getUserFromRequest = async () => ({
@@ -182,6 +183,40 @@ test('POST /requests creates an unsure request with ZIP and radius when no marke
       createdAt: new Date('2026-06-22T10:00:00.000Z'),
       updatedAt: new Date('2026-06-22T10:00:00.000Z'),
     }),
+  };
+  prismaModule.prisma.expert = {
+    findMany: async () => [
+      {
+        id: 'expert_nearby_1',
+        slug: 'westmont-growth',
+        businessName: 'Westmont Growth',
+        city: 'Westmont',
+        state: 'IL',
+        zip: '60559',
+        latitude: 41.79,
+        longitude: -87.98,
+        remoteFriendly: false,
+        servesNationwide: false,
+        services: ['paid-ads'],
+        verified: true,
+        rating: 4.9,
+      },
+      {
+        id: 'expert_far_1',
+        slug: 'chicago-social-house',
+        businessName: 'Chicago Social House',
+        city: 'Chicago',
+        state: 'IL',
+        zip: '60614',
+        latitude: 41.92,
+        longitude: -87.65,
+        remoteFriendly: false,
+        servesNationwide: false,
+        services: ['seo'],
+        verified: true,
+        rating: 4.7,
+      },
+    ],
   };
 
   geocodingModule.lookupZipLocation = async () => ({
@@ -215,11 +250,18 @@ test('POST /requests creates an unsure request with ZIP and radius when no marke
     assert.deepEqual(body.request.serviceTokens, []);
     assert.equal(body.request.zip, '60559');
     assert.equal(body.request.radiusMiles, 15);
-    assert.equal(body.deliveryPreview, null);
+    assert.equal(body.deliveryPreview.matchingModel, 'zip-radius-v1');
+    assert.equal(body.deliveryPreview.totalMatches, 1);
+    assert.deepEqual(
+      body.deliveryPreview.matchedExperts.map((expert) => expert.id),
+      ['expert_nearby_1'],
+    );
+    assert.equal(body.deliveryPreview.matchedExperts[0].primaryReason, 'within_radius');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.customerProfile = originalCustomerProfile;
     prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.expert = originalExpert;
     geocodingModule.lookupZipLocation = originalLookupZipLocation;
     await fastify.close();
   }
@@ -1103,6 +1145,137 @@ test('GET /provider/requests lists active matched requests for the signed-in pro
     assert.equal(body.data[0].id, 'request_provider_match_1');
     assert.equal(body.data[0].primaryReason, 'same_zip');
     assert.equal(body.data[0].proposalStatus, 'PENDING');
+  } finally {
+    sessionModule.getUserFromRequest = originalGetUserFromRequest;
+    prismaModule.prisma.expert = originalExpert;
+    prismaModule.prisma.customerRequest = originalCustomerRequest;
+    prismaModule.prisma.proposal = originalProposal;
+    geocodingModule.lookupZipLocation = originalLookupZipLocation;
+    await fastify.close();
+  }
+});
+
+test('GET /provider/requests only includes unsure requests when the signed-in provider is inside the request radius', async () => {
+  const fastify = await buildFastify();
+
+  const originalGetUserFromRequest = sessionModule.getUserFromRequest;
+  const originalExpert = prismaModule.prisma.expert;
+  const originalCustomerRequest = prismaModule.prisma.customerRequest;
+  const originalProposal = prismaModule.prisma.proposal;
+  const originalLookupZipLocation = geocodingModule.lookupZipLocation;
+
+  sessionModule.getUserFromRequest = async () => ({
+    id: 'provider_user_unsure_radius_1',
+    email: 'provider@example.com',
+    role: 'provider',
+  });
+
+  prismaModule.prisma.expert = {
+    findFirst: async ({ where }) => {
+      assert.equal(where.userId, 'provider_user_unsure_radius_1');
+      return {
+        id: 'expert_unsure_radius_1',
+        slug: 'westmont-growth',
+        businessName: 'Westmont Growth',
+        city: 'Westmont',
+        state: 'IL',
+        zip: '60559',
+        latitude: 41.79,
+        longitude: -87.98,
+        remoteFriendly: true,
+        servesNationwide: true,
+        services: ['paid-ads', 'seo'],
+        verified: true,
+        rating: 4.9,
+      };
+    },
+  };
+
+  prismaModule.prisma.customerRequest = {
+    findMany: async ({ where }) => {
+      assert.equal(where.status, 'ACTIVE');
+      return [
+        {
+          id: 'request_unsure_nearby_1',
+          title: 'Not sure what help I need',
+          description: 'Need more leads for a local business.',
+          intakeMode: 'UNSURE',
+          marketingSubjectId: null,
+          serviceTokens: [],
+          zip: '60559',
+          radiusMiles: 15,
+          budgetLabel: '$2k-$5k',
+          timelineLabel: 'ASAP',
+          status: 'ACTIVE',
+          requesterName: 'Jamie Rivera',
+          requesterBusinessName: 'Westmont Dental',
+          createdAt: new Date('2026-06-29T15:00:00.000Z'),
+          updatedAt: new Date('2026-06-29T15:00:00.000Z'),
+        },
+        {
+          id: 'request_unsure_far_1',
+          title: 'Not sure what help I need',
+          description: 'Need more leads for a local business.',
+          intakeMode: 'UNSURE',
+          marketingSubjectId: null,
+          serviceTokens: [],
+          zip: '60614',
+          radiusMiles: 5,
+          budgetLabel: '$2k-$5k',
+          timelineLabel: 'ASAP',
+          status: 'ACTIVE',
+          requesterName: 'Alex Kim',
+          requesterBusinessName: 'Lakeview Cafe',
+          createdAt: new Date('2026-06-29T16:00:00.000Z'),
+          updatedAt: new Date('2026-06-29T16:00:00.000Z'),
+        },
+      ];
+    },
+  };
+  prismaModule.prisma.proposal = {
+    findMany: async ({ where }) => {
+      assert.deepEqual(where.requestId.in, ['request_unsure_nearby_1']);
+      return [];
+    },
+  };
+
+  geocodingModule.lookupZipLocation = async ({ zip }) => {
+    if (zip === '60559') {
+      return {
+        ok: true,
+        city: 'Westmont',
+        state: 'IL',
+        zip: '60559',
+        latitude: 41.79,
+        longitude: -87.98,
+        geocodedAt: new Date('2026-06-29T15:00:00.000Z'),
+        geocodeProvider: 'geoapify',
+      };
+    }
+
+    return {
+      ok: true,
+      city: 'Chicago',
+      state: 'IL',
+      zip: '60614',
+      latitude: 41.92,
+      longitude: -87.65,
+      geocodedAt: new Date('2026-06-29T16:00:00.000Z'),
+      geocodeProvider: 'geoapify',
+    };
+  };
+
+  try {
+    const response = await fastify.inject({
+      method: 'GET',
+      url: '/provider/requests',
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.ok, true);
+    assert.deepEqual(body.data.map((request) => request.id), ['request_unsure_nearby_1']);
+    assert.equal(body.data[0].primaryReason, 'within_radius');
   } finally {
     sessionModule.getUserFromRequest = originalGetUserFromRequest;
     prismaModule.prisma.expert = originalExpert;


### PR DESCRIPTION
## Summary
- switch unsure customer requests to ZIP-centered radius delivery using the request ZIP lookup plus expert coordinates
- filter provider request inbox, request detail access, and proposal eligibility so only in-radius unsure requests are visible to providers
- keep specific request matching on the existing service-token and locality rules while adding regression coverage for unsure delivery preview and inbox filtering

## Testing
- cd marketlink-backend && node --test tests/requests.test.js
- cd marketlink-backend && npm run build